### PR TITLE
chore: switch tavily back to local

### DIFF
--- a/tavily_search.yaml
+++ b/tavily_search.yaml
@@ -35,9 +35,9 @@ env:
     sensitive: true
     description: Your Tavily API key. Get one at https://app.tavily.com/home
 
-runtime: remote
-remoteConfig:
-  fixedURL: https://mcp.tavily.com/mcp/?tavilyApiKey=${TAVILY_API_KEY}
+runtime: npx
+npxConfig:
+  package: tavily-mcp@0.2.9
 toolPreview:
   - name: tavily_search
     description: Search the web for real-time information about any topic. Use this tool when you need up-to-date information that might not be available in your training data, or when you need to verify current facts. The search results will include relevant snippets and URLs from web pages. This is particularly useful for questions about current events, technology updates, or any topic that requires recent information.


### PR DESCRIPTION
The remote version of Tavily expected an API key in the URL, which is bad, so we're switching back to local.