### PR TITLE
Fix: Bump redis commit

### DIFF
--- a/redis.yaml
+++ b/redis.yaml
@@ -120,7 +120,7 @@ env:
 
 runtime: uvx
 uvxConfig:
-  package: 'git+https://github.com/redis/mcp-redis.git@0.2.0'
+  package: 'git+https://github.com/redis/mcp-redis.git@c74e16f9e99a2e93e91fab7e6c3dd22b93d08722'
   command: redis-mcp-server
   args:
     - --url


### PR DESCRIPTION
Launching the redis mcp from the 0.2.0 tag just stopped working with an
esoteric python/pydantic error. This bumps it up to the most recent
commit available at this time. If they cut a new release, we should
update to that.

Signed-off-by: Craig Jellick <craig@acorn.io>
