### PR TITLE
fix: notion: remove token env var

### DIFF
--- a/notion.yaml
+++ b/notion.yaml
@@ -25,12 +25,6 @@ metadata:
   categories: SaaS & API Integrations,Databases
 icon: https://avatars.githubusercontent.com/u/4792552?v=4
 repoURL: https://github.com/makenotion/notion-mcp-server
-env:
-  - key: NOTION_TOKEN
-    name: Notion Token
-    required: true
-    sensitive: true
-    description: Notion integration token (ntn_****).
 toolPreview:
   - name: search
     description: Search within the Notion workspace.


### PR DESCRIPTION
Forgot to remove this when I switched it to remote.