### PR TITLE
Sync MCP server candidates from upstream registries

### DIFF
--- a/.github/workflows/sync-mcp-registry.yml
+++ b/.github/workflows/sync-mcp-registry.yml
@@ -1,0 +1,66 @@
+name: Sync MCP Registry
+
+on:
+  schedule:
+    # Run daily at 2 AM UTC
+    - cron: '0 2 * * *'
+  workflow_dispatch:  # Allow manual trigger
+
+permissions:
+  contents: write  # Required to commit changes
+  issues: write    # Required to create issues
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      
+      - name: Install dependencies
+        run: |
+          pip install requests pyyaml packaging openai
+      
+      - name: Run MCP Registry Sync
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          REGISTRY_URL: "https://registry.modelcontextprotocol.io/v0/servers"
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          CATALOG_OWNER: ${{ github.repository_owner }}
+          CATALOG_REPO: ${{ github.event.repository.name }}
+          ISSUE_LABELS: "VerifiedMCPServer"
+          STAR_MIN: "500"
+          RECENT_DAYS: "30"
+        run: |
+          python scripts/upstream_sync/auto_sync_workflow.py
+      
+      - name: Commit AI cache if changed
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          
+          # Check if cache file has changes
+          if git diff --quiet scripts/upstream_sync/ai_categorization_cache.json; then
+            echo "No changes to AI cache"
+          else
+            echo "AI cache updated, committing changes..."
+            git add scripts/upstream_sync/ai_categorization_cache.json
+            git commit -m "chore: update AI categorization cache [skip ci]"
+            git push
+          fi
+      
+      - name: Summary
+        if: always()
+        run: |
+          echo "✓ MCP Registry sync completed"
+          if [ -f scripts/upstream_sync/ai_categorization_cache.json ]; then
+            echo "Cache file size: $(du -h scripts/upstream_sync/ai_categorization_cache.json | cut -f1)"
+            echo "Cache entries: $(jq 'length' scripts/upstream_sync/ai_categorization_cache.json)"
+          fi 

--- a/.github/workflows/sync-mcp-registry.yml
+++ b/.github/workflows/sync-mcp-registry.yml
@@ -19,13 +19,13 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.11'
+          python-version: '3.13'
       
       - name: Install dependencies
         run: |
-          pip install requests pyyaml packaging openai
+          pip install -r scripts/upstream_sync/requirements.txt
       
       - name: Run MCP Registry Sync
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .kiro/
 .idea/
+*__pycache__/

--- a/scripts/upstream_sync/ai_categorization_cache.json
+++ b/scripts/upstream_sync/ai_categorization_cache.json
@@ -1,2433 +1,2209 @@
 {
-  "https://github.com/embeddedlayers/mcp-analytics": {
+  "ai.mcpanalytics/analytics:https://github.com/embeddedlayers/mcp-analytics": {
     "ai_decision": "community",
     "ai_confidence": 0.7,
-    "ai_reason": "The GitHub org 'embeddedlayers' does not match the product/brand 'mcpanalytics', and there is no strong evidence of organizational ownership of 'mcpanalytics'.",
-    "cached_at": "2025-09-30 21:25:49 UTC",
+    "ai_reason": "GitHub org 'embeddedlayers' does not match or clearly represent 'mcpanalytics'; no trademarked brand evidence.",
+    "cached_at": "2025-09-30 23:40:38 UTC",
     "repository_url": "https://github.com/embeddedlayers/mcp-analytics",
     "server_name": "ai.mcpanalytics/analytics"
   },
-  "https://github.com/Aman-Amith-Shastry/scientific_computation_mcp": {
+  "ai.smithery/Aman-Amith-Shastry-scientific_computation_mcp:https://github.com/Aman-Amith-Shastry/scientific_computation_mcp": {
     "ai_decision": "community",
     "ai_confidence": 0.7,
-    "ai_reason": "Repo is owned by a personal GitHub user (Aman-Amith-Shastry), not the Smithery org, despite remotes being on smithery.ai.",
-    "cached_at": "2025-09-30 21:25:54 UTC",
+    "ai_reason": "GitHub repo is owned by a personal user (Aman-Amith-Shastry), not the 'smithery' org; no strong evidence of official ownership by Smithery.",
+    "cached_at": "2025-09-30 23:40:40 UTC",
     "repository_url": "https://github.com/Aman-Amith-Shastry/scientific_computation_mcp",
     "server_name": "ai.smithery/Aman-Amith-Shastry-scientific_computation_mcp"
   },
-  "https://github.com/BadRooBot/test_m": {
+  "ai.smithery/BadRooBot-test_m:https://github.com/BadRooBot/test_m": {
     "ai_decision": "community",
-    "ai_confidence": 0.85,
-    "ai_reason": "The GitHub org 'BadRooBot' does not match the product/service 'smithery.ai', and there is no evidence the repository is published by the official Smithery organization.",
-    "cached_at": "2025-09-30 21:25:55 UTC",
+    "ai_confidence": 0.9,
+    "ai_reason": "BadRooBot GitHub org does not match the underlying service Smithery (smithery.ai), and remotes reference smithery.ai but the repo is not under a Smithery/SmitheryAI org.",
+    "cached_at": "2025-09-30 23:40:43 UTC",
     "repository_url": "https://github.com/BadRooBot/test_m",
     "server_name": "ai.smithery/BadRooBot-test_m"
   },
-  "https://github.com/BigVik193/reddit-ads-mcp": {
+  "ai.smithery/BigVik193-reddit-ads-mcp:https://github.com/BigVik193/reddit-ads-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 1.0,
-    "ai_reason": "The repository is published under the BigVik193 user, not Reddit; no evidence of Reddit (the brand owner) operating or affiliating with the server.",
-    "cached_at": "2025-09-30 21:25:57 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "The repo is owned by 'BigVik193' (not Reddit), and neither the org nor remotes indicate Reddit ownership.",
+    "cached_at": "2025-09-30 23:40:47 UTC",
     "repository_url": "https://github.com/BigVik193/reddit-ads-mcp",
     "server_name": "ai.smithery/BigVik193-reddit-ads-mcp"
   },
-  "https://github.com/BigVik193/reddit-ads-mcp-api": {
+  "ai.smithery/BigVik193-reddit-ads-mcp-api:https://github.com/BigVik193/reddit-ads-mcp-api": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "Repo is by user BigVik193, not official Reddit org, and remotes are hosted on smithery.ai, not reddit.com.",
-    "cached_at": "2025-09-30 21:25:59 UTC",
+    "ai_reason": "Publisher BigVik193 is not Reddit; org and remotes do not match Reddit brand, so server is community.",
+    "cached_at": "2025-09-30 23:40:48 UTC",
     "repository_url": "https://github.com/BigVik193/reddit-ads-mcp-api",
     "server_name": "ai.smithery/BigVik193-reddit-ads-mcp-api"
   },
-  "https://github.com/BigVik193/reddit-user-mcp": {
+  "ai.smithery/BigVik193-reddit-ads-mcp-test:https://github.com/BigVik193/reddit-ads-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.97,
+    "ai_reason": "The repo is owned by a user (BigVik193), integrates with Reddit Ads (owned by Reddit), and neither org nor remotes present evidence of official Reddit ownership.",
+    "cached_at": "2025-09-30 23:40:50 UTC",
+    "repository_url": "https://github.com/BigVik193/reddit-ads-mcp",
+    "server_name": "ai.smithery/BigVik193-reddit-ads-mcp-test"
+  },
+  "ai.smithery/BigVik193-reddit-user-mcp:https://github.com/BigVik193/reddit-user-mcp": {
     "ai_decision": "community",
     "ai_confidence": 0.98,
-    "ai_reason": "Publisher 'BigVik193' is not Reddit; GitHub user is not an official Reddit org and remote is not on a Reddit-owned domain.",
-    "cached_at": "2025-09-30 21:26:02 UTC",
+    "ai_reason": "Repository is published by user BigVik193, not Reddit; no official Reddit branding or verified org present.",
+    "cached_at": "2025-09-30 23:40:56 UTC",
     "repository_url": "https://github.com/BigVik193/reddit-user-mcp",
     "server_name": "ai.smithery/BigVik193-reddit-user-mcp"
   },
-  "https://github.com/CryptoCultCurt/appfolio-mcp-server": {
+  "ai.smithery/CryptoCultCurt-appfolio-mcp-server:https://github.com/CryptoCultCurt/appfolio-mcp-server": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "Repo is owned by CryptoCultCurt, not Appfolio; no evidence of involvement by the official Appfolio organization.",
-    "cached_at": "2025-09-30 21:26:04 UTC",
+    "ai_reason": "The publisher CryptoCultCurt is not affiliated with Appfolio, and remotes are on smithery.ai, not appfolio.com.",
+    "cached_at": "2025-09-30 23:40:58 UTC",
     "repository_url": "https://github.com/CryptoCultCurt/appfolio-mcp-server",
     "server_name": "ai.smithery/CryptoCultCurt-appfolio-mcp-server"
   },
-  "https://github.com/Danushkumar-V/mcp-discord": {
+  "ai.smithery/Danushkumar-V-mcp-discord:https://github.com/Danushkumar-V/mcp-discord": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "The repo is under a user account (Danushkumar-V) and not the official Discord org; no evidence of Discord brand ownership.",
-    "cached_at": "2025-09-30 21:26:08 UTC",
+    "ai_reason": "Publisher (Danushkumar-V, smithery.ai) is not Discord Inc.; for generic Discord integration only Discord can publish an official server.",
+    "cached_at": "2025-09-30 23:41:00 UTC",
     "repository_url": "https://github.com/Danushkumar-V/mcp-discord",
     "server_name": "ai.smithery/Danushkumar-V-mcp-discord"
   },
-  "https://github.com/DynamicEndpoints/Autogen_MCP": {
+  "ai.smithery/DynamicEndpoints-autogen_mcp:https://github.com/DynamicEndpoints/Autogen_MCP": {
     "ai_decision": "community",
-    "ai_confidence": 0.8,
-    "ai_reason": "The GitHub org (DynamicEndpoints) does not match the underlying product/service domain (smithery.ai), indicating this is a third-party integration.",
-    "cached_at": "2025-09-30 21:26:10 UTC",
+    "ai_confidence": 0.7,
+    "ai_reason": "The GitHub org DynamicEndpoints does not match the smithery.ai product/brand; Smithery references appear only as remotes and not as the org publisher.",
+    "cached_at": "2025-09-30 23:41:03 UTC",
     "repository_url": "https://github.com/DynamicEndpoints/Autogen_MCP",
     "server_name": "ai.smithery/DynamicEndpoints-autogen_mcp"
   },
-  "https://github.com/DynamicEndpoints/m365-core-mcp": {
+  "ai.smithery/DynamicEndpoints-m365-core-mcp:https://github.com/DynamicEndpoints/m365-core-mcp": {
     "ai_decision": "community",
     "ai_confidence": 0.98,
-    "ai_reason": "DynamicEndpoints is not Microsoft and there is no evidence that the org owns Microsoft 365; remote domain is smithery.ai, not a Microsoft property.",
-    "cached_at": "2025-09-30 21:26:12 UTC",
+    "ai_reason": "Published by DynamicEndpoints for Microsoft 365; org does not match Microsoft, so this is a third-party integration.",
+    "cached_at": "2025-09-30 23:41:05 UTC",
     "repository_url": "https://github.com/DynamicEndpoints/m365-core-mcp",
     "server_name": "ai.smithery/DynamicEndpoints-m365-core-mcp"
   },
-  "https://github.com/DynamicEndpoints/PowerShell-Exec-MCP-Server": {
+  "ai.smithery/DynamicEndpoints-powershell-exec-mcp-server:https://github.com/DynamicEndpoints/PowerShell-Exec-MCP-Server": {
     "ai_decision": "community",
-    "ai_confidence": 0.85,
-    "ai_reason": "DynamicEndpoints is not the owner of PowerShell; remote endpoint is on smithery.ai but service is for generic PowerShell execution.",
-    "cached_at": "2025-09-30 21:26:14 UTC",
+    "ai_confidence": 0.8,
+    "ai_reason": "DynamicEndpoints is the GitHub org, but PowerShell is a Microsoft product with no evidence DynamicEndpoints is Microsoft or the PowerShell brand owner.",
+    "cached_at": "2025-09-30 23:41:07 UTC",
     "repository_url": "https://github.com/DynamicEndpoints/PowerShell-Exec-MCP-Server",
     "server_name": "ai.smithery/DynamicEndpoints-powershell-exec-mcp-server"
   },
-  "https://github.com/HARJAP-SINGH-3105/Splitwise_MCP": {
+  "ai.smithery/HARJAP-SINGH-3105-splitwise_mcp:https://github.com/HARJAP-SINGH-3105/Splitwise_MCP": {
     "ai_decision": "community",
-    "ai_confidence": 0.98,
-    "ai_reason": "Publisher is a personal user (HARJAP-SINGH-3105), not Splitwise's official org, for a third-party integration with Splitwise.",
-    "cached_at": "2025-09-30 21:26:16 UTC",
+    "ai_confidence": 0.93,
+    "ai_reason": "Repository is under user HARJAP-SINGH-3105, not Splitwise’s org; no evidence Splitwise owns or publishes this server.",
+    "cached_at": "2025-09-30 23:41:08 UTC",
     "repository_url": "https://github.com/HARJAP-SINGH-3105/Splitwise_MCP",
     "server_name": "ai.smithery/HARJAP-SINGH-3105-splitwise_mcp"
   },
-  "https://github.com/Hint-Services/obsidian-github-mcp": {
+  "ai.smithery/Hint-Services-obsidian-github-mcp:https://github.com/Hint-Services/obsidian-github-mcp": {
     "ai_decision": "community",
     "ai_confidence": 0.9,
-    "ai_reason": "Hint-Services is not the owner of GitHub or Obsidian; org name and remote domains do not match either core product brand.",
-    "cached_at": "2025-09-30 21:26:18 UTC",
+    "ai_reason": "Hint-Services is not the owner of Obsidian or GitHub; remotes are on smithery.ai, indicating a third-party implementation.",
+    "cached_at": "2025-09-30 23:41:10 UTC",
     "repository_url": "https://github.com/Hint-Services/obsidian-github-mcp",
     "server_name": "ai.smithery/Hint-Services-obsidian-github-mcp"
   },
-  "https://github.com/IlyaGusev/academia_mcp": {
+  "ai.smithery/IlyaGusev-academia_mcp:https://github.com/IlyaGusev/academia_mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.9,
-    "ai_reason": "The repository is owned by a personal user (IlyaGusev), not the organizations behind arXiv or ACL Anthology, and there is no direct evidence of official product ownership.",
-    "cached_at": "2025-09-30 21:26:20 UTC",
+    "ai_confidence": 0.96,
+    "ai_reason": "Repository owner is 'IlyaGusev' (user), not the arXiv or ACL Anthology orgs; no indication of official ownership by the underlying services.",
+    "cached_at": "2025-09-30 23:41:12 UTC",
     "repository_url": "https://github.com/IlyaGusev/academia_mcp",
     "server_name": "ai.smithery/IlyaGusev-academia_mcp"
   },
-  "https://github.com/ImRonAI/mcp-server-browserbase": {
+  "ai.smithery/ImRonAI-mcp-server-browserbase:https://github.com/ImRonAI/mcp-server-browserbase": {
     "ai_decision": "community",
-    "ai_confidence": 0.85,
-    "ai_reason": "ImRonAI is not the owner of Browserbase, and there is no evidence the publisher operates the underlying product or service.",
-    "cached_at": "2025-09-30 21:26:24 UTC",
+    "ai_confidence": 0.7,
+    "ai_reason": "GitHub repo is under user 'ImRonAI' not a Smithery org, and no strong evidence of brand ownership by Smithery.",
+    "cached_at": "2025-09-30 23:41:13 UTC",
     "repository_url": "https://github.com/ImRonAI/mcp-server-browserbase",
     "server_name": "ai.smithery/ImRonAI-mcp-server-browserbase"
   },
-  "https://github.com/JMoak/chrono-mcp": {
+  "ai.smithery/JMoak-chrono-mcp:https://github.com/JMoak/chrono-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.7,
-    "ai_reason": "The GitHub owner (JMoak) does not match the Smithery.ai brand and is a personal user, indicating a third-party/community implementation.",
-    "cached_at": "2025-09-30 21:26:26 UTC",
+    "ai_confidence": 0.8,
+    "ai_reason": "The GitHub org 'JMoak' does not match the product/service 'smithery.ai', and there is no strong evidence it's published by the underlying service owner.",
+    "cached_at": "2025-09-30 23:41:15 UTC",
     "repository_url": "https://github.com/JMoak/chrono-mcp",
     "server_name": "ai.smithery/JMoak-chrono-mcp"
   },
-  "https://github.com/Kim-soung-won/mcp-smithery-exam": {
+  "ai.smithery/Kim-soung-won-mcp-smithery-exam:https://github.com/Kim-soung-won/mcp-smithery-exam": {
     "ai_decision": "community",
-    "ai_confidence": 0.75,
-    "ai_reason": "GitHub owner is a user (Kim-soung-won), not an organization matching 'smithery.ai', despite using smithery.ai remote.",
-    "cached_at": "2025-09-30 21:26:28 UTC",
+    "ai_confidence": 0.85,
+    "ai_reason": "Repo is under user Kim-soung-won, not a verified Smithery org, indicating a third-party implementation for smithery.ai.",
+    "cached_at": "2025-09-30 23:41:17 UTC",
     "repository_url": "https://github.com/Kim-soung-won/mcp-smithery-exam",
     "server_name": "ai.smithery/Kim-soung-won-mcp-smithery-exam"
   },
-  "https://github.com/Leghis/Smart-Thinking": {
+  "ai.smithery/Leghis-smart-thinking:https://github.com/Leghis/Smart-Thinking": {
     "ai_decision": "community",
-    "ai_confidence": 0.8,
-    "ai_reason": "Repo is under user 'Leghis', not org 'Smithery', despite using smithery.ai endpoints and naming.",
-    "cached_at": "2025-09-30 21:26:30 UTC",
+    "ai_confidence": 0.7,
+    "ai_reason": "GitHub org is Leghis, not Smithery; remote uses smithery.ai domain but no evidence Leghis owns or operates Smithery.",
+    "cached_at": "2025-09-30 23:41:19 UTC",
     "repository_url": "https://github.com/Leghis/Smart-Thinking",
     "server_name": "ai.smithery/Leghis-smart-thinking"
   },
-  "https://github.com/MetehanGZL/PokeMCP": {
+  "ai.smithery/MetehanGZL-pokemcp:https://github.com/MetehanGZL/PokeMCP": {
     "ai_decision": "community",
-    "ai_confidence": 0.9,
-    "ai_reason": "Repository is owned by user 'MetehanGZL' not an org, not affiliated with Pokémon brand owner, and no official signals present.",
-    "cached_at": "2025-09-30 21:26:32 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repository is owned by a user (MetehanGZL), not Nintendo or Pokémon Co.; no evidence of official Pokémon brand involvement.",
+    "cached_at": "2025-09-30 23:41:21 UTC",
     "repository_url": "https://github.com/MetehanGZL/PokeMCP",
     "server_name": "ai.smithery/MetehanGZL-pokemcp"
   },
-  "https://github.com/MisterSandFR/Supabase-MCP-SelfHosted": {
+  "ai.smithery/MisterSandFR-supabase-mcp-selfhosted:https://github.com/MisterSandFR/Supabase-MCP-SelfHosted": {
     "ai_decision": "community",
-    "ai_confidence": 0.9,
-    "ai_reason": "The publisher 'MisterSandFR' is not Supabase; no evidence of ownership by Supabase org for this integration.",
-    "cached_at": "2025-09-30 21:26:33 UTC",
+    "ai_confidence": 0.97,
+    "ai_reason": "Publisher is MisterSandFR/Smithery (not Supabase org); server integrates with Supabase but is not by Supabase.",
+    "cached_at": "2025-09-30 23:41:23 UTC",
     "repository_url": "https://github.com/MisterSandFR/Supabase-MCP-SelfHosted",
     "server_name": "ai.smithery/MisterSandFR-supabase-mcp-selfhosted"
   },
-  "https://github.com/Nekzus/npm-sentinel-mcp": {
+  "ai.smithery/Nekzus-npm-sentinel-mcp:https://github.com/Nekzus/npm-sentinel-mcp": {
     "ai_decision": "community",
     "ai_confidence": 0.8,
-    "ai_reason": "GitHub org 'Nekzus' does not match the underlying service 'npm' or 'npmjs', and there is no indication it's operated by the owners of npm.",
-    "cached_at": "2025-09-30 21:26:35 UTC",
+    "ai_reason": "Publisher GitHub org (Nekzus) does not match NPM or Smithery brands; no evidence of official brand ownership.",
+    "cached_at": "2025-09-30 23:41:25 UTC",
     "repository_url": "https://github.com/Nekzus/npm-sentinel-mcp",
     "server_name": "ai.smithery/Nekzus-npm-sentinel-mcp"
   },
-  "https://github.com/PabloLec/KeyProbe-MCP": {
+  "ai.smithery/PabloLec-keyprobe-mcp:https://github.com/PabloLec/KeyProbe-MCP": {
     "ai_decision": "community",
-    "ai_confidence": 0.85,
-    "ai_reason": "GitHub owner is a user (PabloLec) and not the Smithery org, despite remotes using smithery.ai.",
-    "cached_at": "2025-09-30 21:26:37 UTC",
+    "ai_confidence": 0.8,
+    "ai_reason": "GitHub user PabloLec owns the repo, not the Smithery organization, despite remote domain; this indicates a third-party implementation.",
+    "cached_at": "2025-09-30 23:41:27 UTC",
     "repository_url": "https://github.com/PabloLec/KeyProbe-MCP",
     "server_name": "ai.smithery/PabloLec-keyprobe-mcp"
   },
-  "https://github.com/PixdataOrg/coderide-mcp": {
+  "ai.smithery/PixdataOrg-coderide:https://github.com/PixdataOrg/coderide-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.85,
-    "ai_reason": "Repo is owned by PixdataOrg, but the integrated service is smithery.ai; org name and domain do not match, indicating third-party integration.",
-    "cached_at": "2025-09-30 21:26:39 UTC",
+    "ai_confidence": 0.75,
+    "ai_reason": "Repo is published by PixdataOrg but integrates with Smithery (smithery.ai domain); PixdataOrg is not the owner of Smithery.",
+    "cached_at": "2025-09-30 23:41:29 UTC",
     "repository_url": "https://github.com/PixdataOrg/coderide-mcp",
     "server_name": "ai.smithery/PixdataOrg-coderide"
   },
-  "https://github.com/aamangeldi/dad-jokes-mcp": {
+  "ai.smithery/aamangeldi-dad-jokes-mcp:https://github.com/aamangeldi/dad-jokes-mcp": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "The repository is owned by user 'aamangeldi', not a Smithery organization, and the server provides a general dad jokes service, not a Smithery-owned product.",
-    "cached_at": "2025-09-30 21:26:41 UTC",
+    "ai_reason": "GitHub repository is under a user (aamangeldi), not the brand org (smithery), and remote is a user-namespaced subpath, indicating community contribution.",
+    "cached_at": "2025-09-30 23:41:31 UTC",
     "repository_url": "https://github.com/aamangeldi/dad-jokes-mcp",
     "server_name": "ai.smithery/aamangeldi-dad-jokes-mcp"
   },
-  "https://github.com/adamamer20/paper-search-mcp-openai": {
+  "ai.smithery/adamamer20-paper-search-mcp-openai:https://github.com/adamamer20/paper-search-mcp-openai": {
     "ai_decision": "community",
-    "ai_confidence": 0.98,
-    "ai_reason": "The publisher (adamamer20) is a personal user and not the owner of any underlying product/service listed (arXiv, PubMed, Scholar, etc.), with no evidence of official affiliation.",
-    "cached_at": "2025-09-30 21:26:43 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repo is owned by a user (adamamer20) and serves multiple third-party services; no evidence of brand ownership.",
+    "cached_at": "2025-09-30 23:41:33 UTC",
     "repository_url": "https://github.com/adamamer20/paper-search-mcp-openai",
     "server_name": "ai.smithery/adamamer20-paper-search-mcp-openai"
   },
-  "https://github.com/airmang/hwpx-mcp": {
+  "ai.smithery/airmang-hwpx-mcp:https://github.com/airmang/hwpx-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.8,
-    "ai_reason": "Repo is under the 'airmang' user/org which does not match 'HWPX' brand; no evidence publisher owns the HWPX product.",
-    "cached_at": "2025-09-30 21:26:45 UTC",
+    "ai_confidence": 0.75,
+    "ai_reason": "GitHub org airmang does not visibly match smithery.ai (remote host) or the product HWPX; no strong evidence of brand ownership.",
+    "cached_at": "2025-09-30 23:41:38 UTC",
     "repository_url": "https://github.com/airmang/hwpx-mcp",
     "server_name": "ai.smithery/airmang-hwpx-mcp"
   },
-  "https://github.com/alex-llm/attAck-mcp-server": {
+  "ai.smithery/alex-llm-attack-mcp-server:https://github.com/alex-llm/attAck-mcp-server": {
     "ai_decision": "community",
-    "ai_confidence": 0.7,
-    "ai_reason": "GitHub org alex-llm does not match the underlying service Smithery; no evidence Smithery publishes this server.",
-    "cached_at": "2025-09-30 21:26:47 UTC",
+    "ai_confidence": 0.8,
+    "ai_reason": "GitHub org alex-llm does not match product/service (smithery.ai); remotes use smithery.ai domain but no strong evidence org owns the brand.",
+    "cached_at": "2025-09-30 23:41:40 UTC",
     "repository_url": "https://github.com/alex-llm/attAck-mcp-server",
     "server_name": "ai.smithery/alex-llm-attack-mcp-server"
   },
-  "https://github.com/alphago2580/naramarketmcp": {
+  "ai.smithery/alphago2580-naramarketmcp:https://github.com/alphago2580/naramarketmcp": {
     "ai_decision": "community",
     "ai_confidence": 0.85,
-    "ai_reason": "GitHub repo is under 'alphago2580' (not a G2B/Nara Market org), remotes are on smithery.ai (not an official government domain), so not published by the original data source owner.",
-    "cached_at": "2025-09-30 21:26:50 UTC",
+    "ai_reason": "The repo is under 'alphago2580' (not associated with the Nara Market/G2B service owner), and remotes are hosted on smithery.ai (not an official government or Nara Market domain).",
+    "cached_at": "2025-09-30 23:41:44 UTC",
     "repository_url": "https://github.com/alphago2580/naramarketmcp",
     "server_name": "ai.smithery/alphago2580-naramarketmcp"
   },
-  "https://github.com/anirbanbasu/frankfurtermcp": {
+  "ai.smithery/anirbanbasu-frankfurtermcp:https://github.com/anirbanbasu/frankfurtermcp": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "GitHub user anirbanbasu is not affiliated with the Frankfurter API brand, and remotes reference smithery.ai, not frankfurter.app.",
-    "cached_at": "2025-09-30 21:26:52 UTC",
+    "ai_reason": "The GitHub repo is under the user 'anirbanbasu', not the Frankfurter API's organization, and no official branding evidence is present.",
+    "cached_at": "2025-09-30 23:41:46 UTC",
     "repository_url": "https://github.com/anirbanbasu/frankfurtermcp",
     "server_name": "ai.smithery/anirbanbasu-frankfurtermcp"
   },
-  "https://github.com/anirbanbasu/pymcp": {
+  "ai.smithery/anirbanbasu-pymcp:https://github.com/anirbanbasu/pymcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.8,
-    "ai_reason": "Repository is owned by a personal user (anirbanbasu), not by the Smithery organization, and functions as a template rather than an official server.",
-    "cached_at": "2025-09-30 21:26:54 UTC",
+    "ai_confidence": 0.9,
+    "ai_reason": "GitHub repo is user-owned (anirbanbasu), not an organization, and is described as a template with no strong evidence of official brand ownership.",
+    "cached_at": "2025-09-30 23:41:49 UTC",
     "repository_url": "https://github.com/anirbanbasu/pymcp",
     "server_name": "ai.smithery/anirbanbasu-pymcp"
   },
-  "https://github.com/arjunkmrm/ahoy": {
+  "ai.smithery/arjunkmrm-ahoy:https://github.com/arjunkmrm/ahoy": {
     "ai_decision": "community",
-    "ai_confidence": 0.9,
-    "ai_reason": "Repo owned by user arjunkmrm, not Smithery org; not published by the smithery.ai organization.",
-    "cached_at": "2025-09-30 21:26:56 UTC",
+    "ai_confidence": 0.8,
+    "ai_reason": "Repo is owned by a personal user ('arjunkmrm'), not the Smithery organization, and no strong signals the publisher owns the smithery.ai service.",
+    "cached_at": "2025-09-30 23:41:51 UTC",
     "repository_url": "https://github.com/arjunkmrm/ahoy",
     "server_name": "ai.smithery/arjunkmrm-ahoy"
   },
-  "https://github.com/arjunkmrm/clock": {
+  "ai.smithery/arjunkmrm-ahoy2:https://github.com/arjunkmrm/ahoy": {
     "ai_decision": "community",
     "ai_confidence": 0.9,
-    "ai_reason": "The repo is owned by a user (arjunkmrm), not the Smithery organization, and the remote is hosted on smithery.ai but without evidence it is published by Smithery itself.",
-    "cached_at": "2025-09-30 21:26:58 UTC",
+    "ai_reason": "GitHub owner 'arjunkmrm' is a user, not the 'smithery.ai' org; no strong evidence this is publisher-owned.",
+    "cached_at": "2025-09-30 23:41:52 UTC",
+    "repository_url": "https://github.com/arjunkmrm/ahoy",
+    "server_name": "ai.smithery/arjunkmrm-ahoy2"
+  },
+  "ai.smithery/arjunkmrm-clock:https://github.com/arjunkmrm/clock": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "GitHub owner 'arjunkmrm' is a personal user, not the brand/org behind Smithery; remotes use smithery.ai but publisher is not the brand owner.",
+    "cached_at": "2025-09-30 23:41:54 UTC",
     "repository_url": "https://github.com/arjunkmrm/clock",
     "server_name": "ai.smithery/arjunkmrm-clock"
   },
-  "https://github.com/arjunkmrm/lta-mcp": {
+  "ai.smithery/arjunkmrm-lta-mcp:https://github.com/arjunkmrm/lta-mcp": {
     "ai_decision": "community",
     "ai_confidence": 0.85,
-    "ai_reason": "GitHub user 'arjunkmrm' (not an org) publishes the repo and the MCP remote is hosted under smithery.ai, which does not match the brand or official domain for Singapore LTA.",
-    "cached_at": "2025-09-30 21:27:01 UTC",
+    "ai_reason": "Repository is owned by user 'arjunkmrm', not an organization related to the LTA or Smithery brands.",
+    "cached_at": "2025-09-30 23:41:56 UTC",
     "repository_url": "https://github.com/arjunkmrm/lta-mcp",
     "server_name": "ai.smithery/arjunkmrm-lta-mcp"
   },
-  "https://github.com/arjunkmrm/perplexity-search": {
+  "ai.smithery/arjunkmrm-perplexity-search:https://github.com/arjunkmrm/perplexity-search": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "Repo owner arjunkmrm is a user, not Perplexity or its org; no Perplexity brand evidence in GitHub org, repo, or remotes.",
-    "cached_at": "2025-09-30 21:27:02 UTC",
+    "ai_reason": "The repository is under a personal GitHub user ('arjunkmrm') and not Perplexity's official org; remotes use smithery.ai, not Perplexity's domain.",
+    "cached_at": "2025-09-30 23:41:58 UTC",
     "repository_url": "https://github.com/arjunkmrm/perplexity-search",
     "server_name": "ai.smithery/arjunkmrm-perplexity-search"
   },
-  "https://github.com/arjunkmrm/ScraperMcp_el": {
+  "ai.smithery/arjunkmrm-scrapermcp_el:https://github.com/arjunkmrm/ScraperMcp_el": {
     "ai_decision": "community",
     "ai_confidence": 0.85,
-    "ai_reason": "Repository is owned by a user (arjunkmrm), not the Smithery org; no direct evidence Smithery operates or publishes this server.",
-    "cached_at": "2025-09-30 21:27:04 UTC",
+    "ai_reason": "GitHub user 'arjunkmrm' publishes a scraper for Smithery; not under a Smithery/Smithery.ai org, so not official.",
+    "cached_at": "2025-09-30 23:42:01 UTC",
     "repository_url": "https://github.com/arjunkmrm/ScraperMcp_el",
     "server_name": "ai.smithery/arjunkmrm-scrapermcp_el"
   },
-  "https://github.com/arjunkmrm/tutorials": {
+  "ai.smithery/arjunkmrm-tutorials:https://github.com/arjunkmrm/tutorials": {
     "ai_decision": "community",
     "ai_confidence": 0.8,
-    "ai_reason": "The publisher is a personal GitHub user (arjunkmrm), not an organization owning Smithery; remotes are on smithery.ai but without evidence the repo is official.",
-    "cached_at": "2025-09-30 21:27:14 UTC",
+    "ai_reason": "Repo is owned by a user (arjunkmrm), not the Smithery org; no strong signals of official ownership.",
+    "cached_at": "2025-09-30 23:42:03 UTC",
     "repository_url": "https://github.com/arjunkmrm/tutorials",
     "server_name": "ai.smithery/arjunkmrm-tutorials"
   },
-  "https://github.com/aryankeluskar/poke-video-mcp": {
+  "ai.smithery/arjunkmrm-watch2:https://github.com/arjunkmrm/clock": {
     "ai_decision": "community",
-    "ai_confidence": 0.85,
-    "ai_reason": "GitHub repo is under a personal user (aryankeluskar), not the Smithery org, and no evidence links it officially to the Smithery product or organization.",
-    "cached_at": "2025-09-30 21:27:16 UTC",
+    "ai_confidence": 0.8,
+    "ai_reason": "GitHub repo is owned by user arjunkmrm, not the Smithery org, despite using smithery.ai remotes.",
+    "cached_at": "2025-09-30 23:42:05 UTC",
+    "repository_url": "https://github.com/arjunkmrm/clock",
+    "server_name": "ai.smithery/arjunkmrm-watch2"
+  },
+  "ai.smithery/aryankeluskar-poke-video-mcp:https://github.com/aryankeluskar/poke-video-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "Repo is owned by user aryankeluskar, not the Smithery org; strong signals indicate a third-party implementation.",
+    "cached_at": "2025-09-30 23:42:07 UTC",
     "repository_url": "https://github.com/aryankeluskar/poke-video-mcp",
     "server_name": "ai.smithery/aryankeluskar-poke-video-mcp"
   },
-  "https://github.com/bergeramit/bergeramit-hw3-tech": {
+  "ai.smithery/bergeramit-bergeramit-hw3-tech:https://github.com/bergeramit/bergeramit-hw3-tech": {
     "ai_decision": "community",
-    "ai_confidence": 0.9,
-    "ai_reason": "The repo owner is a user (bergeramit), not the Smithery org, so this is a third-party implementation for Smithery.",
-    "cached_at": "2025-09-30 21:27:18 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repo is owned by a user (bergeramit), not the organization behind smithery.ai, and remotes use smithery.ai as a hosting platform for a user-contributed server.",
+    "cached_at": "2025-09-30 23:42:09 UTC",
     "repository_url": "https://github.com/bergeramit/bergeramit-hw3-tech",
     "server_name": "ai.smithery/bergeramit-bergeramit-hw3-tech"
   },
-  "https://github.com/bielacki/igdb-mcp-server": {
+  "ai.smithery/bergeramit-bergeramit-hw3-tech-1:https://github.com/bergeramit/bergeramit-hw3-tech": {
     "ai_decision": "community",
     "ai_confidence": 0.9,
-    "ai_reason": "The repository is owned by user 'bielacki', not IGDB or its brand org, and remote is hosted on smithery.ai; no signals of official IGDB involvement.",
-    "cached_at": "2025-09-30 21:27:21 UTC",
+    "ai_reason": "Repo is under a personal user (bergeramit) not the Smithery org, despite using Smithery’s remote endpoint.",
+    "cached_at": "2025-09-30 23:42:11 UTC",
+    "repository_url": "https://github.com/bergeramit/bergeramit-hw3-tech",
+    "server_name": "ai.smithery/bergeramit-bergeramit-hw3-tech-1"
+  },
+  "ai.smithery/bielacki-igdb-mcp-server:https://github.com/bielacki/igdb-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "Published by user 'bielacki' not IGDB; no strong evidence of ownership by IGDB or its parent org.",
+    "cached_at": "2025-09-30 23:42:15 UTC",
     "repository_url": "https://github.com/bielacki/igdb-mcp-server",
     "server_name": "ai.smithery/bielacki-igdb-mcp-server"
   },
-  "https://github.com/blacklotusdev8/test_m": {
+  "ai.smithery/blacklotusdev8-test_m:https://github.com/blacklotusdev8/test_m": {
     "ai_decision": "community",
-    "ai_confidence": 0.85,
-    "ai_reason": "The GitHub org 'blacklotusdev8' does not match the Smithery brand, and the remote is a user namespace; no evidence the publisher owns the 'smithery.ai' service.",
-    "cached_at": "2025-09-30 21:27:23 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repo owner 'blacklotusdev8' is not a Smithery org; 'Test' in server name and remotes reference a non-brand domain.",
+    "cached_at": "2025-09-30 23:42:17 UTC",
     "repository_url": "https://github.com/blacklotusdev8/test_m",
     "server_name": "ai.smithery/blacklotusdev8-test_m"
   },
-  "https://github.com/blbl147/xhs-mcp": {
+  "ai.smithery/blbl147-xhs-mcp:https://github.com/blbl147/xhs-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.97,
-    "ai_reason": "The GitHub org ('blbl147') does not match the brand of the integrated service ('小红书' / xiaohongshu), indicating this is a third-party implementation.",
-    "cached_at": "2025-09-30 21:27:32 UTC",
+    "ai_confidence": 0.92,
+    "ai_reason": "The GitHub org 'blbl147' does not match the XHS (Xiaohongshu) brand, and the remote is hosted on a third-party domain (smithery.ai).",
+    "cached_at": "2025-09-30 23:42:18 UTC",
     "repository_url": "https://github.com/blbl147/xhs-mcp",
     "server_name": "ai.smithery/blbl147-xhs-mcp"
   },
-  "https://github.com/blockscout/mcp-server": {
-    "ai_decision": "community",
-    "ai_confidence": 0.7,
-    "ai_reason": "Remotes are hosted on smithery.ai rather than blockscout.com, suggesting third-party (Smithery) deployment for Blockscout.",
-    "cached_at": "2025-09-30 21:27:35 UTC",
+  "ai.smithery/blockscout-mcp-server:https://github.com/blockscout/mcp-server": {
+    "ai_decision": "official",
+    "ai_confidence": 0.9,
+    "ai_reason": "GitHub org 'blockscout' matches product name in server and repo, repo is not a fork/archived, strong evidence of official publisher.",
+    "cached_at": "2025-09-30 23:42:20 UTC",
     "repository_url": "https://github.com/blockscout/mcp-server",
     "server_name": "ai.smithery/blockscout-mcp-server"
   },
-  "https://github.com/brave/brave-search-mcp-server": {
+  "ai.smithery/brave:https://github.com/brave/brave-search-mcp-server": {
     "ai_decision": "community",
-    "ai_confidence": 0.95,
-    "ai_reason": "The server integrates with Brave Search, but is published by Smithery (ai.smithery) and remotes are hosted on smithery.ai, not Brave's domain.",
-    "cached_at": "2025-09-30 21:27:37 UTC",
+    "ai_confidence": 0.85,
+    "ai_reason": "The GitHub org is 'brave' (matching Brave Search), but the remote is on smithery.ai, not an official Brave domain, and 'ai.smithery' suggests third-party involvement.",
+    "cached_at": "2025-09-30 23:42:23 UTC",
     "repository_url": "https://github.com/brave/brave-search-mcp-server",
     "server_name": "ai.smithery/brave"
   },
-  "https://github.com/callmybot/cookbook-mcp-server": {
+  "ai.smithery/callmybot-cookbook-mcp-server:https://github.com/callmybot/cookbook-mcp-server": {
     "ai_decision": "community",
-    "ai_confidence": 0.8,
-    "ai_reason": "GitHub org 'callmybot' differs from Smithery (the referenced domain), and there is no evidence that 'callmybot' owns or operates Smithery.",
-    "cached_at": "2025-09-30 21:27:39 UTC",
+    "ai_confidence": 0.7,
+    "ai_reason": "GitHub org 'callmybot' differs from brand/domain 'smithery.ai', and no strong brand alignment is shown.",
+    "cached_at": "2025-09-30 23:42:25 UTC",
     "repository_url": "https://github.com/callmybot/cookbook-mcp-server",
     "server_name": "ai.smithery/callmybot-cookbook-mcp-server"
   },
-  "https://github.com/callmybot/domoticz": {
+  "ai.smithery/callmybot-domoticz:https://github.com/callmybot/domoticz": {
     "ai_decision": "community",
     "ai_confidence": 0.9,
-    "ai_reason": "The GitHub org 'callmybot' is not the owner of Domoticz and the remote domain is smithery.ai, not domoticz.com.",
-    "cached_at": "2025-09-30 21:41:32 UTC",
+    "ai_reason": "The GitHub org 'callmybot' does not match 'domoticz' (the product being integrated), making this a third-party implementation.",
+    "cached_at": "2025-09-30 23:42:26 UTC",
     "repository_url": "https://github.com/callmybot/domoticz",
     "server_name": "ai.smithery/callmybot-domoticz"
   },
-  "https://github.com/callmybot/hello-mcp-server": {
+  "ai.smithery/callmybot-hello-mcp-server:https://github.com/callmybot/hello-mcp-server": {
     "ai_decision": "community",
-    "ai_confidence": 0.85,
-    "ai_reason": "Publisher is 'callmybot', while the product/service referenced in the remote is 'smithery.ai'; no evidence 'callmybot' owns Smithery.",
-    "cached_at": "2025-09-30 21:41:35 UTC",
+    "ai_confidence": 0.9,
+    "ai_reason": "Publisher is 'callmybot' integrating with Smithery.ai; org does not match product/service owner.",
+    "cached_at": "2025-09-30 23:42:29 UTC",
     "repository_url": "https://github.com/callmybot/hello-mcp-server",
     "server_name": "ai.smithery/callmybot-hello-mcp-server"
   },
-  "https://github.com/cc25a/openai-api-agent-project": {
+  "ai.smithery/cc25a-openai-api-agent-project123123123:https://github.com/cc25a/openai-api-agent-project": {
     "ai_decision": "community",
-    "ai_confidence": 0.9,
-    "ai_reason": "Smithery is not OpenAI, and there is no clear evidence that the repo is published by OpenAI; this is a third-party implementation.",
-    "cached_at": "2025-09-30 21:41:37 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "The repo is under the 'cc25a' org but integrates with OpenAI's API, and there is no evidence linking 'cc25a' or 'smithery.ai' to official OpenAI ownership.",
+    "cached_at": "2025-09-30 23:42:31 UTC",
     "repository_url": "https://github.com/cc25a/openai-api-agent-project",
     "server_name": "ai.smithery/cc25a-openai-api-agent-project123123123"
   },
-  "https://github.com/cindyloo/dropbox-mcp-server": {
+  "ai.smithery/cindyloo-dropbox-mcp-server:https://github.com/cindyloo/dropbox-mcp-server": {
     "ai_decision": "community",
-    "ai_confidence": 1.0,
-    "ai_reason": "Publisher is 'cindyloo' and not Dropbox, so this is a third-party implementation for Dropbox.",
-    "cached_at": "2025-09-30 21:41:39 UTC",
+    "ai_confidence": 0.96,
+    "ai_reason": "The server integrates with Dropbox but is published by the cindyloo org, not Dropbox, and remote endpoints are hosted on smithery.ai, not dropbox.com.",
+    "cached_at": "2025-09-30 23:42:34 UTC",
     "repository_url": "https://github.com/cindyloo/dropbox-mcp-server",
     "server_name": "ai.smithery/cindyloo-dropbox-mcp-server"
   },
-  "https://github.com/ctaylor86/mcp-video-download-server": {
+  "ai.smithery/ctaylor86-mcp-video-download-server:https://github.com/ctaylor86/mcp-video-download-server": {
     "ai_decision": "community",
     "ai_confidence": 0.85,
-    "ai_reason": "The repository is published by a user (ctaylor86), not the Smithery org, indicating a third-party implementation despite remotes on smithery.ai.",
-    "cached_at": "2025-09-30 21:41:41 UTC",
+    "ai_reason": "Repository is owned by a user ('ctaylor86'), not an organization, and no direct evidence ties the project to the Smithery brand.",
+    "cached_at": "2025-09-30 23:42:37 UTC",
     "repository_url": "https://github.com/ctaylor86/mcp-video-download-server",
     "server_name": "ai.smithery/ctaylor86-mcp-video-download-server"
   },
-  "https://github.com/demomagic/duckchain-mcp": {
+  "ai.smithery/demomagic-duckchain-mcp:https://github.com/demomagic/duckchain-mcp": {
     "ai_decision": "community",
     "ai_confidence": 0.8,
-    "ai_reason": "GitHub org 'demomagic' does not match Smithery brand in server name or remote domain; remote is on smithery.ai but repo owner is third-party.",
-    "cached_at": "2025-09-30 21:41:45 UTC",
+    "ai_reason": "The publisher 'demomagic' is not the owner of 'smithery.ai'; there is no strong evidence this org operates the underlying Smithery service.",
+    "cached_at": "2025-09-30 23:42:39 UTC",
     "repository_url": "https://github.com/demomagic/duckchain-mcp",
     "server_name": "ai.smithery/demomagic-duckchain-mcp"
   },
-  "https://github.com/devbrother2024/typescript-mcp-server-boilerplate": {
+  "ai.smithery/devbrother2024-typescript-mcp-server-boilerplate:https://github.com/devbrother2024/typescript-mcp-server-boilerplate": {
     "ai_decision": "community",
-    "ai_confidence": 0.95,
-    "ai_reason": "The GitHub org 'devbrother2024' differs from the product/service ('smithery.ai') and there is no evidence this is published by Smithery itself.",
-    "cached_at": "2025-09-30 21:41:48 UTC",
+    "ai_confidence": 0.8,
+    "ai_reason": "The GitHub org 'devbrother2024' does not match the Smithery brand; remote uses smithery.ai but there is no evidence this is published by Smithery itself.",
+    "cached_at": "2025-09-30 23:42:41 UTC",
     "repository_url": "https://github.com/devbrother2024/typescript-mcp-server-boilerplate",
     "server_name": "ai.smithery/devbrother2024-typescript-mcp-server-boilerplate"
   },
-  "https://github.com/docfork/docfork-mcp": {
+  "ai.smithery/docfork-mcp:https://github.com/docfork/docfork-mcp": {
     "ai_decision": "community",
     "ai_confidence": 0.8,
-    "ai_reason": "Repository is under the 'docfork' org, but the remote is on smithery.ai, so it is a third-party integration for Smithery, not published by Smithery itself.",
-    "cached_at": "2025-09-30 21:41:50 UTC",
+    "ai_reason": "The repository is under the 'docfork' org while remotes use the smithery.ai domain; org does not match the underlying smithery product.",
+    "cached_at": "2025-09-30 23:42:43 UTC",
     "repository_url": "https://github.com/docfork/docfork-mcp",
     "server_name": "ai.smithery/docfork-mcp"
   },
-  "https://github.com/faithk7/gmail-mcp": {
+  "ai.smithery/faithk7-gmail-mcp:https://github.com/faithk7/gmail-mcp": {
     "ai_decision": "community",
     "ai_confidence": 1.0,
-    "ai_reason": "The repository is published by 'faithk7' (not Google) for Gmail, which is generic and requires Google as publisher for official status.",
-    "cached_at": "2025-09-30 21:41:53 UTC",
+    "ai_reason": "Publisher is faithk7 (not Google), org and remote domain do not match Gmail or Google.",
+    "cached_at": "2025-09-30 23:42:46 UTC",
     "repository_url": "https://github.com/faithk7/gmail-mcp",
     "server_name": "ai.smithery/faithk7-gmail-mcp"
   },
-  "https://github.com/fengyinxia/jimeng-mcp": {
+  "ai.smithery/fengyinxia-jimeng-mcp:https://github.com/fengyinxia/jimeng-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.85,
-    "ai_reason": "Repository is owned by user 'fengyinxia' (not an org), while remotes reference smithery.ai; no evidence the repo is published by Smithery's organization.",
-    "cached_at": "2025-09-30 21:41:55 UTC",
+    "ai_confidence": 0.8,
+    "ai_reason": "The GitHub repo is under a personal user (fengyinxia) rather than the Smithery org, and there is no evidence that 'fengyinxia' officially represents Smithery.",
+    "cached_at": "2025-09-30 23:42:48 UTC",
     "repository_url": "https://github.com/fengyinxia/jimeng-mcp",
     "server_name": "ai.smithery/fengyinxia-jimeng-mcp"
   },
-  "https://github.com/hithereiamaliff/mcp-datagovmy": {
+  "ai.smithery/hithereiamaliff-mcp-datagovmy:https://github.com/hithereiamaliff/mcp-datagovmy": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "Repository owner 'hithereiamaliff' and org 'smithery.ai' do not match or represent Malaysia's government open data brand; no signals of official ownership.",
-    "cached_at": "2025-09-30 21:41:57 UTC",
+    "ai_reason": "The GitHub user hithereiamaliff is not an official organization for Malaysia's government or its open data services; this is a third-party implementation.",
+    "cached_at": "2025-09-30 23:42:50 UTC",
     "repository_url": "https://github.com/hithereiamaliff/mcp-datagovmy",
     "server_name": "ai.smithery/hithereiamaliff-mcp-datagovmy"
   },
-  "https://github.com/hithereiamaliff/mcp-nextcloud": {
+  "ai.smithery/hithereiamaliff-mcp-nextcloud:https://github.com/hithereiamaliff/mcp-nextcloud": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "The repository is owned by user 'hithereiamaliff', not by Nextcloud's official organization, and there is no evidence of official branding.",
-    "cached_at": "2025-09-30 21:41:59 UTC",
+    "ai_reason": "The publisher 'hithereiamaliff' and domain 'smithery.ai' are not the owners of Nextcloud, and do not match Nextcloud’s official branding.",
+    "cached_at": "2025-09-30 23:42:51 UTC",
     "repository_url": "https://github.com/hithereiamaliff/mcp-nextcloud",
     "server_name": "ai.smithery/hithereiamaliff-mcp-nextcloud"
   },
-  "https://github.com/hollaugo/tutorials": {
+  "ai.smithery/hollaugo-financial-research-mcp-server:https://github.com/hollaugo/tutorials": {
     "ai_decision": "community",
-    "ai_confidence": 0.6,
-    "ai_reason": "The GitHub org 'hollaugo' does not match the product/service brand 'smithery', and the repo is under 'hollaugo', not a verified 'smithery' org.",
-    "cached_at": "2025-09-30 21:42:01 UTC",
+    "ai_confidence": 0.82,
+    "ai_reason": "Repository is owned by 'hollaugo' (not Smithery), while remotes reference 'smithery.ai'; owner is not the brand org for Smithery.",
+    "cached_at": "2025-09-30 23:42:55 UTC",
     "repository_url": "https://github.com/hollaugo/tutorials",
     "server_name": "ai.smithery/hollaugo-financial-research-mcp-server"
   },
-  "https://github.com/hustcc/mcp-mermaid": {
+  "ai.smithery/hustcc-mcp-mermaid:https://github.com/hustcc/mcp-mermaid": {
     "ai_decision": "community",
     "ai_confidence": 0.85,
-    "ai_reason": "The GitHub org 'hustcc' does not match the 'mermaid' product/brand; remote is on 'smithery.ai' which does not indicate ownership by Mermaid's creators.",
-    "cached_at": "2025-09-30 21:42:04 UTC",
+    "ai_reason": "GitHub org 'hustcc' does not match 'Mermaid' brand; no evidence publisher owns Mermaid product.",
+    "cached_at": "2025-09-30 23:42:57 UTC",
     "repository_url": "https://github.com/hustcc/mcp-mermaid",
     "server_name": "ai.smithery/hustcc-mcp-mermaid"
   },
-  "https://github.com/isnow890/data4library-mcp": {
+  "ai.smithery/isnow890-data4library-mcp:https://github.com/isnow890/data4library-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.95,
-    "ai_reason": "Repository is under a personal user (isnow890), not an org related to data4library; no evidence of brand ownership.",
-    "cached_at": "2025-09-30 21:42:07 UTC",
+    "ai_confidence": 0.85,
+    "ai_reason": "The publisher is a personal user (isnow890), not the brand or org behind data4library; there is no strong evidence of official integration.",
+    "cached_at": "2025-09-30 23:42:59 UTC",
     "repository_url": "https://github.com/isnow890/data4library-mcp",
     "server_name": "ai.smithery/isnow890-data4library-mcp"
   },
-  "https://github.com/jessicayanwang/frankfurtermcp": {
+  "ai.smithery/jessicayanwang-test:https://github.com/jessicayanwang/frankfurtermcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.98,
-    "ai_reason": "GitHub repo owner jessicayanwang does not match the Frankfurter service brand; strong signal of community implementation.",
-    "cached_at": "2025-09-30 21:42:09 UTC",
+    "ai_confidence": 0.9,
+    "ai_reason": "GitHub user jessicayanwang is not the official Frankfurter organization; repo name contains 'test', indicating a likely test or personal project.",
+    "cached_at": "2025-09-30 23:43:01 UTC",
     "repository_url": "https://github.com/jessicayanwang/frankfurtermcp",
     "server_name": "ai.smithery/jessicayanwang-test"
   },
-  "https://github.com/jirispilka/actors-mcp-server": {
+  "ai.smithery/jirispilka-actors-mcp-server:https://github.com/jirispilka/actors-mcp-server": {
     "ai_decision": "community",
-    "ai_confidence": 0.9,
-    "ai_reason": "The GitHub owner 'jirispilka' is a user, not an organization, and there is no match between the repo owner and the 'smithery.ai' brand.",
-    "cached_at": "2025-09-30 21:42:12 UTC",
+    "ai_confidence": 0.92,
+    "ai_reason": "GitHub owner is a user (jirispilka) not org, no direct brand match with Smithery or well-known platform, and remote is on smithery.ai not indicative of an underlying product owner.",
+    "cached_at": "2025-09-30 23:43:03 UTC",
     "repository_url": "https://github.com/jirispilka/actors-mcp-server",
     "server_name": "ai.smithery/jirispilka-actors-mcp-server"
   },
-  "https://github.com/jjlabsio/korea-stock-mcp": {
+  "ai.smithery/jjlabsio-korea-stock-mcp:https://github.com/jjlabsio/korea-stock-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.8,
-    "ai_reason": "Organization jjlabsio is not the owner/operator of the Korean stock market data; server integrates an external product with no strong evidence of first-party ownership.",
-    "cached_at": "2025-09-30 21:42:14 UTC",
+    "ai_confidence": 0.85,
+    "ai_reason": "Repository is under the 'jjlabsio' org for a server integrating with Korean stock data, but remotes are on 'smithery.ai' (not a known stock/financial provider); no evidence links either org as the official data source owner.",
+    "cached_at": "2025-09-30 23:43:05 UTC",
     "repository_url": "https://github.com/jjlabsio/korea-stock-mcp",
     "server_name": "ai.smithery/jjlabsio-korea-stock-mcp"
   },
-  "https://github.com/keithah/hostex-mcp": {
+  "ai.smithery/keithah-hostex-mcp:https://github.com/keithah/hostex-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.85,
-    "ai_reason": "Repo is under keithah user, not the official Hostex org; no evidence Hostex is the publisher.",
-    "cached_at": "2025-09-30 21:42:16 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "Publisher 'keithah' is an individual user, not Hostex; no evidence of official Hostex brand ownership.",
+    "cached_at": "2025-09-30 23:43:06 UTC",
     "repository_url": "https://github.com/keithah/hostex-mcp",
     "server_name": "ai.smithery/keithah-hostex-mcp"
   },
-  "https://github.com/keithah/tessie-mcp": {
+  "ai.smithery/keithah-tessie-mcp:https://github.com/keithah/tessie-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.95,
-    "ai_reason": "The repository is under the 'keithah' user (not an org), the description calls it 'Unofficial', and there is no strong link to a product-owning organization.",
-    "cached_at": "2025-09-30 21:42:19 UTC",
+    "ai_confidence": 1.0,
+    "ai_reason": "Description explicitly says 'Unofficial integration' and repo is under a user (keithah), not the service owner.",
+    "cached_at": "2025-09-30 23:43:08 UTC",
     "repository_url": "https://github.com/keithah/tessie-mcp",
     "server_name": "ai.smithery/keithah-tessie-mcp"
   },
-  "https://github.com/kesslerio/attio-mcp-server": {
+  "ai.smithery/kesslerio-attio-mcp-server:https://github.com/kesslerio/attio-mcp-server": {
     "ai_decision": "community",
-    "ai_confidence": 0.8,
-    "ai_reason": "Repository is owned by 'kesslerio', not Attio, so it is a third-party integration for Attio CRM.",
-    "cached_at": "2025-09-30 21:42:21 UTC",
+    "ai_confidence": 0.9,
+    "ai_reason": "Repository is under the 'kesslerio' org, not Attio; remotes use smithery.ai, not attio.com—no evidence of Attio brand owner involvement.",
+    "cached_at": "2025-09-30 23:43:10 UTC",
     "repository_url": "https://github.com/kesslerio/attio-mcp-server",
     "server_name": "ai.smithery/kesslerio-attio-mcp-server"
   },
-  "https://github.com/kkjdaniel/bgg-mcp": {
+  "ai.smithery/kkjdaniel-bgg-mcp:https://github.com/kkjdaniel/bgg-mcp": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "Repo owned by user kkjdaniel, not BoardGameGeek; no evidence of official brand org involvement.",
-    "cached_at": "2025-09-30 21:42:23 UTC",
+    "ai_reason": "Repository owner 'kkjdaniel' is a user not affiliated with BoardGameGeek, and remotes use a third-party domain 'smithery.ai'.",
+    "cached_at": "2025-09-30 23:43:11 UTC",
     "repository_url": "https://github.com/kkjdaniel/bgg-mcp",
     "server_name": "ai.smithery/kkjdaniel-bgg-mcp"
   },
-  "https://github.com/kwp-lab/rss-reader-mcp": {
+  "ai.smithery/kwp-lab-rss-reader-mcp:https://github.com/kwp-lab/rss-reader-mcp": {
     "ai_decision": "community",
     "ai_confidence": 0.85,
-    "ai_reason": "RSS is a generic service and kwp-lab is not the owner of any major RSS product; remotes reference smithery.ai but no clear brand ownership.",
-    "cached_at": "2025-09-30 21:42:25 UTC",
+    "ai_reason": "kwp-lab appears to be a third-party org and RSS is a generic protocol not owned by smithery.ai; no official RSS brand to claim.",
+    "cached_at": "2025-09-30 23:43:15 UTC",
     "repository_url": "https://github.com/kwp-lab/rss-reader-mcp",
     "server_name": "ai.smithery/kwp-lab-rss-reader-mcp"
   },
-  "https://github.com/lineex/pubmed-mcp-smithery": {
+  "ai.smithery/lineex-pubmed-mcp-smithery:https://github.com/lineex/pubmed-mcp-smithery": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "The publisher (lineex) and remotes (smithery.ai) are not affiliated with PubMed; PubMed is owned by NCBI/NLM/NIH.",
-    "cached_at": "2025-09-30 21:42:27 UTC",
+    "ai_reason": "Publisher (lineex) is not the PubMed brand owner (NIH); integrates with PubMed but is third-party.",
+    "cached_at": "2025-09-30 23:43:16 UTC",
     "repository_url": "https://github.com/lineex/pubmed-mcp-smithery",
     "server_name": "ai.smithery/lineex-pubmed-mcp-smithery"
   },
-  "https://github.com/lukaskostka99/marketing-miner-mcp": {
+  "ai.smithery/lukaskostka99-marketing-miner-mcp:https://github.com/lukaskostka99/marketing-miner-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.9,
-    "ai_reason": "GitHub user lukaskostka99 published integration for Marketing Miner but is not the official brand/org; remote is smithery.ai, unrelated to marketingminer.com.",
-    "cached_at": "2025-09-30 21:42:29 UTC",
+    "ai_confidence": 0.85,
+    "ai_reason": "The GitHub user lukaskostka99 is not the owner of Marketing Miner, and there is no evidence the repository is published by the official product organization.",
+    "cached_at": "2025-09-30 23:43:19 UTC",
     "repository_url": "https://github.com/lukaskostka99/marketing-miner-mcp",
     "server_name": "ai.smithery/lukaskostka99-marketing-miner-mcp"
   },
-  "https://github.com/magenie33/quality-dimension-generator": {
+  "ai.smithery/magenie33-quality-dimension-generator:https://github.com/magenie33/quality-dimension-generator": {
     "ai_decision": "community",
-    "ai_confidence": 0.8,
-    "ai_reason": "The GitHub org 'magenie33' does not match or represent 'smithery.ai', and there is no evidence it is officially published by Smithery; appears to be a third-party integration.",
-    "cached_at": "2025-09-30 21:42:31 UTC",
+    "ai_confidence": 0.85,
+    "ai_reason": "GitHub org 'magenie33' does not match the product/brand 'smithery.ai' in remotes; no evidence this is published by Smithery/Smithery.ai.",
+    "cached_at": "2025-09-30 23:43:23 UTC",
     "repository_url": "https://github.com/magenie33/quality-dimension-generator",
     "server_name": "ai.smithery/magenie33-quality-dimension-generator"
   },
-  "https://github.com/mfukushim/map-traveler-mcp": {
+  "ai.smithery/mfukushim-map-traveler-mcp:https://github.com/mfukushim/map-traveler-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.9,
-    "ai_reason": "The repository is owned by 'mfukushim' (not Google), while it integrates with Google Maps, so it is a third-party community server.",
-    "cached_at": "2025-09-30 21:42:33 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "Publisher is 'mfukushim' (not Google), service integrates with Google Maps (a generic/major product) but is not from brand owner.",
+    "cached_at": "2025-09-30 23:43:25 UTC",
     "repository_url": "https://github.com/mfukushim/map-traveler-mcp",
     "server_name": "ai.smithery/mfukushim-map-traveler-mcp"
   },
-  "https://github.com/miguelgarzons/mcp-cun": {
+  "ai.smithery/miguelgarzons-mcp-cun:https://github.com/miguelgarzons/mcp-cun": {
     "ai_decision": "community",
-    "ai_confidence": 0.85,
-    "ai_reason": "Repository is under a user account (miguelgarzons), not the smithery organization, despite using a smithery.ai remote.",
-    "cached_at": "2025-09-30 21:42:35 UTC",
+    "ai_confidence": 0.9,
+    "ai_reason": "The repo is under a personal GitHub user ('miguelgarzons') and not an org matching the Smithery brand; strong signals of community project for Smithery.ai.",
+    "cached_at": "2025-09-30 23:43:26 UTC",
     "repository_url": "https://github.com/miguelgarzons/mcp-cun",
     "server_name": "ai.smithery/miguelgarzons-mcp-cun"
   },
-  "https://github.com/minionszyw/bazi": {
+  "ai.smithery/minionszyw-bazi:https://github.com/minionszyw/bazi": {
     "ai_decision": "community",
-    "ai_confidence": 0.8,
-    "ai_reason": "The GitHub org 'minionszyw' does not match 'smithery' or 'smithery.ai', and there is no evidence the repo owner is the brand/service operator.",
-    "cached_at": "2025-09-30 21:42:37 UTC",
+    "ai_confidence": 0.7,
+    "ai_reason": "The GitHub org minionszyw does not match smithery.ai brand; remote is on smithery.ai but repo is third-party.",
+    "cached_at": "2025-09-30 23:43:28 UTC",
     "repository_url": "https://github.com/minionszyw/bazi",
     "server_name": "ai.smithery/minionszyw-bazi"
   },
-  "https://github.com/mjucius/cozi_mcp": {
+  "ai.smithery/mjucius-cozi_mcp:https://github.com/mjucius/cozi_mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.97,
-    "ai_reason": "Repo owned by user 'mjucius', not Cozi org; remotes and org are unrelated to Cozi brand.",
-    "cached_at": "2025-09-30 21:42:39 UTC",
+    "ai_confidence": 0.9,
+    "ai_reason": "GitHub org mjucius does not match the Cozi brand, and remotes use smithery.ai, indicating a third-party implementation.",
+    "cached_at": "2025-09-30 23:43:30 UTC",
     "repository_url": "https://github.com/mjucius/cozi_mcp",
     "server_name": "ai.smithery/mjucius-cozi_mcp"
   },
-  "https://github.com/morosss/sdfsdf": {
+  "ai.smithery/morosss-sdfsdf:https://github.com/morosss/sdfsdf": {
     "ai_decision": "community",
-    "ai_confidence": 0.95,
-    "ai_reason": "GitHub repo is under user 'morosss', not the Smithery org, despite remotes on smithery.ai.",
-    "cached_at": "2025-09-30 21:42:41 UTC",
+    "ai_confidence": 0.9,
+    "ai_reason": "The GitHub repo is under 'morosss' (not an org matching Smithery), and there is no evidence that 'morosss' is the official Smithery publisher.",
+    "cached_at": "2025-09-30 23:43:32 UTC",
     "repository_url": "https://github.com/morosss/sdfsdf",
     "server_name": "ai.smithery/morosss-sdfsdf"
   },
-  "https://github.com/mrugankpednekar/bill_splitter_mcp": {
+  "ai.smithery/mrugankpednekar-bill_splitter_mcp:https://github.com/mrugankpednekar/bill_splitter_mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.75,
-    "ai_reason": "GitHub repo is under a user (mrugankpednekar) and not the org that owns the product (Smithery); no evidence it's published by Smithery.",
-    "cached_at": "2025-09-30 21:42:43 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "The repository is owned by a personal user (mrugankpednekar) and not the brand/organization behind Smithery or bill_splitter; remote is hosted on Smithery's platform but publisher is not the official org.",
+    "cached_at": "2025-09-30 23:43:34 UTC",
     "repository_url": "https://github.com/mrugankpednekar/bill_splitter_mcp",
     "server_name": "ai.smithery/mrugankpednekar-bill_splitter_mcp"
   },
-  "https://github.com/neverinfamous/memory-journal-mcp": {
+  "ai.smithery/neverinfamous-memory-journal-mcp:https://github.com/neverinfamous/memory-journal-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.7,
-    "ai_reason": "The repository is under the 'neverinfamous' org and not 'smithery'; main remote is on smithery.ai but publisher is a third party.",
-    "cached_at": "2025-09-30 21:42:45 UTC",
+    "ai_confidence": 0.8,
+    "ai_reason": "GitHub org (neverinfamous) does not match the Smithery brand or domain; appears to be a third-party implementation.",
+    "cached_at": "2025-09-30 23:43:37 UTC",
     "repository_url": "https://github.com/neverinfamous/memory-journal-mcp",
     "server_name": "ai.smithery/neverinfamous-memory-journal-mcp"
   },
-  "https://github.com/oxylabs/oxylabs-mcp": {
+  "ai.smithery/oxylabs-oxylabs-mcp:https://github.com/oxylabs/oxylabs-mcp": {
     "ai_decision": "community",
     "ai_confidence": 0.85,
-    "ai_reason": "Although the repository is under the oxylabs org and the integration is for Oxylabs, the remote endpoint is hosted on smithery.ai, not an official Oxylabs domain, indicating third-party implementation.",
-    "cached_at": "2025-09-30 21:42:47 UTC",
+    "ai_reason": "The GitHub org 'oxylabs' suggests a match for the Oxylabs brand, but the remote is hosted on 'smithery.ai', indicating this is a community integration for use on Smithery, not an official Oxylabs server.",
+    "cached_at": "2025-09-30 23:43:39 UTC",
     "repository_url": "https://github.com/oxylabs/oxylabs-mcp",
     "server_name": "ai.smithery/oxylabs-oxylabs-mcp"
   },
-  "https://github.com/pinion05/supabase-mcp-lite": {
+  "ai.smithery/pinion05-supabase-mcp-lite:https://github.com/pinion05/supabase-mcp-lite": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "Repo owner 'pinion05' is not Supabase; remotes use 'smithery.ai', not an official Supabase domain.",
-    "cached_at": "2025-09-30 21:42:48 UTC",
+    "ai_reason": "The repo is under user 'pinion05' and not the official Supabase organization, with remotes on smithery.ai, indicating third-party implementation.",
+    "cached_at": "2025-09-30 23:43:42 UTC",
     "repository_url": "https://github.com/pinion05/supabase-mcp-lite",
     "server_name": "ai.smithery/pinion05-supabase-mcp-lite"
   },
-  "https://github.com/pinkpixel-dev/web-scout-mcp": {
+  "ai.smithery/pinkpixel-dev-web-scout-mcp:https://github.com/pinkpixel-dev/web-scout-mcp": {
     "ai_decision": "community",
     "ai_confidence": 0.8,
-    "ai_reason": "The GitHub org 'pinkpixel-dev' differs from 'smithery.ai', indicating a third-party implementation for Smithery's service.",
-    "cached_at": "2025-09-30 21:42:50 UTC",
+    "ai_reason": "pinkpixel-dev is not the organization behind Smithery; remote uses smithery.ai but publisher differs from product owner.",
+    "cached_at": "2025-09-30 23:43:44 UTC",
     "repository_url": "https://github.com/pinkpixel-dev/web-scout-mcp",
     "server_name": "ai.smithery/pinkpixel-dev-web-scout-mcp"
   },
-  "https://github.com/plainyogurt21/sec-edgar-mcp": {
+  "ai.smithery/plainyogurt21-sec-edgar-mcp:https://github.com/plainyogurt21/sec-edgar-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.95,
-    "ai_reason": "The publisher 'plainyogurt21' is not the SEC or an official government organization; no evidence of SEC brand ownership.",
-    "cached_at": "2025-09-30 21:42:51 UTC",
+    "ai_confidence": 0.9,
+    "ai_reason": "The repository is published by the GitHub user 'plainyogurt21', not the U.S. SEC, so it is not official per the definition.",
+    "cached_at": "2025-09-30 23:43:46 UTC",
     "repository_url": "https://github.com/plainyogurt21/sec-edgar-mcp",
     "server_name": "ai.smithery/plainyogurt21-sec-edgar-mcp"
   },
-  "https://github.com/rainbowgore/stealthee-MCP-tools": {
+  "ai.smithery/rainbowgore-stealthee-mcp-tools:https://github.com/rainbowgore/stealthee-MCP-tools": {
     "ai_decision": "community",
-    "ai_confidence": 0.75,
-    "ai_reason": "GitHub org (rainbowgore) and repository do not match the product (smithery.ai) in remote; lacks official branding signals.",
-    "cached_at": "2025-09-30 21:42:53 UTC",
+    "ai_confidence": 0.8,
+    "ai_reason": "The GitHub org rainbowgore does not match the product/brand Smithery; remotes use smithery.ai but publisher is not clearly Smithery's official GitHub.",
+    "cached_at": "2025-09-30 23:43:48 UTC",
     "repository_url": "https://github.com/rainbowgore/stealthee-MCP-tools",
     "server_name": "ai.smithery/rainbowgore-stealthee-mcp-tools"
   },
-  "https://github.com/ramadasmr/networkcalc-mcp": {
+  "ai.smithery/ramadasmr-networkcalc-mcp:https://github.com/ramadasmr/networkcalc-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.85,
-    "ai_reason": "The repo is under a personal user (ramadasmr) and not the Smithery organization; remotes use Smithery's domain but publisher is third-party.",
-    "cached_at": "2025-09-30 21:42:56 UTC",
+    "ai_confidence": 0.9,
+    "ai_reason": "The GitHub repo is under a personal user (ramadasmr), not an org matching Smithery or networkcalc; remotes use Smithery but not brand owner, so it is a third-party integration.",
+    "cached_at": "2025-09-30 23:43:50 UTC",
     "repository_url": "https://github.com/ramadasmr/networkcalc-mcp",
     "server_name": "ai.smithery/ramadasmr-networkcalc-mcp"
   },
-  "https://github.com/renCosta2025/context7fork": {
+  "ai.smithery/renCosta2025-context7fork:https://github.com/renCosta2025/context7fork": {
     "ai_decision": "community",
     "ai_confidence": 0.8,
-    "ai_reason": "GitHub org 'renCosta2025' does not match 'smithery', and there is no evidence it is operated by the Smithery organization.",
-    "cached_at": "2025-09-30 21:42:58 UTC",
+    "ai_reason": "The repository is under the 'renCosta2025' user, not a GitHub Organization matching 'smithery' or 'Smithery AI', and the server name and remotes reference Smithery but are not published by the brand owner.",
+    "cached_at": "2025-09-30 23:43:51 UTC",
     "repository_url": "https://github.com/renCosta2025/context7fork",
     "server_name": "ai.smithery/renCosta2025-context7fork"
   },
-  "https://github.com/rfdez/pvpc-mcp-server": {
+  "ai.smithery/rfdez-pvpc-mcp-server:https://github.com/rfdez/pvpc-mcp-server": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "The repo is owned by a personal user ('rfdez'), not Red Eléctrica, and the remote is hosted on smithery.ai—a third party.",
-    "cached_at": "2025-09-30 21:43:00 UTC",
+    "ai_reason": "GitHub org is rfdez (an individual), not Red Eléctrica; no evidence of official affiliation in repo or remotes.",
+    "cached_at": "2025-09-30 23:43:55 UTC",
     "repository_url": "https://github.com/rfdez/pvpc-mcp-server",
     "server_name": "ai.smithery/rfdez-pvpc-mcp-server"
   },
-  "https://github.com/sebastianall1977/gmail-mcp": {
+  "ai.smithery/sebastianall1977-gmail-mcp:https://github.com/sebastianall1977/gmail-mcp": {
     "ai_decision": "community",
     "ai_confidence": 1.0,
-    "ai_reason": "Publisher is a user (sebastianall1977) and not Google; 'gmail' is a generic service requiring Google ownership for Official status.",
-    "cached_at": "2025-09-30 21:43:02 UTC",
+    "ai_reason": "The repository is owned by an individual (sebastianall1977) and not Google, which is required for official Gmail integrations.",
+    "cached_at": "2025-09-30 23:43:56 UTC",
     "repository_url": "https://github.com/sebastianall1977/gmail-mcp",
     "server_name": "ai.smithery/sebastianall1977-gmail-mcp"
   },
-  "https://github.com/serkan-ozal/driflyte-mcp-server": {
+  "ai.smithery/serkan-ozal-driflyte-mcp-server:https://github.com/serkan-ozal/driflyte-mcp-server": {
     "ai_decision": "community",
-    "ai_confidence": 0.85,
-    "ai_reason": "Repository owner is a user (serkan-ozal), not an organization matching 'Smithery' or 'Driflyte', despite remote referencing smithery.ai.",
-    "cached_at": "2025-09-30 21:43:05 UTC",
+    "ai_confidence": 0.8,
+    "ai_reason": "The repository owner is a user (serkan-ozal), not an organization matching the service (Smithery); strong signals of first-party brand ownership are missing.",
+    "cached_at": "2025-09-30 23:43:58 UTC",
     "repository_url": "https://github.com/serkan-ozal/driflyte-mcp-server",
     "server_name": "ai.smithery/serkan-ozal-driflyte-mcp-server"
   },
-  "https://github.com/slhad/aha-mcp": {
+  "ai.smithery/slhad-aha-mcp:https://github.com/slhad/aha-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.9,
-    "ai_reason": "The GitHub org 'slhad' and domain 'smithery.ai' do not belong to the Home Assistant project, indicating a third-party integration.",
-    "cached_at": "2025-09-30 21:43:07 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "slhad is not the Home Assistant org; repo and remote reference smithery.ai, not the official brand.",
+    "cached_at": "2025-09-30 23:44:00 UTC",
     "repository_url": "https://github.com/slhad/aha-mcp",
     "server_name": "ai.smithery/slhad-aha-mcp"
   },
-  "https://github.com/smithery-ai/smithery-cookbook": {
-    "ai_decision": "official",
-    "ai_confidence": 0.95,
-    "ai_reason": "The GitHub org 'smithery-ai' matches the product/brand 'smithery.ai', the remote is on the smithery.ai domain, and there is no indication the repo is a fork or archived.",
-    "cached_at": "2025-09-30 21:43:10 UTC",
-    "repository_url": "https://github.com/smithery-ai/smithery-cookbook",
-    "server_name": "ai.smithery/smithery-ai-cookbook-python-quickstart"
-  },
-  "https://github.com/smithery-ai/mcp-servers": {
+  "ai.smithery/smithery-ai-github:https://github.com/smithery-ai/mcp-servers": {
     "ai_decision": "community",
     "ai_confidence": 1.0,
-    "ai_reason": "Smithery-ai is not owned by GitHub and thus is a third-party publisher for a generic service (GitHub).",
-    "cached_at": "2025-09-30 21:43:13 UTC",
+    "ai_reason": "The publisher is smithery-ai, not GitHub (the brand owner for the GitHub service), and this is a generic GitHub server.",
+    "cached_at": "2025-09-30 23:44:02 UTC",
     "repository_url": "https://github.com/smithery-ai/mcp-servers",
     "server_name": "ai.smithery/smithery-ai-github"
   },
-  "https://github.com/sunub/obsidian-mcp-server": {
+  "ai.smithery/smithery-ai-national-weather-service:https://github.com/smithery-ai/mcp-servers": {
     "ai_decision": "community",
-    "ai_confidence": 0.8,
-    "ai_reason": "The GitHub org 'sunub' does not match Obsidian's brand, and there is no evidence Smithery owns Obsidian.",
-    "cached_at": "2025-09-30 21:43:16 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "Smithery AI is not the owner of the National Weather Service; the server is published by smithery-ai integrating a third-party service.",
+    "cached_at": "2025-09-30 23:44:04 UTC",
+    "repository_url": "https://github.com/smithery-ai/mcp-servers",
+    "server_name": "ai.smithery/smithery-ai-national-weather-service"
+  },
+  "ai.smithery/smithery-ai-slack:https://github.com/smithery-ai/mcp-servers": {
+    "ai_decision": "community",
+    "ai_confidence": 0.98,
+    "ai_reason": "Smithery-ai is not Slack's publisher and Slack is a generic service; no evidence Smithery-ai is owned by Slack.",
+    "cached_at": "2025-09-30 23:44:06 UTC",
+    "repository_url": "https://github.com/smithery-ai/mcp-servers",
+    "server_name": "ai.smithery/smithery-ai-slack"
+  },
+  "ai.smithery/smithery-notion:https://github.com/smithery-ai/mcp-servers": {
+    "ai_decision": "community",
+    "ai_confidence": 0.98,
+    "ai_reason": "Smithery-ai is not affiliated with Notion; for generic services like Notion, only the actual brand owner (Notion) counts as official.",
+    "cached_at": "2025-09-30 23:44:08 UTC",
+    "repository_url": "https://github.com/smithery-ai/mcp-servers",
+    "server_name": "ai.smithery/smithery-notion"
+  },
+  "ai.smithery/sunub-obsidian-mcp-server:https://github.com/sunub/obsidian-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "Obsidian is the integrated product but publisher (sunub, smithery.ai) is not affiliated with Obsidian's brand or organization.",
+    "cached_at": "2025-09-30 23:44:10 UTC",
     "repository_url": "https://github.com/sunub/obsidian-mcp-server",
     "server_name": "ai.smithery/sunub-obsidian-mcp-server"
   },
-  "https://github.com/xinkuang/china-stock-mcp": {
+  "ai.smithery/xinkuang-china-stock-mcp:https://github.com/xinkuang/china-stock-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.85,
-    "ai_reason": "Repo is by org 'xinkuang' and integrates with Smithery ('smithery.ai') but 'xinkuang' does not appear to own or operate Smithery, indicating third-party implementation.",
-    "cached_at": "2025-09-30 21:43:18 UTC",
+    "ai_confidence": 0.7,
+    "ai_reason": "Repo is under user 'xinkuang', not an organization clearly owning a stock market product/service; remote is on smithery.ai (a platform), signaling a third-party/community integration.",
+    "cached_at": "2025-09-30 23:44:11 UTC",
     "repository_url": "https://github.com/xinkuang/china-stock-mcp",
     "server_name": "ai.smithery/xinkuang-china-stock-mcp"
   },
-  "https://github.com/yuna0x0/anilist-mcp": {
+  "ai.smithery/yuna0x0-anilist-mcp:https://github.com/yuna0x0/anilist-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.9,
-    "ai_reason": "The publisher is yuna0x0 (user, not an organization) and does not match AniList, indicating a third-party implementation.",
-    "cached_at": "2025-09-30 21:43:20 UTC",
+    "ai_confidence": 0.85,
+    "ai_reason": "The repository is under the user yuna0x0 and not the official Anilist organization, and remotes are hosted by smithery.ai, indicating a third-party implementation.",
+    "cached_at": "2025-09-30 23:44:13 UTC",
     "repository_url": "https://github.com/yuna0x0/anilist-mcp",
     "server_name": "ai.smithery/yuna0x0-anilist-mcp"
   },
-  "https://github.com/yuna0x0/hackmd-mcp": {
+  "ai.smithery/yuna0x0-hackmd-mcp:https://github.com/yuna0x0/hackmd-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.9,
-    "ai_reason": "Publisher yuna0x0 is not the HackMD organization; remote uses smithery.ai, indicating third-party integration, not official HackMD ownership.",
-    "cached_at": "2025-09-30 21:43:21 UTC",
+    "ai_confidence": 0.85,
+    "ai_reason": "GitHub repo is under the user yuna0x0, not HackMD; 'smithery.ai' remote suggests integration on a third-party platform.",
+    "cached_at": "2025-09-30 23:44:15 UTC",
     "repository_url": "https://github.com/yuna0x0/hackmd-mcp",
     "server_name": "ai.smithery/yuna0x0-hackmd-mcp"
   },
-  "https://github.com/zeta-chain/cli": {
+  "ai.smithery/zeta-chain-cli:https://github.com/zeta-chain/cli": {
     "ai_decision": "community",
-    "ai_confidence": 0.7,
-    "ai_reason": "The GitHub organization 'zeta-chain' develops the CLI but remote endpoints are hosted under 'smithery.ai', indicating integration by Smithery and not ZetaChain.",
-    "cached_at": "2025-09-30 21:43:23 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "The server integrates with Smithery ('smithery.ai'), but is published by 'zeta-chain', which does not own the Smithery product or brand.",
+    "cached_at": "2025-09-30 23:44:17 UTC",
     "repository_url": "https://github.com/zeta-chain/cli",
     "server_name": "ai.smithery/zeta-chain-cli"
   },
-  "https://github.com/zhaoganghao/hellomcp": {
+  "ai.smithery/zhaoganghao-hellomcp:https://github.com/zhaoganghao/hellomcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.7,
-    "ai_reason": "Repo owner is a user (zhaoganghao), not the Smithery org, so it is a third-party implementation despite using Smithery's domain.",
-    "cached_at": "2025-09-30 21:43:26 UTC",
+    "ai_confidence": 0.9,
+    "ai_reason": "Repository owner 'zhaoganghao' is a user, not the 'smithery' organization, and no strong official branding.",
+    "cached_at": "2025-09-30 23:44:20 UTC",
     "repository_url": "https://github.com/zhaoganghao/hellomcp",
     "server_name": "ai.smithery/zhaoganghao-hellomcp"
   },
-  "https://github.com/zwldarren/akshare-one-mcp": {
+  "ai.smithery/zwldarren-akshare-one-mcp:https://github.com/zwldarren/akshare-one-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.95,
-    "ai_reason": "Repo is owned by a personal user (zwldarren), not an organization matching 'akshare' or 'smithery', so it is a third-party implementation.",
-    "cached_at": "2025-09-30 21:43:28 UTC",
+    "ai_confidence": 0.9,
+    "ai_reason": "Repository owner is a user (zwldarren), not an org owning Akshare or Smithery; remote is at smithery.ai but user namespace signals community.",
+    "cached_at": "2025-09-30 23:44:23 UTC",
     "repository_url": "https://github.com/zwldarren/akshare-one-mcp",
     "server_name": "ai.smithery/zwldarren-akshare-one-mcp"
   },
-  "https://github.com/toolprint/hypertool-mcp": {
-    "ai_decision": "official",
-    "ai_confidence": 0.95,
-    "ai_reason": "GitHub organization 'toolprint' matches the product in server name and npm package scope is '@toolprint', indicating official ownership.",
-    "cached_at": "2025-09-30 21:43:31 UTC",
-    "repository_url": "https://github.com/toolprint/hypertool-mcp",
-    "server_name": "ai.toolprint/hypertool-mcp"
-  },
-  "https://github.com/waystation-ai/mcp": {
+  "ai.waystation/airtable:https://github.com/waystation-ai/mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.98,
-    "ai_reason": "The GitHub org (waystation-ai) does not match Airtable's brand, and for a generic service like Airtable, only Airtable Inc. itself would be official.",
-    "cached_at": "2025-09-30 21:43:33 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "waystation-ai is not owned by Airtable; remotes are waystation.ai not airtable.com, indicating a third-party implementation.",
+    "cached_at": "2025-09-30 23:44:25 UTC",
     "repository_url": "https://github.com/waystation-ai/mcp",
     "server_name": "ai.waystation/airtable"
   },
-  "https://github.com/thoughtspot/mcp-server": {
-    "ai_decision": "official",
+  "ai.waystation/jira:https://github.com/waystation-ai/mcp": {
+    "ai_decision": "community",
     "ai_confidence": 1.0,
-    "ai_reason": "GitHub org 'thoughtspot' matches product 'ThoughtSpot' and all remotes use 'thoughtspot.app' domain.",
-    "cached_at": "2025-09-30 21:43:37 UTC",
-    "repository_url": "https://github.com/thoughtspot/mcp-server",
-    "server_name": "app.thoughtspot/mcp-server"
+    "ai_reason": "Waystation AI is not the brand owner of Jira (owned by Atlassian), so this is a third-party/community implementation.",
+    "cached_at": "2025-09-30 23:44:27 UTC",
+    "repository_url": "https://github.com/waystation-ai/mcp",
+    "server_name": "ai.waystation/jira"
   },
-  "https://github.com/martinellich/jooq-mcp": {
+  "ai.waystation/mcp:https://github.com/waystation-ai/mcp": {
+    "ai_decision": "official",
+    "ai_confidence": 0.95,
+    "ai_reason": "The GitHub org (waystation-ai) and remote domain (waystation.ai) match the server name (ai.waystation/mcp) indicating direct publication by the Waystation organization.",
+    "cached_at": "2025-09-30 23:44:29 UTC",
+    "repository_url": "https://github.com/waystation-ai/mcp",
+    "server_name": "ai.waystation/mcp"
+  },
+  "ai.waystation/miro:https://github.com/waystation-ai/mcp": {
     "ai_decision": "community",
     "ai_confidence": 0.85,
-    "ai_reason": "GitHub org/user 'martinellich' does not match the jOOQ brand (jooq.org), so this is a third-party implementation.",
-    "cached_at": "2025-09-30 21:43:39 UTC",
+    "ai_reason": "The server integrates with Miro but is published by waystation-ai, which is not the Miro organization.",
+    "cached_at": "2025-09-30 23:44:30 UTC",
+    "repository_url": "https://github.com/waystation-ai/mcp",
+    "server_name": "ai.waystation/miro"
+  },
+  "ai.waystation/office:https://github.com/waystation-ai/mcp": {
+    "ai_decision": "official",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub org (waystation-ai) matches root of remote domain (waystation.ai) and product (Waystation Office), with non-generic service name and custom endpoint.",
+    "cached_at": "2025-09-30 23:44:33 UTC",
+    "repository_url": "https://github.com/waystation-ai/mcp",
+    "server_name": "ai.waystation/office"
+  },
+  "ai.waystation/teams:https://github.com/waystation-ai/mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "Waystation-ai is not Microsoft, so this is a third-party integration for Microsoft Teams.",
+    "cached_at": "2025-09-30 23:44:35 UTC",
+    "repository_url": "https://github.com/waystation-ai/mcp",
+    "server_name": "ai.waystation/teams"
+  },
+  "ai.waystation/wrike:https://github.com/waystation-ai/mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "Publisher is waystation-ai, not Wrike; remotes and org do not match Wrike's official brand.",
+    "cached_at": "2025-09-30 23:44:37 UTC",
+    "repository_url": "https://github.com/waystation-ai/mcp",
+    "server_name": "ai.waystation/wrike"
+  },
+  "ch.martinelli/jooq-mcp:https://github.com/martinellich/jooq-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.8,
+    "ai_reason": "GitHub org/user is 'martinellich', not the official jOOQ or Data Geekery org; remote is on a personal domain (martinelli.ch), not the jOOQ brand owner.",
+    "cached_at": "2025-09-30 23:44:39 UTC",
     "repository_url": "https://github.com/martinellich/jooq-mcp",
     "server_name": "ch.martinelli/jooq-mcp"
   },
-  "https://github.com/wei/mymlh-mcp-server": {
+  "ci.git/mymlh-mcp-server:https://github.com/wei/mymlh-mcp-server": {
     "ai_decision": "community",
-    "ai_confidence": 0.8,
-    "ai_reason": "GitHub user 'wei' is not the MyMLH organization, and there is no evidence of official MyMLH branding or verified org status.",
-    "cached_at": "2025-09-30 21:43:41 UTC",
+    "ai_confidence": 0.75,
+    "ai_reason": "The GitHub repo is under the personal user wei, not an org matching MyMLH, and there is no proof the publisher is the official MyMLH organization.",
+    "cached_at": "2025-09-30 23:44:41 UTC",
     "repository_url": "https://github.com/wei/mymlh-mcp-server",
     "server_name": "ci.git/mymlh-mcp-server"
   },
-  "https://github.com/axiomhq/mcp": {
-    "ai_decision": "official",
-    "ai_confidence": 0.97,
-    "ai_reason": "GitHub org 'axiomhq' and remote endpoints 'mcp.axiom.co' both match the Axiom brand, indicating official ownership.",
-    "cached_at": "2025-09-30 21:43:42 UTC",
-    "repository_url": "https://github.com/axiomhq/mcp",
-    "server_name": "co.axiom/mcp"
-  },
-  "https://github.com/apify/apify-mcp-server": {
-    "ai_decision": "official",
-    "ai_confidence": 0.98,
-    "ai_reason": "Published by GitHub org 'apify' matching product and uses apify.com remote, signaling strong brand ownership.",
-    "cached_at": "2025-09-30 21:43:44 UTC",
-    "repository_url": "https://github.com/apify/apify-mcp-server",
-    "server_name": "com.apify/apify-mcp-server"
-  },
-  "https://github.com/BingoWon/apple-rag-mcp": {
+  "com.apple-rag/mcp-server:https://github.com/BingoWon/apple-rag-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.95,
-    "ai_reason": "Repository is under user 'BingoWon', not an Apple org, despite Apple branding in the name and description.",
-    "cached_at": "2025-09-30 21:43:46 UTC",
+    "ai_confidence": 0.93,
+    "ai_reason": "The repo owner BingoWon is not Apple and the domain/apple-rag branding is not Apple's; no evidence this is published by Apple.",
+    "cached_at": "2025-09-30 23:44:43 UTC",
     "repository_url": "https://github.com/BingoWon/apple-rag-mcp",
     "server_name": "com.apple-rag/mcp-server"
   },
-  "https://github.com/DevCycleHQ/cli": {
+  "com.blockscout/mcp-server:https://github.com/blockscout/mcp-server": {
+    "ai_decision": "official",
+    "ai_confidence": 1.0,
+    "ai_reason": "GitHub org blockscout matches product Blockscout and remote endpoint is on blockscout.com.",
+    "cached_at": "2025-09-30 23:44:45 UTC",
+    "repository_url": "https://github.com/blockscout/mcp-server",
+    "server_name": "com.blockscout/mcp-server"
+  },
+  "com.docfork/docfork-mcp:https://github.com/docfork/docfork-mcp": {
+    "ai_decision": "official",
+    "ai_confidence": 1.0,
+    "ai_reason": "GitHub org and remote domain are both docfork, matching the server’s product name, indicating official ownership.",
+    "cached_at": "2025-09-30 23:44:49 UTC",
+    "repository_url": "https://github.com/docfork/docfork-mcp",
+    "server_name": "com.docfork/docfork-mcp"
+  },
+  "com.driflyte/driflyte-mcp-server:https://github.com/serkan-ozal/driflyte-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.8,
+    "ai_reason": "Repo owner is a personal user (serkan-ozal), not an org, despite strong brand/domain match to Driflyte.",
+    "cached_at": "2025-09-30 23:44:50 UTC",
+    "repository_url": "https://github.com/serkan-ozal/driflyte-mcp-server",
+    "server_name": "com.driflyte/driflyte-mcp-server"
+  },
+  "com.falkordb/QueryWeaver:https://github.com/FalkorDB/QueryWeaver": {
     "ai_decision": "official",
     "ai_confidence": 0.95,
-    "ai_reason": "The GitHub org 'DevCycleHQ' matches the product 'DevCycle' in the server and remote domain, with branded endpoints and no negative signals.",
-    "cached_at": "2025-09-30 21:43:50 UTC",
-    "repository_url": "https://github.com/DevCycleHQ/cli",
-    "server_name": "com.devcycle/mcp"
-  },
-  "https://github.com/FalkorDB/QueryWeaver": {
-    "ai_decision": "community",
-    "ai_confidence": 0.75,
-    "ai_reason": "FalkorDB appears to be the publisher but the service is generic SQL, not tied to a proprietary FalkorDB product.",
-    "cached_at": "2025-09-30 21:43:53 UTC",
+    "ai_reason": "GitHub org 'FalkorDB' matches product in server_name and repo, with docker package under org namespace.",
+    "cached_at": "2025-09-30 23:44:53 UTC",
     "repository_url": "https://github.com/FalkorDB/QueryWeaver",
     "server_name": "com.falkordb/QueryWeaver"
   },
-  "https://github.com/gibsonai/mcp": {
-    "ai_decision": "official",
-    "ai_confidence": 0.95,
-    "ai_reason": "GitHub organization (gibsonai) and remote domain (gibsonai.com) both match the product/brand in server name (GibsonAI), indicating this is published by the brand owner.",
-    "cached_at": "2025-09-30 21:43:55 UTC",
-    "repository_url": "https://github.com/gibsonai/mcp",
-    "server_name": "com.gibsonai/mcp"
-  },
-  "https://github.com/iunera/druid-mcp-server": {
+  "com.iunera/druid-mcp-server:https://github.com/iunera/druid-mcp-server": {
     "ai_decision": "community",
-    "ai_confidence": 0.97,
-    "ai_reason": "The server is published by iunera, not Apache or the Druid project, so it is a third-party implementation.",
-    "cached_at": "2025-09-30 21:43:58 UTC",
+    "ai_confidence": 0.85,
+    "ai_reason": "Iunera is not the organization that owns or operates Apache Druid, which is owned by Apache Software Foundation.",
+    "cached_at": "2025-09-30 23:44:55 UTC",
     "repository_url": "https://github.com/iunera/druid-mcp-server",
     "server_name": "com.iunera/druid-mcp-server"
   },
-  "https://github.com/joelverhagen/Knapcode.SampleMcpServer.git": {
+  "com.joelverhagen.mcp/Knapcode.SampleMcpServer:https://github.com/joelverhagen/Knapcode.SampleMcpServer.git": {
     "ai_decision": "community",
     "ai_confidence": 1.0,
-    "ai_reason": "Owned by a personal user (joelverhagen) and relates to a sample server, not an official product or service.",
-    "cached_at": "2025-09-30 21:43:59 UTC",
+    "ai_reason": "Published by a personal user (joelverhagen) and not an org owning any related product/service.",
+    "cached_at": "2025-09-30 23:44:57 UTC",
     "repository_url": "https://github.com/joelverhagen/Knapcode.SampleMcpServer.git",
     "server_name": "com.joelverhagen.mcp/Knapcode.SampleMcpServer"
   },
-  "https://github.com/mintmcp/servers": {
+  "com.mintmcp/gcal:https://github.com/mintmcp/servers": {
     "ai_decision": "community",
-    "ai_confidence": 0.98,
-    "ai_reason": "The org 'mintmcp' is not Google, and the integration is for Google Calendar; strong signal this is a third-party/community server.",
-    "cached_at": "2025-09-30 21:44:01 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "mintmcp is not Google (the owner of Google Calendar); package and remotes use mintmcp.com domain, not google.com.",
+    "cached_at": "2025-09-30 23:45:00 UTC",
     "repository_url": "https://github.com/mintmcp/servers",
     "server_name": "com.mintmcp/gcal"
   },
-  "https://github.com/muxinc/mux-node-sdk": {
-    "ai_decision": "official",
-    "ai_confidence": 0.98,
-    "ai_reason": "GitHub org muxinc matches Mux brand; npm package under @mux and remote at mcp.mux.com confirm brand ownership.",
-    "cached_at": "2025-09-30 21:44:04 UTC",
-    "repository_url": "https://github.com/muxinc/mux-node-sdk",
-    "server_name": "com.mux/mcp"
-  },
-  "https://github.com/onkernel/kernel-mcp-server": {
-    "ai_decision": "official",
-    "ai_confidence": 0.95,
-    "ai_reason": "GitHub organization 'onkernel' matches the product 'Kernel'; remote is on onkernel.com; clear brand ownership.",
-    "cached_at": "2025-09-30 21:44:07 UTC",
-    "repository_url": "https://github.com/onkernel/kernel-mcp-server",
-    "server_name": "com.onkernel/kernel-mcp-server"
-  },
-  "https://github.com/pulsemcp/mcp-servers": {
-    "ai_decision": "official",
-    "ai_confidence": 0.95,
-    "ai_reason": "GitHub org pulsemcp matches server and npm scope (@pulsemcp), signaling official ownership of this PulseMCP product.",
-    "cached_at": "2025-09-30 21:44:11 UTC",
-    "repository_url": "https://github.com/pulsemcp/mcp-servers",
-    "server_name": "com.pulsemcp.servers/pulse-fetch"
-  },
-  "https://github.com/redpanda-data/docs-site": {
-    "ai_decision": "official",
-    "ai_confidence": 0.98,
-    "ai_reason": "GitHub org redpanda-data matches the product Redpanda and remote is on docs.redpanda.com.",
-    "cached_at": "2025-09-30 21:44:12 UTC",
-    "repository_url": "https://github.com/redpanda-data/docs-site",
-    "server_name": "com.redpanda/docs-mcp"
-  },
-  "https://github.com/jaw9c/mcp-registry-mcp": {
+  "com.mintmcp/outlook-calendar:https://github.com/mintmcp/servers": {
     "ai_decision": "community",
-    "ai_confidence": 0.6,
-    "ai_reason": "Repository is under user jaw9c, not an organization matching remote-mcp or registry-mcp, with no clear official branding.",
-    "cached_at": "2025-09-30 21:44:14 UTC",
+    "ai_confidence": 0.9,
+    "ai_reason": "Org mintmcp does not match Microsoft (Outlook Calendar owner); remotes are on mintmcp.com, not microsoft.com.",
+    "cached_at": "2025-09-30 23:45:01 UTC",
+    "repository_url": "https://github.com/mintmcp/servers",
+    "server_name": "com.mintmcp/outlook-calendar"
+  },
+  "com.mintmcp/outlook-email:https://github.com/mintmcp/servers": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "GitHub org 'mintmcp' is not Microsoft and remotes are on mintmcp.com, not outlook.com, indicating a third-party implementation.",
+    "cached_at": "2025-09-30 23:45:03 UTC",
+    "repository_url": "https://github.com/mintmcp/servers",
+    "server_name": "com.mintmcp/outlook-email"
+  },
+  "com.remote-mcp/registry-mcp:https://github.com/jaw9c/mcp-registry-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.65,
+    "ai_reason": "Repository is under a personal GitHub user (jaw9c) rather than an organization matching 'remote-mcp', despite remotes using the remote-mcp.com domain.",
+    "cached_at": "2025-09-30 23:45:05 UTC",
     "repository_url": "https://github.com/jaw9c/mcp-registry-mcp",
     "server_name": "com.remote-mcp/registry-mcp"
   },
-  "https://github.com/ritza-co/acme-todo": {
+  "com.ritzademo/acme-todo:https://github.com/ritza-co/acme-todo": {
     "ai_decision": "community",
-    "ai_confidence": 0.8,
-    "ai_reason": "The acme-todo server is published by ritzaco (ritza-co), not an organization clearly matching 'acme' or an established todo product brand.",
-    "cached_at": "2025-09-30 21:44:16 UTC",
+    "ai_confidence": 0.85,
+    "ai_reason": "The GitHub org 'ritza-co' does not directly match the product 'acme-todo'; remote is on 'ritzademo.com' rather than a clear product brand domain.",
+    "cached_at": "2025-09-30 23:45:07 UTC",
     "repository_url": "https://github.com/ritza-co/acme-todo",
     "server_name": "com.ritzademo/acme-todo"
   },
-  "https://github.com/SmartBear/smartbear-mcp": {
-    "ai_decision": "official",
-    "ai_confidence": 1.0,
-    "ai_reason": "Published by the SmartBear organization on GitHub with product-matching org name and npm scope, not a fork or archived.",
-    "cached_at": "2025-09-30 21:44:18 UTC",
-    "repository_url": "https://github.com/SmartBear/smartbear-mcp",
-    "server_name": "com.smartbear/smartbear-mcp"
-  },
-  "https://github.com/teamwork/mcp": {
-    "ai_decision": "official",
-    "ai_confidence": 1.0,
-    "ai_reason": "GitHub org 'teamwork' exactly matches the product Teamwork.com, repository is not a fork or archived, and remotes are on the official teamwork.com domain.",
-    "cached_at": "2025-09-30 21:44:20 UTC",
-    "repository_url": "https://github.com/teamwork/mcp",
-    "server_name": "com.teamwork/mcp"
-  },
-  "https://github.com/cameroncooke/XcodeBuildMCP": {
-    "ai_decision": "community",
-    "ai_confidence": 0.98,
-    "ai_reason": "Repository is owned by user 'cameroncooke' rather than Apple, and Xcode is an Apple product.",
-    "cached_at": "2025-09-30 21:44:21 UTC",
-    "repository_url": "https://github.com/cameroncooke/XcodeBuildMCP",
-    "server_name": "com.xcodebuildmcp/XcodeBuildMCP"
-  },
-  "https://github.com/Zomato/mcp-server-manifest": {
-    "ai_decision": "official",
-    "ai_confidence": 0.95,
-    "ai_reason": "GitHub org 'Zomato' matches the product in server name and remote is zomato.com.",
-    "cached_at": "2025-09-30 21:44:24 UTC",
-    "repository_url": "https://github.com/Zomato/mcp-server-manifest",
-    "server_name": "com.zomato/mcp"
-  },
-  "https://github.com/augmnt/augments-mcp-server": {
-    "ai_decision": "official",
-    "ai_confidence": 0.95,
-    "ai_reason": "The GitHub org ('augmnt') matches the product/brand in the server name and remote ('augments'), server remotes are on the augments.dev domain, and the package is under the same brand.",
-    "cached_at": "2025-09-30 21:44:26 UTC",
-    "repository_url": "https://github.com/augmnt/augments-mcp-server",
-    "server_name": "dev.augments/mcp"
-  },
-  "https://github.com/ComposioHQ/Rube": {
+  "dev.composio.rube/rube:https://github.com/ComposioHQ/Rube": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "ComposioHQ is not the brand owner for Gmail, Slack, GitHub, or Notion; this is a third-party community integration for multiple services.",
-    "cached_at": "2025-09-30 21:44:28 UTC",
+    "ai_reason": "ComposioHQ is not the brand owner of Gmail, Slack, GitHub, or Notion; repo integrates with generic services and is published by a third-party organization.",
+    "cached_at": "2025-09-30 23:45:09 UTC",
     "repository_url": "https://github.com/ComposioHQ/Rube",
     "server_name": "dev.composio.rube/rube"
   },
-  "https://github.com/promplate/hmr": {
-    "ai_decision": "official",
-    "ai_confidence": 0.95,
-    "ai_reason": "GitHub org 'promplate' matches server name 'promplate/hmr' and remotes use promplate.dev subdomain.",
-    "cached_at": "2025-09-30 21:44:30 UTC",
-    "repository_url": "https://github.com/promplate/hmr",
-    "server_name": "dev.promplate/hmr"
-  },
-  "https://github.com/francis-ros/rostro-mcp-server": {
+  "dev.rostro/rostro:https://github.com/francis-ros/rostro-mcp-server": {
     "ai_decision": "community",
     "ai_confidence": 0.7,
-    "ai_reason": "The repo is owned by a personal user (francis-ros), not an organization matching 'rostro' or 'rostro.dev'; no clear evidence of official brand ownership.",
-    "cached_at": "2025-09-30 21:44:31 UTC",
+    "ai_reason": "Repo owner 'francis-ros' is a personal user, not an organization matching 'rostro' product; no verified brand ownership.",
+    "cached_at": "2025-09-30 23:45:12 UTC",
     "repository_url": "https://github.com/francis-ros/rostro-mcp-server",
     "server_name": "dev.rostro/rostro"
   },
-  "https://github.com/khromov/svelte-llm-mcp": {
+  "garden.stanislav.svelte-llm/svelte-llm-mcp:https://github.com/khromov/svelte-llm-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.95,
-    "ai_reason": "Repository is owned by a personal user (khromov), not an official Svelte organization, with no signals linking to the product's brand owner.",
-    "cached_at": "2025-09-30 21:44:33 UTC",
+    "ai_confidence": 0.85,
+    "ai_reason": "GitHub org is 'khromov' (personal user, not the Svelte org), and remotes are on a personal domain; no evidence of ownership by Svelte.",
+    "cached_at": "2025-09-30 23:45:14 UTC",
     "repository_url": "https://github.com/khromov/svelte-llm-mcp",
     "server_name": "garden.stanislav.svelte-llm/svelte-llm-mcp"
   },
-  "https://github.com/balldontlie-api/mcp": {
-    "ai_decision": "official",
-    "ai_confidence": 0.95,
-    "ai_reason": "GitHub org 'balldontlie-api' matches the service 'balldontlie', the remote is on balldontlie.io, and all signals indicate direct ownership.",
-    "cached_at": "2025-09-30 21:44:36 UTC",
-    "repository_url": "https://github.com/balldontlie-api/mcp",
-    "server_name": "io.balldontlie/mcp"
-  },
-  "https://github.com/foqal/mcp": {
-    "ai_decision": "official",
-    "ai_confidence": 0.97,
-    "ai_reason": "GitHub org ('foqal') matches product/brand in server name and remote endpoint is on the organization's domain.",
-    "cached_at": "2025-09-30 21:44:38 UTC",
-    "repository_url": "https://github.com/foqal/mcp",
-    "server_name": "io.foqal/Foqal"
-  },
-  "https://github.com/8beeeaaat/touchdesigner-mcp.git": {
+  "io.github.8beeeaaat/touchdesigner-mcp-server:https://github.com/8beeeaaat/touchdesigner-mcp.git": {
     "ai_decision": "community",
     "ai_confidence": 0.9,
-    "ai_reason": "The GitHub org '8beeeaaat' does not match the TouchDesigner brand; no evidence links the publisher to the official TouchDesigner organization.",
-    "cached_at": "2025-09-30 21:44:39 UTC",
+    "ai_reason": "The publisher '8beeeaaat' is a personal user, not the official TouchDesigner organization.",
+    "cached_at": "2025-09-30 23:45:16 UTC",
     "repository_url": "https://github.com/8beeeaaat/touchdesigner-mcp.git",
     "server_name": "io.github.8beeeaaat/touchdesigner-mcp-server"
   },
-  "https://github.com/Antonytm/mcp-all": {
+  "io.github.Antonytm/mcp-all:https://github.com/Antonytm/mcp-all": {
     "ai_decision": "community",
-    "ai_confidence": 0.9,
-    "ai_reason": "The GitHub org 'Antonytm' does not match a known product/service brand, and evidence points to a personal or third-party community implementation.",
-    "cached_at": "2025-09-30 21:44:41 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "Published by a personal user (Antonytm), not an organization owning an underlying service; no strong official branding.",
+    "cached_at": "2025-09-30 23:45:18 UTC",
     "repository_url": "https://github.com/Antonytm/mcp-all",
     "server_name": "io.github.Antonytm/mcp-all"
   },
-  "https://github.com/Antonytm/mcp-sitecore-server": {
+  "io.github.Antonytm/mcp-sitecore-server:https://github.com/Antonytm/mcp-sitecore-server": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "GitHub org 'Antonytm' does not match Sitecore brand, and Sitecore ownership is not evidenced.",
-    "cached_at": "2025-09-30 21:44:43 UTC",
+    "ai_reason": "Published by user Antonytm, not the official Sitecore organization, and no strong official signals.",
+    "cached_at": "2025-09-30 23:45:19 UTC",
     "repository_url": "https://github.com/Antonytm/mcp-sitecore-server",
     "server_name": "io.github.Antonytm/mcp-sitecore-server"
   },
-  "https://github.com/AungMyoKyaw/betterprompt-mcp": {
+  "io.github.AungMyoKyaw/betterprompt-mcp:https://github.com/AungMyoKyaw/betterprompt-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.85,
-    "ai_reason": "The publisher is a personal GitHub user (AungMyoKyaw) and not an organization owning a recognizable underlying product or service.",
-    "cached_at": "2025-09-30 21:44:44 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repo is owned by a personal user 'AungMyoKyaw' and not a verified organization matching any product/brand.",
+    "cached_at": "2025-09-30 23:45:21 UTC",
     "repository_url": "https://github.com/AungMyoKyaw/betterprompt-mcp",
     "server_name": "io.github.AungMyoKyaw/betterprompt-mcp"
   },
-  "https://github.com/BenAHammond/code-auditor-mcp": {
+  "io.github.BenAHammond/code-auditor-mcp:https://github.com/BenAHammond/code-auditor-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 1.0,
-    "ai_reason": "The repository owner is a personal user (BenAHammond), with no evidence of organization or brand ownership for 'code-auditor'; signals indicate a community project.",
-    "cached_at": "2025-09-30 21:44:46 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "The repository is owned by a personal user (BenAHammond) and not by an organization corresponding to a distinct product or service brand.",
+    "cached_at": "2025-09-30 23:45:24 UTC",
     "repository_url": "https://github.com/BenAHammond/code-auditor-mcp",
     "server_name": "io.github.BenAHammond/code-auditor-mcp"
   },
-  "https://github.com/ChengJiale150/jupyter-mcp-server": {
+  "io.github.ChengJiale150/jupyter-mcp-server:https://github.com/ChengJiale150/jupyter-mcp-server": {
     "ai_decision": "community",
-    "ai_confidence": 1.0,
-    "ai_reason": "Repository is published by a personal user (ChengJiale150) and not the official Jupyter organization.",
-    "cached_at": "2025-09-30 21:44:48 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "Published by user ChengJiale150 not the Jupyter organization, so not official.",
+    "cached_at": "2025-09-30 23:45:27 UTC",
     "repository_url": "https://github.com/ChengJiale150/jupyter-mcp-server",
     "server_name": "io.github.ChengJiale150/jupyter-mcp-server"
   },
-  "https://github.com/ChiR24/Unreal_mcp.git": {
+  "io.github.ChiR24/unreal-engine-mcp:https://github.com/ChiR24/Unreal_mcp.git": {
     "ai_decision": "community",
-    "ai_confidence": 1.0,
-    "ai_reason": "The GitHub owner 'ChiR24' is a user, not the Unreal Engine brand owner (Epic Games), indicating this is a third-party implementation.",
-    "cached_at": "2025-09-30 21:44:50 UTC",
+    "ai_confidence": 0.9,
+    "ai_reason": "GitHub org 'ChiR24' does not match Unreal Engine/Epic Games branding, indicating this is a third-party server.",
+    "cached_at": "2025-09-30 23:45:29 UTC",
     "repository_url": "https://github.com/ChiR24/Unreal_mcp.git",
     "server_name": "io.github.ChiR24/unreal-engine-mcp"
   },
-  "https://github.com/ChromeDevTools/chrome-devtools-mcp": {
-    "ai_decision": "official",
-    "ai_confidence": 0.95,
-    "ai_reason": "GitHub organization name ChromeDevTools exactly matches the integrated product, indicating direct brand ownership.",
-    "cached_at": "2025-09-30 21:44:52 UTC",
-    "repository_url": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
-    "server_name": "io.github.ChromeDevTools/chrome-devtools-mcp"
-  },
-  "https://github.com/CodeAlive-AI/codealive-mcp.git": {
-    "ai_decision": "official",
-    "ai_confidence": 0.95,
-    "ai_reason": "GitHub Organization 'CodeAlive-AI' matches the product 'CodeAlive' in the server name, and all key signals (repo name, org, package namespace) are consistent with official ownership.",
-    "cached_at": "2025-09-30 21:44:56 UTC",
-    "repository_url": "https://github.com/CodeAlive-AI/codealive-mcp.git",
-    "server_name": "io.github.CodeAlive-AI/codealive-mcp"
-  },
-  "https://github.com/CodeLogicIncEngineering/codelogic-mcp-server": {
-    "ai_decision": "official",
-    "ai_confidence": 0.95,
-    "ai_reason": "GitHub org CodeLogicIncEngineering matches the product CodeLogic referenced in server name, repo, and remotes.",
-    "cached_at": "2025-09-30 21:44:58 UTC",
-    "repository_url": "https://github.com/CodeLogicIncEngineering/codelogic-mcp-server",
-    "server_name": "io.github.CodeLogicIncEngineering/codelogic-mcp-server"
-  },
-  "https://github.com/CursorTouch/Windows-MCP": {
+  "io.github.DeanWard/HAL:https://github.com/DeanWard/HAL": {
     "ai_decision": "community",
-    "ai_confidence": 0.85,
-    "ai_reason": "CursorTouch is not an official Microsoft or Windows organization, and there is no evidence it is published by the Windows brand owner.",
-    "cached_at": "2025-09-30 21:45:01 UTC",
-    "repository_url": "https://github.com/CursorTouch/Windows-MCP",
-    "server_name": "io.github.CursorTouch/Windows-MCP"
-  },
-  "https://github.com/DeanWard/HAL": {
-    "ai_decision": "community",
-    "ai_confidence": 0.9,
-    "ai_reason": "Repository is owned by a user (DeanWard), not an organization, and does not match a major proprietary product/brand.",
-    "cached_at": "2025-09-30 21:45:03 UTC",
+    "ai_confidence": 0.7,
+    "ai_reason": "Repo is owned by a personal user (DeanWard) and not by an organization that owns/operates a HAL-branded product/service.",
+    "cached_at": "2025-09-30 23:45:31 UTC",
     "repository_url": "https://github.com/DeanWard/HAL",
     "server_name": "io.github.DeanWard/HAL"
   },
-  "https://github.com/Decodo/mcp-web-scraper": {
+  "io.github.Decodo/mcp-web-scraper:https://github.com/Decodo/mcp-web-scraper": {
     "ai_decision": "community",
-    "ai_confidence": 0.8,
-    "ai_reason": "Decodo is not a widely recognized web scraping brand; package, repo, and org are self-published and not tied to a major product/service.",
-    "cached_at": "2025-09-30 21:45:05 UTC",
+    "ai_confidence": 0.85,
+    "ai_reason": "Decodo is not the owner of the generic web scraping functionality; matches in org and package names indicate publisher, but not a brand-owned integration.",
+    "cached_at": "2025-09-30 23:45:33 UTC",
     "repository_url": "https://github.com/Decodo/mcp-web-scraper",
     "server_name": "io.github.Decodo/mcp-web-scraper"
   },
-  "https://github.com/Flightradar24/fr24api-mcp": {
-    "ai_decision": "official",
-    "ai_confidence": 0.97,
-    "ai_reason": "GitHub org Flightradar24 matches the product name and owns both the repo and npm package namespace.",
-    "cached_at": "2025-09-30 21:45:07 UTC",
-    "repository_url": "https://github.com/Flightradar24/fr24api-mcp",
-    "server_name": "io.github.Flightradar24/fr24api-mcp"
-  },
-  "https://github.com/GLips/Figma-Context-MCP": {
-    "ai_decision": "community",
-    "ai_confidence": 0.95,
-    "ai_reason": "The publisher GLips is not associated with Figma, and there is no evidence of official Figma branding in the organization, repo, or npm package.",
-    "cached_at": "2025-09-30 21:45:11 UTC",
-    "repository_url": "https://github.com/GLips/Figma-Context-MCP",
-    "server_name": "io.github.GLips/Figma-Context-MCP"
-  },
-  "https://github.com/testing9384/mcp-server": {
+  "io.github.GabrielaHdzMicrosoft/mcp-server:https://github.com/testing9384/mcp-server": {
     "ai_decision": "community",
     "ai_confidence": 0.9,
-    "ai_reason": "Repository is owned by a personal GitHub user ('testing9384'), not an organization matching Microsoft or any product brand mentioned.",
-    "cached_at": "2025-09-30 21:45:12 UTC",
+    "ai_reason": "The repository is owned by a personal user (testing9384) and not by a verified organization matching the service or brand.",
+    "cached_at": "2025-09-30 23:45:35 UTC",
     "repository_url": "https://github.com/testing9384/mcp-server",
     "server_name": "io.github.GabrielaHdzMicrosoft/mcp-server"
   },
-  "https://github.com/GitHub30/note-mcp-server": {
+  "io.github.GitHub30/note-mcp-server:https://github.com/GitHub30/note-mcp-server": {
     "ai_decision": "community",
-    "ai_confidence": 0.9,
-    "ai_reason": "The repository is under a user account (GitHub30) not affiliated with note.com, indicating a third-party implementation for the note.com service.",
-    "cached_at": "2025-09-30 21:45:14 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub30 is a personal user, not the official Note.com org; no evidence links to the brand owner.",
+    "cached_at": "2025-09-30 23:45:37 UTC",
     "repository_url": "https://github.com/GitHub30/note-mcp-server",
     "server_name": "io.github.GitHub30/note-mcp-server"
   },
-  "https://github.com/GitHub30/qiita-mcp-server": {
+  "io.github.GitHub30/qiita-mcp-server:https://github.com/GitHub30/qiita-mcp-server": {
     "ai_decision": "community",
-    "ai_confidence": 0.9,
-    "ai_reason": "The repository is owned by a personal user (GitHub30), not by Qiita's official organization.",
-    "cached_at": "2025-09-30 21:45:15 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repo is owned by a user (GitHub30) not the Qiita org, and there is no signal it is published by the Qiita brand owner.",
+    "cached_at": "2025-09-30 23:45:39 UTC",
     "repository_url": "https://github.com/GitHub30/qiita-mcp-server",
     "server_name": "io.github.GitHub30/qiita-mcp-server"
   },
-  "https://github.com/GitHub30/zenn-mcp-server": {
+  "io.github.GitHub30/zenn-mcp-server:https://github.com/GitHub30/zenn-mcp-server": {
     "ai_decision": "community",
-    "ai_confidence": 0.85,
-    "ai_reason": "GitHub repo owner is a user (GitHub30), not the Zenn organization, with no strong signals of official Zenn ownership.",
-    "cached_at": "2025-09-30 21:45:18 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repo is authored by a user (GitHub30), not the Zenn organization, indicating third-party community implementation.",
+    "cached_at": "2025-09-30 23:45:41 UTC",
     "repository_url": "https://github.com/GitHub30/zenn-mcp-server",
     "server_name": "io.github.GitHub30/zenn-mcp-server"
   },
-  "https://github.com/GoneTone/mcp-server-taiwan-weather": {
+  "io.github.GoneTone/mcp-server-taiwan-weather:https://github.com/GoneTone/mcp-server-taiwan-weather": {
     "ai_decision": "community",
-    "ai_confidence": 1.0,
-    "ai_reason": "The publisher (GoneTone) is not the official owner of the Taiwan Central Weather Administration API; organization and package names do not match the official brand.",
-    "cached_at": "2025-09-30 21:45:20 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub org (GoneTone) does not match official Taiwan Central Weather Bureau branding, indicating a community project.",
+    "cached_at": "2025-09-30 23:45:43 UTC",
     "repository_url": "https://github.com/GoneTone/mcp-server-taiwan-weather",
     "server_name": "io.github.GoneTone/mcp-server-taiwan-weather"
   },
-  "https://github.com/GoogleCloudPlatform/gemini-cloud-assist-mcp": {
-    "ai_decision": "official",
-    "ai_confidence": 1.0,
-    "ai_reason": "Published by the verified GoogleCloudPlatform organization with npm package under @google-cloud, matching an official Google Cloud service.",
-    "cached_at": "2025-09-30 21:45:21 UTC",
-    "repository_url": "https://github.com/GoogleCloudPlatform/gemini-cloud-assist-mcp",
-    "server_name": "io.github.GoogleCloudPlatform/gemini-cloud-assist-mcp"
-  },
-  "https://github.com/IvanMurzak/Unity-MCP": {
+  "io.github.IvanMurzak/Unity-MCP:https://github.com/IvanMurzak/Unity-MCP": {
     "ai_decision": "community",
-    "ai_confidence": 0.95,
-    "ai_reason": "The repository is owned by a personal user (IvanMurzak) and not by Unity Technologies, which owns Unity Engine.",
-    "cached_at": "2025-09-30 21:45:23 UTC",
+    "ai_confidence": 0.98,
+    "ai_reason": "Repository is owned by personal user IvanMurzak, not the official Unity organization.",
+    "cached_at": "2025-09-30 23:45:45 UTC",
     "repository_url": "https://github.com/IvanMurzak/Unity-MCP",
     "server_name": "io.github.IvanMurzak/Unity-MCP"
   },
-  "https://github.com/JustasMonkev/mcp-accessibility-scanner": {
+  "io.github.JustasMonkev/mcp-accessibility-scanner:https://github.com/JustasMonkev/mcp-accessibility-scanner": {
     "ai_decision": "community",
-    "ai_confidence": 1.0,
-    "ai_reason": "Repository is owned by a personal GitHub user (JustasMonkev), not by the maintainers of Playwright or Axe-core.",
-    "cached_at": "2025-09-30 21:45:25 UTC",
+    "ai_confidence": 0.98,
+    "ai_reason": "Published by a personal GitHub user (JustasMonkev), not an organization owning Playwright, Axe-core, or accessibility platforms.",
+    "cached_at": "2025-09-30 23:45:47 UTC",
     "repository_url": "https://github.com/JustasMonkev/mcp-accessibility-scanner",
     "server_name": "io.github.JustasMonkev/mcp-accessibility-scanner"
   },
-  "https://github.com/KylinMountain/web-fetch-mcp.git": {
+  "io.github.KylinMountain/web-fetch-mcp:https://github.com/KylinMountain/web-fetch-mcp.git": {
     "ai_decision": "community",
-    "ai_confidence": 0.9,
-    "ai_reason": "The publisher is the 'KylinMountain' GitHub user (not a Gemini/Google org), and 'Gemini' is a generic service requiring actual brand ownership for official.",
-    "cached_at": "2025-09-30 21:45:28 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "KylinMountain is not an official org for any major web service, and the project provides a general web fetch/summarizing server with community packaging and generic integration hints.",
+    "cached_at": "2025-09-30 23:45:49 UTC",
     "repository_url": "https://github.com/KylinMountain/web-fetch-mcp.git",
     "server_name": "io.github.KylinMountain/web-fetch-mcp"
   },
-  "https://github.com/LinuxSuRen/atest-mcp-server": {
+  "io.github.LinuxSuRen/atest-mcp-server:https://github.com/LinuxSuRen/atest-mcp-server": {
     "ai_decision": "community",
-    "ai_confidence": 0.85,
-    "ai_reason": "LinuxSuRen is a personal username not a verified org, and no strong product/brand ownership ties to any known product.",
-    "cached_at": "2025-09-30 21:45:30 UTC",
+    "ai_confidence": 0.9,
+    "ai_reason": "The publisher (LinuxSuRen) does not match a recognized brand or product, and the server_name includes 'atest', suggesting it is a test implementation rather than an official integration.",
+    "cached_at": "2025-09-30 23:45:50 UTC",
     "repository_url": "https://github.com/LinuxSuRen/atest-mcp-server",
     "server_name": "io.github.LinuxSuRen/atest-mcp-server"
   },
-  "https://github.com/Lyellr88/MARM-Systems": {
+  "io.github.Lyellr88/marm-mcp-server:https://github.com/Lyellr88/MARM-Systems": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "Published by a personal user (Lyellr88) rather than an official organization for the underlying service.",
-    "cached_at": "2025-09-30 21:45:32 UTC",
+    "ai_reason": "The repo is owned by a personal user (Lyellr88) and not an organization; there is no evidence of brand/service ownership.",
+    "cached_at": "2025-09-30 23:45:52 UTC",
     "repository_url": "https://github.com/Lyellr88/MARM-Systems",
     "server_name": "io.github.Lyellr88/marm-mcp-server"
   },
-  "https://github.com/MR901/mcp-plots": {
+  "io.github.MR901/mcp-plots:https://github.com/MR901/mcp-plots": {
     "ai_decision": "community",
-    "ai_confidence": 0.9,
-    "ai_reason": "Publisher MR901 is a personal user, not the Mermaid brand or organization.",
-    "cached_at": "2025-09-30 21:45:33 UTC",
+    "ai_confidence": 0.8,
+    "ai_reason": "The GitHub user MR901 does not match or represent the Mermaid brand or any major product/service; MR901 is not an organization.",
+    "cached_at": "2025-09-30 23:45:54 UTC",
     "repository_url": "https://github.com/MR901/mcp-plots",
     "server_name": "io.github.MR901/mcp-plots"
   },
-  "https://github.com/MR901/plots-mcp": {
+  "io.github.MR901/plots-mcp:https://github.com/MR901/plots-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.9,
-    "ai_reason": "The GitHub owner MR901 is a user, does not match a known product or brand, and there is no evidence of official brand ownership.",
-    "cached_at": "2025-09-30 21:45:36 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub owner 'MR901' is a user, not an organization owning 'Mermaid'; no official brand signals.",
+    "cached_at": "2025-09-30 23:45:56 UTC",
     "repository_url": "https://github.com/MR901/plots-mcp",
     "server_name": "io.github.MR901/plots-mcp"
   },
-  "https://github.com/MasonChow/source-map-parser-mcp": {
+  "io.github.MasonChow/source-map-parser-mcp:https://github.com/MasonChow/source-map-parser-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.95,
-    "ai_reason": "Repository is owned by a personal user (MasonChow) rather than an organization associated with source maps or JavaScript tooling brands.",
-    "cached_at": "2025-09-30 21:45:38 UTC",
+    "ai_confidence": 1.0,
+    "ai_reason": "Repo is owned by a personal user (MasonChow) and not by an organization that owns the underlying service (source maps/JavaScript), which are generic technologies.",
+    "cached_at": "2025-09-30 23:45:58 UTC",
     "repository_url": "https://github.com/MasonChow/source-map-parser-mcp",
     "server_name": "io.github.MasonChow/source-map-parser-mcp"
   },
-  "https://github.com/NitishGourishetty/contextual-mcp-server": {
+  "io.github.Nekzus/npm-sentinel-mcp:https://github.com/Nekzus/npm-sentinel-mcp": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "Repo owned by personal user (NitishGourishetty), not Contextual AI organization.",
-    "cached_at": "2025-09-30 21:45:40 UTC",
+    "ai_reason": "Nekzus is not the owner of npm; repo owner is a personal user, not the official NPM organization.",
+    "cached_at": "2025-09-30 23:46:00 UTC",
+    "repository_url": "https://github.com/Nekzus/npm-sentinel-mcp",
+    "server_name": "io.github.Nekzus/npm-sentinel-mcp"
+  },
+  "io.github.NitishGourishetty/contextual-mcp-server:https://github.com/NitishGourishetty/contextual-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "GitHub repo is owned by a personal user (NitishGourishetty) not the Contextual AI org, and no org-verified signals are present.",
+    "cached_at": "2025-09-30 23:46:02 UTC",
     "repository_url": "https://github.com/NitishGourishetty/contextual-mcp-server",
     "server_name": "io.github.NitishGourishetty/contextual-mcp-server"
   },
-  "https://github.com/OpenCageData/opencage-geocoding-mcp": {
-    "ai_decision": "official",
-    "ai_confidence": 0.98,
-    "ai_reason": "The GitHub organization (OpenCageData) matches the product (OpenCage geocoding), is not generic, and package namespace (@opencage) is controlled by the org.",
-    "cached_at": "2025-09-30 21:45:42 UTC",
-    "repository_url": "https://github.com/OpenCageData/opencage-geocoding-mcp",
-    "server_name": "io.github.OpenCageData/opencage-geocoding-mcp"
-  },
-  "https://github.com/OtherVibes/mcp-as-a-judge": {
+  "io.github.OtherVibes/mcp-as-a-judge:https://github.com/OtherVibes/mcp-as-a-judge": {
     "ai_decision": "community",
-    "ai_confidence": 0.9,
-    "ai_reason": "GitHub org 'OtherVibes' does not match a known product/service brand in the server name or description.",
-    "cached_at": "2025-09-30 21:45:44 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "Published by a user/org (OtherVibes) not matching any mainstream product or brand; no evidence of ownership of an underlying product/service.",
+    "cached_at": "2025-09-30 23:46:04 UTC",
     "repository_url": "https://github.com/OtherVibes/mcp-as-a-judge",
     "server_name": "io.github.OtherVibes/mcp-as-a-judge"
   },
-  "https://github.com/PV-Bhat/vibe-check-mcp-server": {
+  "io.github.PV-Bhat/vibe-check-mcp-server:https://github.com/PV-Bhat/vibe-check-mcp-server": {
     "ai_decision": "community",
-    "ai_confidence": 0.95,
-    "ai_reason": "Repo is owned by a personal user (PV-Bhat), not an organization matching a recognized product/service brand.",
-    "cached_at": "2025-09-30 21:45:45 UTC",
+    "ai_confidence": 0.8,
+    "ai_reason": "Repository owner 'PV-Bhat' appears to be an individual user and not an official organization tied to a product or service.",
+    "cached_at": "2025-09-30 23:46:06 UTC",
     "repository_url": "https://github.com/PV-Bhat/vibe-check-mcp-server",
     "server_name": "io.github.PV-Bhat/vibe-check-mcp-server"
   },
-  "https://github.com/Raistlin82/btp-sap-odata-to-mcp-server-optimized": {
+  "io.github.Raistlin82/btp-sap-odata-to-mcp-server-optimized:https://github.com/Raistlin82/btp-sap-odata-to-mcp-server-optimized": {
     "ai_decision": "community",
-    "ai_confidence": 0.95,
-    "ai_reason": "GitHub repo is owned by a user (Raistlin82), not by SAP or an SAP-verified org.",
-    "cached_at": "2025-09-30 21:45:48 UTC",
+    "ai_confidence": 0.97,
+    "ai_reason": "Repo owned by user Raistlin82, not SAP/BTP org, with no verified org or official branding signals.",
+    "cached_at": "2025-09-30 23:46:08 UTC",
     "repository_url": "https://github.com/Raistlin82/btp-sap-odata-to-mcp-server-optimized",
     "server_name": "io.github.Raistlin82/btp-sap-odata-to-mcp-server-optimized"
   },
-  "https://github.com/Saidiibrahim/search-papers": {
+  "io.github.Saidiibrahim/search-papers:https://github.com/Saidiibrahim/search-papers": {
     "ai_decision": "community",
     "ai_confidence": 1.0,
-    "ai_reason": "Repo is under a user account (Saidiibrahim) not the arXiv org, with no official branding or verified signals.",
-    "cached_at": "2025-09-30 21:45:52 UTC",
+    "ai_reason": "Publisher is a personal user (Saidiibrahim) and not affiliated with arXiv, which is the integrated service.",
+    "cached_at": "2025-09-30 23:46:11 UTC",
     "repository_url": "https://github.com/Saidiibrahim/search-papers",
     "server_name": "io.github.Saidiibrahim/search-papers"
   },
-  "https://github.com/Selenium39/mcp-server-tempmail": {
+  "io.github.Selenium39/mcp-server-tempmail:https://github.com/Selenium39/mcp-server-tempmail": {
     "ai_decision": "community",
-    "ai_confidence": 0.95,
-    "ai_reason": "The publisher is the GitHub user Selenium39, not the ChatTempMail organization, and there is no evidence of official association.",
-    "cached_at": "2025-09-30 21:45:53 UTC",
+    "ai_confidence": 0.9,
+    "ai_reason": "Repo published by user Selenium39 integrating ChatTempMail API, not by ChatTempMail or related brand org.",
+    "cached_at": "2025-09-30 23:46:13 UTC",
     "repository_url": "https://github.com/Selenium39/mcp-server-tempmail",
     "server_name": "io.github.Selenium39/mcp-server-tempmail"
   },
-  "https://github.com/SnowLeopard-AI/bigquery-mcp": {
+  "io.github.SnowLeopard-AI/bigquery-mcp:https://github.com/SnowLeopard-AI/bigquery-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.95,
-    "ai_reason": "Published by SnowLeopard-AI for Google BigQuery, but SnowLeopard-AI is not Google so it is a third-party integration.",
-    "cached_at": "2025-09-30 21:45:55 UTC",
+    "ai_confidence": 0.92,
+    "ai_reason": "Published by SnowLeopard-AI org for Google BigQuery; not from Google, so it is a community implementation.",
+    "cached_at": "2025-09-30 23:46:15 UTC",
     "repository_url": "https://github.com/SnowLeopard-AI/bigquery-mcp",
     "server_name": "io.github.SnowLeopard-AI/bigquery-mcp"
   },
-  "https://github.com/SonarSource/sonarqube-mcp-server": {
-    "ai_decision": "official",
-    "ai_confidence": 0.98,
-    "ai_reason": "GitHub organization 'SonarSource' owns both the repo and the SonarQube product brand, with matching naming and no negative signals.",
-    "cached_at": "2025-09-30 21:45:57 UTC",
-    "repository_url": "https://github.com/SonarSource/sonarqube-mcp-server",
-    "server_name": "io.github.SonarSource/sonarqube-mcp-server"
-  },
-  "https://github.com/Synclub-tech/Synclub-dxt": {
-    "ai_decision": "official",
-    "ai_confidence": 0.9,
-    "ai_reason": "The GitHub organization 'Synclub-tech' matches the product name 'SynClub' in the server and repo, indicating direct ownership.",
-    "cached_at": "2025-09-30 21:46:00 UTC",
-    "repository_url": "https://github.com/Synclub-tech/Synclub-dxt",
-    "server_name": "io.github.Synclub-tech/synclub-dxt"
-  },
-  "https://github.com/TonySimonovsky/claude-code-conversation-search-mcp": {
+  "io.github.TonySimonovsky/claude-code-conversation-search-mcp:https://github.com/TonySimonovsky/claude-code-conversation-search-mcp": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "GitHub repo is owned by a personal user (TonySimonovsky) and not Anthropic, which owns Claude.",
-    "cached_at": "2025-09-30 21:46:03 UTC",
+    "ai_reason": "The repo is owned by a user (TonySimonovsky), not the official Claude/Anthropic org, and there is no strong evidence of brand ownership.",
+    "cached_at": "2025-09-30 23:46:17 UTC",
     "repository_url": "https://github.com/TonySimonovsky/claude-code-conversation-search-mcp",
     "server_name": "io.github.TonySimonovsky/claude-code-conversation-search-mcp"
   },
-  "https://github.com/YinTokey/mcp_hackernews": {
+  "io.github.YinTokey/mcp_hackernews:https://github.com/YinTokey/mcp_hackernews": {
     "ai_decision": "community",
-    "ai_confidence": 0.96,
-    "ai_reason": "The repo owner YinTokey is not affiliated with Hacker News (owned by Y Combinator), so this is a community implementation.",
-    "cached_at": "2025-09-30 21:46:04 UTC",
+    "ai_confidence": 0.99,
+    "ai_reason": "GitHub org 'YinTokey' does not match 'HackerNews' brand and there is no indication this is operated by Hacker News or Y Combinator.",
+    "cached_at": "2025-09-30 23:46:21 UTC",
     "repository_url": "https://github.com/YinTokey/mcp_hackernews",
     "server_name": "io.github.YinTokey/mcp_hackernews"
   },
-  "https://github.com/abelljs/abell": {
+  "io.github.abelljs/abell:https://github.com/abelljs/abell": {
     "ai_decision": "community",
-    "ai_confidence": 0.6,
-    "ai_reason": "The GitHub org 'abelljs' is not a widely recognized brand; insufficient evidence the server integrates with a third-party product/service outside the maintainer's own project.",
-    "cached_at": "2025-09-30 21:46:06 UTC",
+    "ai_confidence": 0.5,
+    "ai_reason": "No clear evidence that abelljs is the owner of a recognized product/service called Abell; lacks strong brand match or verification.",
+    "cached_at": "2025-09-30 23:46:23 UTC",
     "repository_url": "https://github.com/abelljs/abell",
     "server_name": "io.github.abelljs/abell"
   },
-  "https://github.com/agentailor/slimcontext-mcp-server": {
+  "io.github.agentailor/slimcontext-mcp-server:https://github.com/agentailor/slimcontext-mcp-server": {
     "ai_decision": "community",
-    "ai_confidence": 0.6,
-    "ai_reason": "Publisher 'agentailor' does not clearly match 'SlimContext' brand; no verified org or strong evidence of official ownership.",
-    "cached_at": "2025-09-30 21:46:08 UTC",
+    "ai_confidence": 0.85,
+    "ai_reason": "Agentailor is not widely recognized as the owner of an underlying product/service called SlimContext; server appears to be a third-party project.",
+    "cached_at": "2025-09-30 23:46:24 UTC",
     "repository_url": "https://github.com/agentailor/slimcontext-mcp-server",
     "server_name": "io.github.agentailor/slimcontext-mcp-server"
   },
-  "https://github.com/alex-feel/mcp-context-server": {
+  "io.github.alex-feel/mcp-context-server:https://github.com/alex-feel/mcp-context-server": {
     "ai_decision": "community",
     "ai_confidence": 1.0,
-    "ai_reason": "The repository belongs to a personal GitHub user (alex-feel) and does not match any known product/service organization.",
-    "cached_at": "2025-09-30 21:46:10 UTC",
+    "ai_reason": "Published by a personal user (alex-feel) rather than an organization owning an underlying product/service.",
+    "cached_at": "2025-09-30 23:46:26 UTC",
     "repository_url": "https://github.com/alex-feel/mcp-context-server",
     "server_name": "io.github.alex-feel/mcp-context-server"
   },
-  "https://github.com/andrasfe/vulnicheck": {
+  "io.github.andrasfe/vulnicheck:https://github.com/andrasfe/vulnicheck": {
     "ai_decision": "community",
     "ai_confidence": 1.0,
-    "ai_reason": "The repository is owned by a personal GitHub user (andrasfe), not an organization tied to a specific product or brand.",
-    "cached_at": "2025-09-30 21:46:12 UTC",
+    "ai_reason": "Published by a personal GitHub user (andrasfe) with no evidence of ownership of any core product/service; server targets generic vulnerability sources.",
+    "cached_at": "2025-09-30 23:46:28 UTC",
     "repository_url": "https://github.com/andrasfe/vulnicheck",
     "server_name": "io.github.andrasfe/vulnicheck"
   },
-  "https://github.com/anyproto/anytype-mcp": {
-    "ai_decision": "official",
-    "ai_confidence": 0.95,
-    "ai_reason": "GitHub organization and npm scope are both 'anyproto', matching the product 'Anytype', with no negative signals and strong branding alignment.",
-    "cached_at": "2025-09-30 21:46:14 UTC",
-    "repository_url": "https://github.com/anyproto/anytype-mcp",
-    "server_name": "io.github.anyproto/anytype-mcp"
-  },
-  "https://github.com/appwrite/mcp-for-api": {
-    "ai_decision": "official",
-    "ai_confidence": 0.9,
-    "ai_reason": "GitHub organization 'appwrite' matches the product 'Appwrite' in the server name and repo, indicating official ownership.",
-    "cached_at": "2025-09-30 21:46:15 UTC",
-    "repository_url": "https://github.com/appwrite/mcp-for-api",
-    "server_name": "io.github.appwrite/mcp-for-api"
-  },
-  "https://github.com/arielbk/anki-mcp": {
+  "io.github.arielbk/anki-mcp:https://github.com/arielbk/anki-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 1.0,
-    "ai_reason": "The server integrates with Anki but is published by the user 'arielbk', not the Anki organization.",
-    "cached_at": "2025-09-30 21:46:17 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repository is under a personal user (arielbk), not the official Anki organization.",
+    "cached_at": "2025-09-30 23:46:29 UTC",
     "repository_url": "https://github.com/arielbk/anki-mcp",
     "server_name": "io.github.arielbk/anki-mcp"
   },
-  "https://github.com/b1ff/atlassian-dc-mcp": {
+  "io.github.b1ff/atlassian-dc-mcp-bitbucket:https://github.com/b1ff/atlassian-dc-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.95,
-    "ai_reason": "GitHub org is b1ff, not Atlassian; no strong signals the publisher is the Bitbucket brand owner.",
-    "cached_at": "2025-09-30 21:46:19 UTC",
+    "ai_confidence": 0.85,
+    "ai_reason": "The repository is under a user (b1ff), not the official Atlassian org, and there is no direct evidence of brand ownership.",
+    "cached_at": "2025-09-30 23:46:32 UTC",
     "repository_url": "https://github.com/b1ff/atlassian-dc-mcp",
     "server_name": "io.github.b1ff/atlassian-dc-mcp-bitbucket"
   },
-  "https://github.com/burningion/video-editing-mcp": {
+  "io.github.b1ff/atlassian-dc-mcp-confluence:https://github.com/b1ff/atlassian-dc-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.8,
-    "ai_reason": "The GitHub owner 'burningion' is a personal user, not 'video-jungle'; no strong evidence this is published by the Video Jungle organization.",
-    "cached_at": "2025-09-30 21:46:22 UTC",
+    "ai_confidence": 0.93,
+    "ai_reason": "The GitHub org (b1ff) does not match Atlassian/Confluence branding and is not verified; package uses an unofficial namespace.",
+    "cached_at": "2025-09-30 23:46:33 UTC",
+    "repository_url": "https://github.com/b1ff/atlassian-dc-mcp",
+    "server_name": "io.github.b1ff/atlassian-dc-mcp-confluence"
+  },
+  "io.github.b1ff/atlassian-dc-mcp-jira:https://github.com/b1ff/atlassian-dc-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repo is under user 'b1ff', not Atlassian org, and no official brand signals for Jira/Atlassian.",
+    "cached_at": "2025-09-30 23:46:35 UTC",
+    "repository_url": "https://github.com/b1ff/atlassian-dc-mcp",
+    "server_name": "io.github.b1ff/atlassian-dc-mcp-jira"
+  },
+  "io.github.brave/brave-search-mcp-server:https://github.com/brave/brave-search-mcp-server": {
+    "ai_decision": "official",
+    "ai_confidence": 1.0,
+    "ai_reason": "The GitHub org 'brave' matches the product 'Brave Search', owns the repo, and the npm scope is also '@brave', indicating clear brand ownership.",
+    "cached_at": "2025-09-30 23:46:37 UTC",
+    "repository_url": "https://github.com/brave/brave-search-mcp-server",
+    "server_name": "io.github.brave/brave-search-mcp-server"
+  },
+  "io.github.burningion/video-editing-mcp:https://github.com/burningion/video-editing-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "The repo is owned by user 'burningion', not an organization matching 'Video Jungle', with no signals linking directly to the underlying service's publisher.",
+    "cached_at": "2025-09-30 23:46:39 UTC",
     "repository_url": "https://github.com/burningion/video-editing-mcp",
     "server_name": "io.github.burningion/video-editing-mcp"
   },
-  "https://github.com/bytedance/UI-TARS-desktop": {
-    "ai_decision": "community",
-    "ai_confidence": 0.85,
-    "ai_reason": "bytedance is not the owner of Chrome, Edge, or Firefox browsers and this server targets generic browser access.",
-    "cached_at": "2025-09-30 21:46:24 UTC",
-    "repository_url": "https://github.com/bytedance/UI-TARS-desktop",
-    "server_name": "io.github.bytedance/mcp-server-browser"
-  },
-  "https://github.com/chris-schra/mcp-funnel": {
+  "io.github.chris-schra/mcp-funnel:https://github.com/chris-schra/mcp-funnel": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "The repository is under a personal GitHub user (chris-schra), not an org matching any product/brand; no evidence of official brand ownership.",
-    "cached_at": "2025-09-30 21:46:27 UTC",
+    "ai_reason": "Repository is published by a personal user (chris-schra) rather than an organization, with no strong brand signals.",
+    "cached_at": "2025-09-30 23:46:40 UTC",
     "repository_url": "https://github.com/chris-schra/mcp-funnel",
     "server_name": "io.github.chris-schra/mcp-funnel"
   },
-  "https://github.com/clappia-dev/clappia-mcp": {
+  "io.github.clappia-dev/clappia-mcp:https://github.com/clappia-dev/clappia-mcp": {
     "ai_decision": "community",
     "ai_confidence": 0.8,
-    "ai_reason": "The GitHub org 'clappia-dev' is unverified and does not clearly match the official Clappia brand, and the Docker image is under a user namespace ('okaru413').",
-    "cached_at": "2025-09-30 21:46:29 UTC",
+    "ai_reason": "The GitHub org 'clappia-dev' is not verified and does not clearly match the official Clappia brand; Docker image is not under a verified org namespace.",
+    "cached_at": "2025-09-30 23:46:42 UTC",
     "repository_url": "https://github.com/clappia-dev/clappia-mcp",
     "server_name": "io.github.clappia-dev/clappia-mcp"
   },
-  "https://github.com/cmpxchg16/mcp-ethical-hacking": {
+  "io.github.cmpxchg16/mcp-ethical-hacking:https://github.com/cmpxchg16/mcp-ethical-hacking": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "Repository is owned by a personal user (cmpxchg16) and not by the LinkedIn or Reddit organizations.",
-    "cached_at": "2025-09-30 21:46:31 UTC",
+    "ai_reason": "Org cmpxchg16 does not match LinkedIn or Reddit brands; no evidence of official ownership.",
+    "cached_at": "2025-09-30 23:46:44 UTC",
     "repository_url": "https://github.com/cmpxchg16/mcp-ethical-hacking",
     "server_name": "io.github.cmpxchg16/mcp-ethical-hacking"
   },
-  "https://github.com/containers/kubernetes-mcp-server": {
-    "ai_decision": "community",
-    "ai_confidence": 0.85,
-    "ai_reason": "The publisher is the 'containers' GitHub org, which is not owned by Kubernetes or the Kubernetes brand owner, so this is a third-party integration.",
-    "cached_at": "2025-09-30 21:46:32 UTC",
-    "repository_url": "https://github.com/containers/kubernetes-mcp-server",
-    "server_name": "io.github.containers/kubernetes-mcp-server"
-  },
-  "https://github.com/cr7258/elasticsearch-mcp-server": {
+  "io.github.cr7258/elasticsearch-mcp-server:https://github.com/cr7258/elasticsearch-mcp-server": {
     "ai_decision": "community",
     "ai_confidence": 1.0,
-    "ai_reason": "GitHub org 'cr7258' does not match Elasticsearch or Elastic and is a personal user, indicating this is a third-party implementation.",
-    "cached_at": "2025-09-30 21:46:34 UTC",
+    "ai_reason": "Published under a user account (cr7258), not the official Elastic org, for Elasticsearch.",
+    "cached_at": "2025-09-30 23:46:46 UTC",
     "repository_url": "https://github.com/cr7258/elasticsearch-mcp-server",
     "server_name": "io.github.cr7258/elasticsearch-mcp-server"
   },
-  "https://github.com/croit/mcp-croit-ceph": {
-    "ai_decision": "official",
-    "ai_confidence": 0.95,
-    "ai_reason": "GitHub org 'croit' matches product 'Croit', endpoints/reference to 'croit.io', and Docker image is under org—strong alignment with official signals.",
-    "cached_at": "2025-09-30 21:46:36 UTC",
-    "repository_url": "https://github.com/croit/mcp-croit-ceph",
-    "server_name": "io.github.croit/mcp-croit-ceph"
-  },
-  "https://github.com/cyanheads/git-mcp-server": {
+  "io.github.cyanheads/git-mcp-server:https://github.com/cyanheads/git-mcp-server": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "The publisher ('cyanheads') is not the owner of Git and no official connection to Git is shown; thus, this is a community implementation.",
-    "cached_at": "2025-09-30 21:46:38 UTC",
+    "ai_reason": "The publisher (cyanheads) is not associated with the official Git project, and no strong signals indicate ownership by the Git brand; cyanheads appears to be a third-party organization.",
+    "cached_at": "2025-09-30 23:46:51 UTC",
     "repository_url": "https://github.com/cyanheads/git-mcp-server",
     "server_name": "io.github.cyanheads/git-mcp-server"
   },
-  "https://github.com/cyanheads/mcp-ts-template": {
+  "io.github.cyanheads/mcp-ts-template:https://github.com/cyanheads/mcp-ts-template": {
     "ai_decision": "community",
     "ai_confidence": 1.0,
-    "ai_reason": "GitHub org 'cyanheads' does not match any underlying product/service and repo is a general template, not tied to an official platform.",
-    "cached_at": "2025-09-30 21:46:39 UTC",
+    "ai_reason": "The GitHub org 'cyanheads' does not match any product or service, and the server is described as a generic template rather than an integration for a specific brand.",
+    "cached_at": "2025-09-30 23:46:53 UTC",
     "repository_url": "https://github.com/cyanheads/mcp-ts-template",
     "server_name": "io.github.cyanheads/mcp-ts-template"
   },
-  "https://github.com/cyanheads/pubmed-mcp-server": {
+  "io.github.cyanheads/pubmed-mcp-server:https://github.com/cyanheads/pubmed-mcp-server": {
     "ai_decision": "community",
-    "ai_confidence": 0.95,
-    "ai_reason": "The publisher is cyanheads (not NCBI or PubMed), indicating a third-party community implementation for PubMed.",
-    "cached_at": "2025-09-30 21:46:41 UTC",
+    "ai_confidence": 1.0,
+    "ai_reason": "The publisher is 'cyanheads', not NCBI (the owner of PubMed), and there is no evidence of official brand ownership.",
+    "cached_at": "2025-09-30 23:46:55 UTC",
     "repository_url": "https://github.com/cyanheads/pubmed-mcp-server",
     "server_name": "io.github.cyanheads/pubmed-mcp-server"
   },
-  "https://github.com/dba-i/mssql-dba": {
+  "io.github.dba-i/mssql-dba:https://github.com/dba-i/mssql-dba": {
     "ai_decision": "community",
-    "ai_confidence": 0.95,
-    "ai_reason": "The publisher (dba-i) does not match Microsoft, the owner of MSSQL; org is not brand owner of the service.",
-    "cached_at": "2025-09-30 21:46:43 UTC",
+    "ai_confidence": 0.9,
+    "ai_reason": "The GitHub org 'dba-i' does not match the brand owner of Microsoft SQL Server, and there is no evidence of official publisher signals.",
+    "cached_at": "2025-09-30 23:46:58 UTC",
     "repository_url": "https://github.com/dba-i/mssql-dba",
     "server_name": "io.github.dba-i/mssql-dba"
   },
-  "https://github.com/delorenj/mcp-server-trello": {
+  "io.github.delorenj/mcp-server-trello:https://github.com/delorenj/mcp-server-trello": {
     "ai_decision": "community",
     "ai_confidence": 1.0,
-    "ai_reason": "The publisher delorenj is an individual GitHub user, not Atlassian (the owner of Trello), so this is a community implementation.",
-    "cached_at": "2025-09-30 21:46:45 UTC",
+    "ai_reason": "GitHub org 'delorenj' does not match Trello, and there is no evidence this is published by the Trello/Atlassian organization.",
+    "cached_at": "2025-09-30 23:47:00 UTC",
     "repository_url": "https://github.com/delorenj/mcp-server-trello",
     "server_name": "io.github.delorenj/mcp-server-trello"
   },
-  "https://github.com/dockersamples/mcp-docker-release-information": {
+  "io.github.dockersamples/mcp-docker-release-information:https://github.com/dockersamples/mcp-docker-release-information": {
     "ai_decision": "community",
-    "ai_confidence": 0.6,
-    "ai_reason": "The repository is under the dockersamples org, which is not the official Docker organization, so brand ownership is not proven.",
-    "cached_at": "2025-09-30 21:46:46 UTC",
+    "ai_confidence": 0.7,
+    "ai_reason": "The publisher is dockersamples, not the Docker org, and there is no indication this is an official Docker-maintained implementation.",
+    "cached_at": "2025-09-30 23:47:01 UTC",
     "repository_url": "https://github.com/dockersamples/mcp-docker-release-information",
     "server_name": "io.github.dockersamples/mcp-docker-release-information"
   },
-  "https://github.com/domdomegg/airtable-mcp-server.git": {
+  "io.github.domdomegg/airtable-mcp-server:https://github.com/domdomegg/airtable-mcp-server.git": {
     "ai_decision": "community",
     "ai_confidence": 1.0,
-    "ai_reason": "Repository is published by domdomegg (not Airtable), so it does not meet the 'official' criteria for generic service 'airtable'.",
-    "cached_at": "2025-09-30 21:46:49 UTC",
+    "ai_reason": "The repo is owned by a personal user (domdomegg), not Airtable’s GitHub org, for a generic service (Airtable).",
+    "cached_at": "2025-09-30 23:47:03 UTC",
     "repository_url": "https://github.com/domdomegg/airtable-mcp-server.git",
     "server_name": "io.github.domdomegg/airtable-mcp-server"
   },
-  "https://github.com/domdomegg/time-mcp-nuget.git": {
+  "io.github.domdomegg/time-mcp-nuget:https://github.com/domdomegg/time-mcp-nuget.git": {
     "ai_decision": "community",
-    "ai_confidence": 0.98,
-    "ai_reason": "The publisher is a personal GitHub user (domdomegg) and not an organization owning a time service; no strong brand ownership evidence.",
-    "cached_at": "2025-09-30 21:46:52 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repo owner 'domdomegg' is a personal user, not an organization representing the underlying 'time' service.",
+    "cached_at": "2025-09-30 23:47:05 UTC",
     "repository_url": "https://github.com/domdomegg/time-mcp-nuget.git",
     "server_name": "io.github.domdomegg/time-mcp-nuget"
   },
-  "https://github.com/domdomegg/time-mcp-pypi.git": {
+  "io.github.domdomegg/time-mcp-pypi:https://github.com/domdomegg/time-mcp-pypi.git": {
     "ai_decision": "community",
-    "ai_confidence": 1.0,
-    "ai_reason": "The publisher is a personal GitHub user (domdomegg) and not an official organization for a time service product.",
-    "cached_at": "2025-09-30 21:46:54 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "Owner 'domdomegg' is a user account, not an org; no brand or product ownership indicated.",
+    "cached_at": "2025-09-30 23:47:07 UTC",
     "repository_url": "https://github.com/domdomegg/time-mcp-pypi.git",
     "server_name": "io.github.domdomegg/time-mcp-pypi"
   },
-  "https://github.com/dubuqingfeng/gitlab-mcp-server": {
+  "io.github.dubuqingfeng/gitlab-mcp-server:https://github.com/dubuqingfeng/gitlab-mcp-server": {
     "ai_decision": "community",
-    "ai_confidence": 0.98,
-    "ai_reason": "Published by user 'dubuqingfeng', not an official GitLab organization, so not official for GitLab.",
-    "cached_at": "2025-09-30 21:46:56 UTC",
+    "ai_confidence": 0.97,
+    "ai_reason": "Repo is owned by user 'dubuqingfeng' not official GitLab org, with no signals of brand owner involvement.",
+    "cached_at": "2025-09-30 23:47:09 UTC",
     "repository_url": "https://github.com/dubuqingfeng/gitlab-mcp-server",
     "server_name": "io.github.dubuqingfeng/gitlab-mcp-server"
   },
-  "https://github.com/dynatrace-oss/Dynatrace-mcp": {
-    "ai_decision": "official",
-    "ai_confidence": 0.97,
-    "ai_reason": "GitHub org dynatrace-oss matches Dynatrace product, package namespace is @dynatrace-oss, and repo is not a fork or archived.",
-    "cached_at": "2025-09-30 21:46:58 UTC",
-    "repository_url": "https://github.com/dynatrace-oss/Dynatrace-mcp",
-    "server_name": "io.github.dynatrace-oss/Dynatrace-mcp"
-  },
-  "https://github.com/estruyf/vscode-demo-time": {
+  "io.github.estruyf/vscode-demo-time:https://github.com/estruyf/vscode-demo-time": {
     "ai_decision": "community",
     "ai_confidence": 0.8,
-    "ai_reason": "The repository is under the estruyf user (not a verified organization) and there is no evidence that estruyf is the Demo Time brand owner.",
-    "cached_at": "2025-09-30 21:47:00 UTC",
+    "ai_reason": "The GitHub repo owner (estruyf) is a personal user, not the Demo Time organization, and there is no strong evidence of official brand ownership for Demo Time.",
+    "cached_at": "2025-09-30 23:47:12 UTC",
     "repository_url": "https://github.com/estruyf/vscode-demo-time",
     "server_name": "io.github.estruyf/vscode-demo-time"
   },
-  "https://github.com/fliptheweb/yazio-mcp": {
+  "io.github.fliptheweb/yazio-mcp:https://github.com/fliptheweb/yazio-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.95,
-    "ai_reason": "The publisher GitHub org 'fliptheweb' does not match the Yazio brand and the description states 'unofficial'.",
-    "cached_at": "2025-09-30 21:47:02 UTC",
+    "ai_confidence": 0.99,
+    "ai_reason": "The publisher 'fliptheweb' is not Yazio's organization and the description explicitly states the server is unofficial.",
+    "cached_at": "2025-09-30 23:47:15 UTC",
     "repository_url": "https://github.com/fliptheweb/yazio-mcp",
     "server_name": "io.github.fliptheweb/yazio-mcp"
   },
-  "https://github.com/florentine-ai/mcp": {
-    "ai_decision": "official",
-    "ai_confidence": 0.95,
-    "ai_reason": "GitHub org florentine-ai matches product Florentine.ai, repo is not a fork or archived, npm package uses org namespace.",
-    "cached_at": "2025-09-30 21:47:05 UTC",
-    "repository_url": "https://github.com/florentine-ai/mcp",
-    "server_name": "io.github.florentine-ai/mcp"
-  },
-  "https://github.com/formulahendry/mcp-server-code-runner": {
+  "io.github.formulahendry/code-runner:https://github.com/formulahendry/mcp-server-code-runner": {
     "ai_decision": "community",
     "ai_confidence": 0.9,
-    "ai_reason": "The publisher 'formulahendry' is a personal GitHub user not affiliated with an organization or product; server is a general-purpose code runner, not tied to a specific owned service.",
-    "cached_at": "2025-09-30 21:47:06 UTC",
+    "ai_reason": "Repository is under the personal user 'formulahendry', not an organization owning a specific service or product.",
+    "cached_at": "2025-09-30 23:47:18 UTC",
     "repository_url": "https://github.com/formulahendry/mcp-server-code-runner",
     "server_name": "io.github.formulahendry/code-runner"
   },
-  "https://github.com/formulahendry/mcp-server-mcp-registry": {
+  "io.github.formulahendry/mcp-server-mcp-registry:https://github.com/formulahendry/mcp-server-mcp-registry": {
     "ai_decision": "community",
-    "ai_confidence": 0.85,
-    "ai_reason": "GitHub org 'formulahendry' does not match a known product/brand and is a personal namespace, not tied to an official underlying service.",
-    "cached_at": "2025-09-30 21:47:09 UTC",
+    "ai_confidence": 0.7,
+    "ai_reason": "The GitHub org (formulahendry) does not match any product/brand named 'MCP Registry'; owner is not a brand org but a user.",
+    "cached_at": "2025-09-30 23:47:19 UTC",
     "repository_url": "https://github.com/formulahendry/mcp-server-mcp-registry",
     "server_name": "io.github.formulahendry/mcp-server-mcp-registry"
   },
-  "https://github.com/formulahendry/mcp-server-spec-driven-development": {
+  "io.github.formulahendry/spec-driven-development:https://github.com/formulahendry/mcp-server-spec-driven-development": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "The GitHub owner 'formulahendry' is a personal user, not an official organization for any product/service mentioned.",
-    "cached_at": "2025-09-30 21:47:11 UTC",
+    "ai_reason": "The GitHub owner 'formulahendry' is a personal user, not an org owning a major product or platform.",
+    "cached_at": "2025-09-30 23:47:21 UTC",
     "repository_url": "https://github.com/formulahendry/mcp-server-spec-driven-development",
     "server_name": "io.github.formulahendry/spec-driven-development"
   },
-  "https://github.com/francisco-perez-sorrosal/cv": {
+  "io.github.francisco-perez-sorrosal/cv:https://github.com/francisco-perez-sorrosal/cv": {
     "ai_decision": "community",
-    "ai_confidence": 0.95,
-    "ai_reason": "Repository is owned by a personal user and serves a personal CV, not an organizational product/service.",
-    "cached_at": "2025-09-30 21:47:13 UTC",
+    "ai_confidence": 1.0,
+    "ai_reason": "Repo is owned by a personal GitHub user and serves a personal CV, not an organization-backed product.",
+    "cached_at": "2025-09-30 23:47:23 UTC",
     "repository_url": "https://github.com/francisco-perez-sorrosal/cv",
     "server_name": "io.github.francisco-perez-sorrosal/cv"
   },
-  "https://github.com/gjeltep/app-store-connect-mcp": {
+  "io.github.gjeltep/app-store-connect-mcp:https://github.com/gjeltep/app-store-connect-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.98,
-    "ai_reason": "The publisher is 'gjeltep' (a personal account, not Apple), for App Store Connect; no evidence of Apple ownership.",
-    "cached_at": "2025-09-30 21:47:14 UTC",
+    "ai_confidence": 1.0,
+    "ai_reason": "Repo is published by a user (gjeltep) not Apple; no evidence of Apple ownership for App Store Connect service.",
+    "cached_at": "2025-09-30 23:47:25 UTC",
     "repository_url": "https://github.com/gjeltep/app-store-connect-mcp",
     "server_name": "io.github.gjeltep/app-store-connect-mcp"
   },
-  "https://github.com/gradion-ai/ipybox": {
+  "io.github.gradion-ai/ipybox:https://github.com/gradion-ai/ipybox": {
     "ai_decision": "community",
-    "ai_confidence": 0.95,
-    "ai_reason": "The GitHub org 'gradion-ai' does not match any major product/brand for IPython or Docker; strong signals indicate this is a third-party community server.",
-    "cached_at": "2025-09-30 21:47:17 UTC",
+    "ai_confidence": 0.85,
+    "ai_reason": "The org 'gradion-ai' does not own or represent 'IPython', 'Docker', or Python; repo integrates generic tech and shows no official vendor signals.",
+    "cached_at": "2025-09-30 23:47:26 UTC",
     "repository_url": "https://github.com/gradion-ai/ipybox",
     "server_name": "io.github.gradion-ai/ipybox"
   },
-  "https://github.com/grupo-avispa/dsr_mcp_server": {
+  "io.github.grupo-avispa/dsr_mcp_server:https://github.com/grupo-avispa/dsr_mcp_server": {
     "ai_decision": "community",
-    "ai_confidence": 0.7,
-    "ai_reason": "GitHub org 'grupo-avispa' does not match or obviously own 'Deep State Representation' and there is no strong brand-product evidence.",
-    "cached_at": "2025-09-30 21:47:19 UTC",
+    "ai_confidence": 0.6,
+    "ai_reason": "Org 'grupo-avispa' does not clearly own a widely recognized product/service called 'DSR'; no strong brand evidence.",
+    "cached_at": "2025-09-30 23:47:28 UTC",
     "repository_url": "https://github.com/grupo-avispa/dsr_mcp_server",
     "server_name": "io.github.grupo-avispa/dsr_mcp_server"
   },
-  "https://github.com/guanqun-yang/mcp-server-r-counter": {
+  "io.github.guanqun-yang/mcp-server-r-counter:https://github.com/guanqun-yang/mcp-server-r-counter": {
     "ai_decision": "community",
-    "ai_confidence": 1.0,
-    "ai_reason": "Repository is published by a personal user (guanqun-yang), not an organization, and there is no indication of brand/product ownership.",
-    "cached_at": "2025-09-30 21:47:21 UTC",
+    "ai_confidence": 0.9,
+    "ai_reason": "The GitHub owner is a personal user (guanqun-yang) unrelated to any brand or product, indicating a community implementation.",
+    "cached_at": "2025-09-30 23:47:30 UTC",
     "repository_url": "https://github.com/guanqun-yang/mcp-server-r-counter",
     "server_name": "io.github.guanqun-yang/mcp-server-r-counter"
   },
-  "https://github.com/habedi/omni-lpr": {
+  "io.github.habedi/omni-lpr:https://github.com/habedi/omni-lpr": {
     "ai_decision": "community",
-    "ai_confidence": 0.85,
-    "ai_reason": "Repository is owned by a personal user (habedi), not an organization linked to a brand or product.",
-    "cached_at": "2025-09-30 21:47:22 UTC",
+    "ai_confidence": 0.9,
+    "ai_reason": "The GitHub org 'habedi' does not appear to be an official organization for a license plate recognition product/service; no evidence of official brand ownership.",
+    "cached_at": "2025-09-30 23:47:32 UTC",
     "repository_url": "https://github.com/habedi/omni-lpr",
     "server_name": "io.github.habedi/omni-lpr"
   },
-  "https://github.com/hellocoop/admin-mcp": {
-    "ai_decision": "official",
-    "ai_confidence": 0.95,
-    "ai_reason": "GitHub org name 'hellocoop' and npm scope '@hellocoop' match the product in server name and repo, indicating official publication by Hellocoop.",
-    "cached_at": "2025-09-30 21:47:24 UTC",
-    "repository_url": "https://github.com/hellocoop/admin-mcp",
-    "server_name": "io.github.hellocoop/admin-mcp"
-  },
-  "https://github.com/henilcalagiya/google-sheets-mcp": {
+  "io.github.henilcalagiya/google-sheets-mcp:https://github.com/henilcalagiya/google-sheets-mcp": {
     "ai_decision": "community",
     "ai_confidence": 1.0,
-    "ai_reason": "The repository is owned by a personal GitHub user (henilcalagiya) and not by Google, which is required for official status for Google Sheets.",
-    "cached_at": "2025-09-30 21:47:26 UTC",
+    "ai_reason": "Owner is a personal user (henilcalagiya) not Google, and Google Sheets is a generic Google service.",
+    "cached_at": "2025-09-30 23:47:34 UTC",
     "repository_url": "https://github.com/henilcalagiya/google-sheets-mcp",
     "server_name": "io.github.henilcalagiya/google-sheets-mcp"
   },
-  "https://github.com/henilcalagiya/mcp-apple-notes": {
+  "io.github.henilcalagiya/mcp-apple-notes:https://github.com/henilcalagiya/mcp-apple-notes": {
     "ai_decision": "community",
     "ai_confidence": 1.0,
-    "ai_reason": "The publisher is an individual user (henilcalagiya), not Apple, and Apple is the only entity that could publish an official server for Apple Notes.",
-    "cached_at": "2025-09-30 21:47:29 UTC",
+    "ai_reason": "The publisher is a personal user (henilcalagiya) not Apple, so cannot be official for Apple Notes.",
+    "cached_at": "2025-09-30 23:47:36 UTC",
     "repository_url": "https://github.com/henilcalagiya/mcp-apple-notes",
     "server_name": "io.github.henilcalagiya/mcp-apple-notes"
   },
-  "https://github.com/himorishige/hatago-mcp-hub": {
+  "io.github.himorishige/hatago-mcp-hub:https://github.com/himorishige/hatago-mcp-hub": {
     "ai_decision": "community",
-    "ai_confidence": 0.95,
-    "ai_reason": "The repository is owned by a user (himorishige), not an organization, and there is no brand or product match indicating official ownership.",
-    "cached_at": "2025-09-30 21:47:31 UTC",
+    "ai_confidence": 0.9,
+    "ai_reason": "Published by a personal GitHub user 'himorishige', not an organization or product company.",
+    "cached_at": "2025-09-30 23:47:37 UTC",
     "repository_url": "https://github.com/himorishige/hatago-mcp-hub",
     "server_name": "io.github.himorishige/hatago-mcp-hub"
   },
-  "https://github.com/iggredible/vim-mcp": {
+  "io.github.iggredible/vim-mcp:https://github.com/iggredible/vim-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 1.0,
-    "ai_reason": "The publisher 'iggredible' is not the official Vim organization and there is no evidence of brand ownership; this is a third-party integration.",
-    "cached_at": "2025-09-30 21:47:34 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub org is a personal user (iggredible), not Vim’s official organization, and no evidence Vim is the publisher.",
+    "cached_at": "2025-09-30 23:47:40 UTC",
     "repository_url": "https://github.com/iggredible/vim-mcp",
     "server_name": "io.github.iggredible/vim-mcp"
   },
-  "https://github.com/imbenrabi/Financial-Modeling-Prep-MCP-Server": {
+  "io.github.imbenrabi/financial-modeling-prep-mcp-server:https://github.com/imbenrabi/Financial-Modeling-Prep-MCP-Server": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "The GitHub owner is a personal user ('imbenrabi'), not an organization matching 'Financial Modeling Prep', indicating a third-party implementation.",
-    "cached_at": "2025-09-30 21:47:36 UTC",
+    "ai_reason": "The repo is published by a user (imbenrabi) rather than the Financial Modeling Prep org; no official branding or verified org evidence.",
+    "cached_at": "2025-09-30 23:47:42 UTC",
     "repository_url": "https://github.com/imbenrabi/Financial-Modeling-Prep-MCP-Server",
     "server_name": "io.github.imbenrabi/financial-modeling-prep-mcp-server"
   },
-  "https://github.com/indragiek/uniprof": {
+  "io.github.indragiek/uniprof:https://github.com/indragiek/uniprof": {
     "ai_decision": "community",
-    "ai_confidence": 0.9,
-    "ai_reason": "The repo is published under a personal user (indragiek), not an org matching a product; no evidence of brand ownership.",
-    "cached_at": "2025-09-30 21:47:38 UTC",
+    "ai_confidence": 0.85,
+    "ai_reason": "The GitHub repo owner is a personal user (indragiek) and not an organization, indicating it is a community project.",
+    "cached_at": "2025-09-30 23:47:44 UTC",
     "repository_url": "https://github.com/indragiek/uniprof",
     "server_name": "io.github.indragiek/uniprof"
   },
-  "https://github.com/receptron/mulmocast-vision": {
+  "io.github.isamu/mulmocast-vision:https://github.com/receptron/mulmocast-vision": {
     "ai_decision": "community",
-    "ai_confidence": 0.9,
-    "ai_reason": "The GitHub organization 'receptron' does not clearly match a known product brand and shows no direct evidence of being the official publisher of 'mulmocast-vision'.",
-    "cached_at": "2025-09-30 21:47:39 UTC",
+    "ai_confidence": 0.8,
+    "ai_reason": "The GitHub organization 'receptron' does not clearly match the product 'mulmocast'; lacking brand/domain alignment or verified signals.",
+    "cached_at": "2025-09-30 23:47:46 UTC",
     "repository_url": "https://github.com/receptron/mulmocast-vision",
     "server_name": "io.github.isamu/mulmocast-vision"
   },
-  "https://github.com/iworkist/btcmcp": {
+  "io.github.iworkist/btcmcp:https://github.com/iworkist/btcmcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.95,
-    "ai_reason": "The GitHub org 'iworkist' does not match the product/service (Binance or Bitcoin), so it's a third-party/community server.",
-    "cached_at": "2025-09-30 21:47:41 UTC",
+    "ai_confidence": 0.9,
+    "ai_reason": "iworkist is not Binance or Bitcoin’s official org; repo provides Binance Bitcoin data but is published by a third party.",
+    "cached_at": "2025-09-30 23:47:48 UTC",
     "repository_url": "https://github.com/iworkist/btcmcp",
     "server_name": "io.github.iworkist/btcmcp"
   },
-  "https://github.com/jcucci/dotnet-sherlock-mcp": {
+  "io.github.jcucci/dotnet-sherlock-mcp:https://github.com/jcucci/dotnet-sherlock-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.9,
-    "ai_reason": "Repository is under a personal user account (jcucci), not an organization owning .NET or Sherlock, indicating a third-party/community implementation.",
-    "cached_at": "2025-09-30 21:47:43 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repo is owned by a personal user (jcucci) and not an official brand or organization.",
+    "cached_at": "2025-09-30 23:47:49 UTC",
     "repository_url": "https://github.com/jcucci/dotnet-sherlock-mcp",
     "server_name": "io.github.jcucci/dotnet-sherlock-mcp"
   },
-  "https://github.com/jgador/websharp": {
+  "io.github.jgador/websharp:https://github.com/jgador/websharp": {
     "ai_decision": "community",
-    "ai_confidence": 1.0,
-    "ai_reason": "Repository is under a user (jgador), not an organization owning a web search service; no evidence links to an official web search provider.",
-    "cached_at": "2025-09-30 21:47:45 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "The GitHub owner is a personal user (jgador), not a brand/org linked to a specific official product/service.",
+    "cached_at": "2025-09-30 23:47:51 UTC",
     "repository_url": "https://github.com/jgador/websharp",
     "server_name": "io.github.jgador/websharp"
   },
-  "https://github.com/blaideinc/cookwith-mcp": {
+  "io.github.jjlabsio/korea-stock-mcp:https://github.com/jjlabsio/korea-stock-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "Publisher 'jjlabsio' does not match any official Korea stock exchange entity, and neither npm nor repo ownership shows strong ties to a relevant stock market operator.",
+    "cached_at": "2025-09-30 23:47:53 UTC",
+    "repository_url": "https://github.com/jjlabsio/korea-stock-mcp",
+    "server_name": "io.github.jjlabsio/korea-stock-mcp"
+  },
+  "io.github.jkakar/cookwith-mcp:https://github.com/blaideinc/cookwith-mcp": {
     "ai_decision": "community",
     "ai_confidence": 0.7,
-    "ai_reason": "The repo is owned by 'blaideinc', not matching the product/service name 'cookwith', with no evidence it's an official organization.",
-    "cached_at": "2025-09-30 21:47:47 UTC",
+    "ai_reason": "The GitHub org 'blaideinc' does not clearly match the product 'Cookwith', and there is no strong evidence it is the official owner of the service.",
+    "cached_at": "2025-09-30 23:47:55 UTC",
     "repository_url": "https://github.com/blaideinc/cookwith-mcp",
     "server_name": "io.github.jkakar/cookwith-mcp"
   },
-  "https://github.com/blaideinc/recipe-mcp": {
+  "io.github.jkakar/recipe-mcp:https://github.com/blaideinc/recipe-mcp": {
     "ai_decision": "community",
     "ai_confidence": 0.7,
-    "ai_reason": "GitHub org 'blaideinc' does not match the cookwith.co brand referenced in the description and npm scope, lacking strong signals of official ownership.",
-    "cached_at": "2025-09-30 21:47:50 UTC",
+    "ai_reason": "GitHub org (blaideinc) does not match cookwith.co branding despite npm scope @cookwith; lacks strong evidence this is by cookwith.co.",
+    "cached_at": "2025-09-30 23:47:57 UTC",
     "repository_url": "https://github.com/blaideinc/recipe-mcp",
     "server_name": "io.github.jkakar/recipe-mcp"
   },
-  "https://github.com/jkawamoto/mcp-bear": {
+  "io.github.jkawamoto/mcp-bear:https://github.com/jkawamoto/mcp-bear": {
     "ai_decision": "community",
     "ai_confidence": 1.0,
-    "ai_reason": "The repository is published by user 'jkawamoto' (not Bear's organization), indicating it is a community implementation for the Bear note-taking software.",
-    "cached_at": "2025-09-30 21:47:52 UTC",
+    "ai_reason": "Repo is owned by user 'jkawamoto' not Bear; no evidence of official Bear organization or branding.",
+    "cached_at": "2025-09-30 23:47:59 UTC",
     "repository_url": "https://github.com/jkawamoto/mcp-bear",
     "server_name": "io.github.jkawamoto/mcp-bear"
   },
-  "https://github.com/jkawamoto/mcp-florence2": {
+  "io.github.jkawamoto/mcp-florence2:https://github.com/jkawamoto/mcp-florence2": {
     "ai_decision": "community",
-    "ai_confidence": 0.85,
-    "ai_reason": "The repo is owned by user 'jkawamoto' not an organization matching the 'Florence-2' brand, indicating a third-party implementation.",
-    "cached_at": "2025-09-30 21:47:54 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repository is under a personal user (jkawamoto) not an organization matching Florence-2, so not official.",
+    "cached_at": "2025-09-30 23:48:01 UTC",
     "repository_url": "https://github.com/jkawamoto/mcp-florence2",
     "server_name": "io.github.jkawamoto/mcp-florence2"
   },
-  "https://github.com/jkawamoto/mcp-youtube-transcript": {
+  "io.github.jkawamoto/mcp-youtube-transcript:https://github.com/jkawamoto/mcp-youtube-transcript": {
     "ai_decision": "community",
-    "ai_confidence": 0.98,
-    "ai_reason": "Repo is owned by a personal user (jkawamoto), not YouTube or Google, and no other official signals are present.",
-    "cached_at": "2025-09-30 21:47:55 UTC",
+    "ai_confidence": 1.0,
+    "ai_reason": "Repo is under a personal user (jkawamoto) and not Google's org for YouTube integration.",
+    "cached_at": "2025-09-30 23:48:03 UTC",
     "repository_url": "https://github.com/jkawamoto/mcp-youtube-transcript",
     "server_name": "io.github.jkawamoto/mcp-youtube-transcript"
   },
-  "https://github.com/jztan/redmine-mcp-server": {
+  "io.github.joelverhagen/Knapcode.SampleMcpServer:https://github.com/joelverhagen/Knapcode.SampleMcpServer.git": {
     "ai_decision": "community",
     "ai_confidence": 1.0,
-    "ai_reason": "Repository owner is a personal user (jztan), not Redmine's organization, so this is a third-party implementation.",
-    "cached_at": "2025-09-30 21:47:59 UTC",
+    "ai_reason": "Published by user 'joelverhagen' for a sample/random-weather service, not representing any official product/brand.",
+    "cached_at": "2025-09-30 23:48:05 UTC",
+    "repository_url": "https://github.com/joelverhagen/Knapcode.SampleMcpServer.git",
+    "server_name": "io.github.joelverhagen/Knapcode.SampleMcpServer"
+  },
+  "io.github.jztan/redmine-mcp-server:https://github.com/jztan/redmine-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "Published by user 'jztan', not an official Redmine organization, with no evidence of Redmine brand ownership.",
+    "cached_at": "2025-09-30 23:48:08 UTC",
     "repository_url": "https://github.com/jztan/redmine-mcp-server",
     "server_name": "io.github.jztan/redmine-mcp-server"
   },
-  "https://github.com/karanb192/reddit-mcp-buddy": {
+  "io.github.karanb192/reddit-mcp-buddy:https://github.com/karanb192/reddit-mcp-buddy": {
     "ai_decision": "community",
-    "ai_confidence": 0.9,
-    "ai_reason": "Repository is published by a user (karanb192), not the official Reddit org, so it is a community implementation.",
-    "cached_at": "2025-09-30 21:48:01 UTC",
+    "ai_confidence": 0.98,
+    "ai_reason": "Repo is owned by a user (karanb192) and not Reddit; no signals of brand ownership for Reddit.",
+    "cached_at": "2025-09-30 23:48:10 UTC",
     "repository_url": "https://github.com/karanb192/reddit-mcp-buddy",
     "server_name": "io.github.karanb192/reddit-mcp-buddy"
   },
-  "https://github.com/kayembahamid/cybersim-pro": {
+  "io.github.kayembahamid/cybersim-pro:https://github.com/kayembahamid/cybersim-pro": {
     "ai_decision": "community",
-    "ai_confidence": 0.95,
-    "ai_reason": "The publisher is a personal GitHub user (kayembahamid) and not an organization owning a product/service called 'cybersim-pro'.",
-    "cached_at": "2025-09-30 21:48:03 UTC",
+    "ai_confidence": 1.0,
+    "ai_reason": "The publisher (kayembahamid) is a personal GitHub user, not an organization, and there is no evidence they own the underlying cyber simulation product/brand.",
+    "cached_at": "2025-09-30 23:48:12 UTC",
     "repository_url": "https://github.com/kayembahamid/cybersim-pro",
     "server_name": "io.github.kayembahamid/cybersim-pro"
   },
-  "https://github.com/kemalersin/fonparam-mcp": {
+  "io.github.kemalersin/fonparam-mcp:https://github.com/kemalersin/fonparam-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.9,
-    "ai_reason": "GitHub user kemalersin (not an org) published the server for FonParam API, with no signals of official affiliation.",
-    "cached_at": "2025-09-30 21:48:04 UTC",
+    "ai_confidence": 0.85,
+    "ai_reason": "Repo owner kemalersin is a user, not an org; no evidence ties this to an official FonParam source.",
+    "cached_at": "2025-09-30 23:48:13 UTC",
     "repository_url": "https://github.com/kemalersin/fonparam-mcp",
     "server_name": "io.github.kemalersin/fonparam-mcp"
   },
-  "https://github.com/king-of-the-grackles/reddit-research-mcp": {
+  "io.github.king-of-the-grackles/reddit-research-mcp:https://github.com/king-of-the-grackles/reddit-research-mcp": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "GitHub org king-of-the-grackles is not affiliated with Reddit, so this is a third-party community implementation.",
-    "cached_at": "2025-09-30 21:48:06 UTC",
+    "ai_reason": "The GitHub org 'king-of-the-grackles' does not match Reddit's brand; strong signal this is a third-party project for Reddit.",
+    "cached_at": "2025-09-30 23:48:17 UTC",
     "repository_url": "https://github.com/king-of-the-grackles/reddit-research-mcp",
     "server_name": "io.github.king-of-the-grackles/reddit-research-mcp"
   },
-  "https://github.com/kirbah/mcp-youtube": {
+  "io.github.kirbah/mcp-youtube:https://github.com/kirbah/mcp-youtube": {
     "ai_decision": "community",
     "ai_confidence": 0.98,
-    "ai_reason": "Published by 'kirbah', not YouTube/Google org; YouTube is a generic/ubiquitous service and only Google can be official.",
-    "cached_at": "2025-09-30 21:48:09 UTC",
+    "ai_reason": "GitHub org/user ('kirbah') does not match or represent YouTube/Google and package scope is personal, not official brand owner.",
+    "cached_at": "2025-09-30 23:48:18 UTC",
     "repository_url": "https://github.com/kirbah/mcp-youtube",
     "server_name": "io.github.kirbah/mcp-youtube"
   },
-  "https://github.com/koki-develop/esa-mcp-server.git": {
+  "io.github.kkjdaniel/bgg-mcp:https://github.com/kkjdaniel/bgg-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.85,
-    "ai_reason": "The GitHub org 'koki-develop' does not match the esa.io brand, indicating this is a third-party implementation.",
-    "cached_at": "2025-09-30 21:48:10 UTC",
+    "ai_confidence": 0.93,
+    "ai_reason": "GitHub org is a personal user (kkjdaniel) and not BoardGameGeek; no signals of official brand ownership.",
+    "cached_at": "2025-09-30 23:48:21 UTC",
+    "repository_url": "https://github.com/kkjdaniel/bgg-mcp",
+    "server_name": "io.github.kkjdaniel/bgg-mcp"
+  },
+  "io.github.koki-develop/esa-mcp-server:https://github.com/koki-develop/esa-mcp-server.git": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "The publisher (koki-develop) is a personal user and not the official esa.io organization.",
+    "cached_at": "2025-09-30 23:48:23 UTC",
     "repository_url": "https://github.com/koki-develop/esa-mcp-server.git",
     "server_name": "io.github.koki-develop/esa-mcp-server"
   },
-  "https://github.com/lapfelix/XcodeMCP": {
+  "io.github.lapfelix/xcodemcp:https://github.com/lapfelix/XcodeMCP": {
     "ai_decision": "community",
-    "ai_confidence": 0.85,
-    "ai_reason": "The GitHub org is a user ('lapfelix'), not Apple; thus, this is not published by the Xcode brand owner.",
-    "cached_at": "2025-09-30 21:48:12 UTC",
+    "ai_confidence": 0.8,
+    "ai_reason": "Repo is owned by a user (lapfelix), not Apple or an Xcode-related org, for Xcode integration.",
+    "cached_at": "2025-09-30 23:48:24 UTC",
     "repository_url": "https://github.com/lapfelix/XcodeMCP",
     "server_name": "io.github.lapfelix/xcodemcp"
   },
-  "https://github.com/leshchenko1979/fast-mcp-telegram": {
+  "io.github.leshchenko1979/fast-mcp-telegram:https://github.com/leshchenko1979/fast-mcp-telegram": {
     "ai_decision": "community",
     "ai_confidence": 1.0,
-    "ai_reason": "The repository is owned by an individual (leshchenko1979), not by Telegram or its official org.",
-    "cached_at": "2025-09-30 21:48:14 UTC",
+    "ai_reason": "Published by user leshchenko1979, not an official Telegram org, so this is a community implementation.",
+    "cached_at": "2025-09-30 23:48:26 UTC",
     "repository_url": "https://github.com/leshchenko1979/fast-mcp-telegram",
     "server_name": "io.github.leshchenko1979/fast-mcp-telegram"
   },
-  "https://github.com/linxule/lotus-wisdom-mcp": {
+  "io.github.linxule/lotus-wisdom:https://github.com/linxule/lotus-wisdom-mcp": {
     "ai_decision": "community",
     "ai_confidence": 0.85,
-    "ai_reason": "The publisher 'linxule' is a user, not an organization, and does not match a recognizable brand or product.",
-    "cached_at": "2025-09-30 21:48:16 UTC",
+    "ai_reason": "Repo is owned by a GitHub user (linxule) rather than an organization tied to a recognized product/brand.",
+    "cached_at": "2025-09-30 23:48:27 UTC",
     "repository_url": "https://github.com/linxule/lotus-wisdom-mcp",
     "server_name": "io.github.linxule/lotus-wisdom"
   },
-  "https://github.com/localstack/localstack-mcp-server": {
+  "io.github.macuse-app/macuse:https://github.com/macuse-app/macuse": {
     "ai_decision": "official",
-    "ai_confidence": 0.97,
-    "ai_reason": "GitHub org 'localstack' matches product 'LocalStack', repo is not a fork/archived, and npm scope '@localstack' shows ownership.",
-    "cached_at": "2025-09-30 21:48:18 UTC",
-    "repository_url": "https://github.com/localstack/localstack-mcp-server",
-    "server_name": "io.github.localstack/localstack-mcp-server"
-  },
-  "https://github.com/macuse-app/macuse": {
-    "ai_decision": "community",
-    "ai_confidence": 0.85,
-    "ai_reason": "macuse-app is not the publisher of macOS, and the server integrates with native macOS functionality rather than being published by Apple.",
-    "cached_at": "2025-09-30 21:48:20 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub org 'macuse-app' matches server and repo name 'macuse', indicating publication by the primary product owner.",
+    "cached_at": "2025-09-30 23:48:29 UTC",
     "repository_url": "https://github.com/macuse-app/macuse",
     "server_name": "io.github.macuse-app/macuse"
   },
-  "https://github.com/mapbox/mcp-server": {
-    "ai_decision": "official",
-    "ai_confidence": 0.98,
-    "ai_reason": "Repository is under the verified Mapbox organization and npm package uses the @mapbox scope, both matching the product name.",
-    "cached_at": "2025-09-30 21:48:22 UTC",
-    "repository_url": "https://github.com/mapbox/mcp-server",
-    "server_name": "io.github.mapbox/mcp-server"
-  },
-  "https://github.com/marianfoo/mcp-sap-docs": {
+  "io.github.marianfoo/mcp-sap-docs:https://github.com/marianfoo/mcp-sap-docs": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "Repository is owned by a personal user (marianfoo), not the SAP organization, so it is a third-party implementation for SAP Docs.",
-    "cached_at": "2025-09-30 21:48:23 UTC",
+    "ai_reason": "GitHub repo is under a personal user (marianfoo), not an official SAP org, and there is no evidence of brand ownership.",
+    "cached_at": "2025-09-30 23:48:32 UTC",
     "repository_url": "https://github.com/marianfoo/mcp-sap-docs",
     "server_name": "io.github.marianfoo/mcp-sap-docs"
   },
-  "https://github.com/marlenezw/publish-mcp-server": {
+  "io.github.marlenezw/publish-mcp-server:https://github.com/marlenezw/publish-mcp-server": {
     "ai_decision": "community",
-    "ai_confidence": 0.9,
-    "ai_reason": "Repo is owned by an individual user (marlenezw), not an organization or brand owner.",
-    "cached_at": "2025-09-30 21:48:24 UTC",
+    "ai_confidence": 0.85,
+    "ai_reason": "Published by user marlenezw, no evidence of brand ownership or official product integration.",
+    "cached_at": "2025-09-30 23:48:35 UTC",
     "repository_url": "https://github.com/marlenezw/publish-mcp-server",
     "server_name": "io.github.marlenezw/publish-mcp-server"
   },
-  "https://github.com/mobile-next/mobile-mcp": {
+  "io.github.mfukushim/map-traveler-mcp:https://github.com/mfukushim/map-traveler-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.7,
-    "ai_reason": "The GitHub organization 'mobile-next' does not clearly correspond to a well-known mobile platform owner (e.g., Apple or Google), and there is no strong brand linkage.",
-    "cached_at": "2025-09-30 21:48:27 UTC",
-    "repository_url": "https://github.com/mobile-next/mobile-mcp",
-    "server_name": "io.github.mobile-next/mobile-mcp"
+    "ai_confidence": 1.0,
+    "ai_reason": "The publisher is a personal GitHub user (mfukushim), not an organization matching any product/brand in the service; no signals of official affiliation.",
+    "cached_at": "2025-09-30 23:48:37 UTC",
+    "repository_url": "https://github.com/mfukushim/map-traveler-mcp",
+    "server_name": "io.github.mfukushim/map-traveler-mcp"
   },
-  "https://github.com/moonolgerd/game-mcp": {
+  "io.github.moonolgerd/game-mcp:https://github.com/moonolgerd/game-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.9,
-    "ai_reason": "The GitHub org 'moonolgerd' does not match the brands (Steam, Epic, GOG, Xbox) mentioned in the description and appears to be a personal or third-party publisher.",
-    "cached_at": "2025-09-30 21:48:29 UTC",
+    "ai_confidence": 0.8,
+    "ai_reason": "moonolgerd is not an organization owning any of the supported game platforms (Steam, Epic, GOG, Xbox), so this is a third-party implementation.",
+    "cached_at": "2025-09-30 23:48:39 UTC",
     "repository_url": "https://github.com/moonolgerd/game-mcp",
     "server_name": "io.github.moonolgerd/game-mcp"
   },
-  "https://github.com/morinokami/astro-mcp": {
+  "io.github.morinokami/astro-mcp:https://github.com/morinokami/astro-mcp": {
     "ai_decision": "community",
     "ai_confidence": 0.8,
-    "ai_reason": "The repository is owned by a user (morinokami), not the Astro org, and there's no strong evidence this is an official Astro project.",
-    "cached_at": "2025-09-30 21:48:31 UTC",
+    "ai_reason": "The GitHub owner 'morinokami' is a user account, not the official Astro organization, and there are no signals tying this to the official Astro project.",
+    "cached_at": "2025-09-30 23:48:41 UTC",
     "repository_url": "https://github.com/morinokami/astro-mcp",
     "server_name": "io.github.morinokami/astro-mcp"
   },
-  "https://github.com/motherduckdb/mcp-server-motherduck": {
-    "ai_decision": "official",
-    "ai_confidence": 0.98,
-    "ai_reason": "GitHub organization name 'motherduckdb' matches the product 'MotherDuck', repository is not a fork/archived, indicating organizational ownership.",
-    "cached_at": "2025-09-30 21:48:32 UTC",
-    "repository_url": "https://github.com/motherduckdb/mcp-server-motherduck",
-    "server_name": "io.github.motherduckdb/mcp-server-motherduck"
-  },
-  "https://github.com/nerfels/mind-map": {
+  "io.github.nerfels/mind-map:https://github.com/nerfels/mind-map": {
     "ai_decision": "community",
-    "ai_confidence": 1.0,
-    "ai_reason": "GitHub organization 'nerfels' does not match 'Claude' or any major product/brand in the description; signals indicate third-party implementation.",
-    "cached_at": "2025-09-30 21:48:34 UTC",
+    "ai_confidence": 0.9,
+    "ai_reason": "The GitHub owner 'nerfels' is not a known organization for any underlying product/service, and there is no strong brand match to indicate official status.",
+    "cached_at": "2025-09-30 23:48:43 UTC",
     "repository_url": "https://github.com/nerfels/mind-map",
     "server_name": "io.github.nerfels/mind-map"
   },
-  "https://github.com/nesquikm/mcp-rubber-duck": {
+  "io.github.nesquikm/rubber-duck:https://github.com/nesquikm/mcp-rubber-duck": {
     "ai_decision": "community",
     "ai_confidence": 1.0,
-    "ai_reason": "The repository is published by a user (nesquikm), bridges to multiple OpenAI-compatible LLMs, and is not from any of the relevant official organizations (OpenAI, Google, Groq).",
-    "cached_at": "2025-09-30 21:48:36 UTC",
+    "ai_reason": "Published by user 'nesquikm' with no credentials from OpenAI, Google, or Groq; integrates multiple third-party LLMs.",
+    "cached_at": "2025-09-30 23:48:45 UTC",
     "repository_url": "https://github.com/nesquikm/mcp-rubber-duck",
     "server_name": "io.github.nesquikm/rubber-duck"
   },
-  "https://github.com/nickzren/opentargets-mcp": {
+  "io.github.nickzren/opentargets:https://github.com/nickzren/opentargets-mcp": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "The repository is owned by a personal user (nickzren), not the official Open Targets organization.",
-    "cached_at": "2025-09-30 21:48:38 UTC",
+    "ai_reason": "Repo is owned by a personal user (nickzren) and not the official Open Targets organization.",
+    "cached_at": "2025-09-30 23:48:47 UTC",
     "repository_url": "https://github.com/nickzren/opentargets-mcp",
     "server_name": "io.github.nickzren/opentargets"
   },
-  "https://github.com/nrwl/nx-console": {
-    "ai_decision": "official",
-    "ai_confidence": 0.9,
-    "ai_reason": "Organization nrwl owns Nx and the repository nx-console is under nrwl GitHub org in primary namespace.",
-    "cached_at": "2025-09-30 21:48:39 UTC",
-    "repository_url": "https://github.com/nrwl/nx-console",
-    "server_name": "io.github.nrwl/nx-console"
-  },
-  "https://github.com/overstarry/qweather-mcp": {
+  "io.github.opencontext-team/mcp-server:https://github.com/testing9384/mcp-server": {
     "ai_decision": "community",
-    "ai_confidence": 0.85,
-    "ai_reason": "GitHub org 'overstarry' does not match the Qweather brand and there is no evidence of official affiliation.",
-    "cached_at": "2025-09-30 21:48:41 UTC",
+    "ai_confidence": 0.9,
+    "ai_reason": "GitHub repo owner is a personal user (testing9384) and package has no clear brand; no evidence of brand ownership by relevant org.",
+    "cached_at": "2025-09-30 23:48:50 UTC",
+    "repository_url": "https://github.com/testing9384/mcp-server",
+    "server_name": "io.github.opencontext-team/mcp-server"
+  },
+  "io.github.overstarry/qweather-mcp:https://github.com/overstarry/qweather-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.8,
+    "ai_reason": "The publisher is the personal GitHub user overstarry, not an organization matching 'qweather', with no strong evidence of QWeather brand ownership.",
+    "cached_at": "2025-09-30 23:48:51 UTC",
     "repository_url": "https://github.com/overstarry/qweather-mcp",
     "server_name": "io.github.overstarry/qweather-mcp"
   },
-  "https://github.com/p1va/symbols": {
+  "io.github.p1va/symbols:https://github.com/p1va/symbols": {
     "ai_decision": "community",
-    "ai_confidence": 0.8,
-    "ai_reason": "The publisher 'p1va' is a personal namespace and not the brand owner of a specific product/service referenced by the server.",
-    "cached_at": "2025-09-30 21:48:43 UTC",
+    "ai_confidence": 0.7,
+    "ai_reason": "Repository owned by a user (p1va), not an organization matching any notable product/brand; no strong signals of official status.",
+    "cached_at": "2025-09-30 23:48:53 UTC",
     "repository_url": "https://github.com/p1va/symbols",
     "server_name": "io.github.p1va/symbols"
   },
-  "https://github.com/pab1it0/prometheus-mcp-server": {
+  "io.github.pab1it0/prometheus-mcp-server:https://github.com/pab1it0/prometheus-mcp-server": {
     "ai_decision": "community",
-    "ai_confidence": 1.0,
-    "ai_reason": "The publisher is a personal user (pab1it0), not the official Prometheus organization.",
-    "cached_at": "2025-09-30 21:48:44 UTC",
+    "ai_confidence": 0.98,
+    "ai_reason": "Repository is published by user 'pab1it0' not the official Prometheus org; no official branding or verified signals.",
+    "cached_at": "2025-09-30 23:48:55 UTC",
     "repository_url": "https://github.com/pab1it0/prometheus-mcp-server",
     "server_name": "io.github.pab1it0/prometheus-mcp-server"
   },
-  "https://github.com/pedro-rivas/android-puppeteer-mcp": {
+  "io.github.pedro-rivas/android-puppeteer-mcp:https://github.com/pedro-rivas/android-puppeteer-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.9,
-    "ai_reason": "The repository is owned by a personal user (pedro-rivas), not an official organization associated with Android or Puppeteer.",
-    "cached_at": "2025-09-30 21:48:46 UTC",
+    "ai_confidence": 1.0,
+    "ai_reason": "Repo is owned by a user (pedro-rivas), not an organization, for an Android automation tool, indicating third-party community implementation.",
+    "cached_at": "2025-09-30 23:48:57 UTC",
     "repository_url": "https://github.com/pedro-rivas/android-puppeteer-mcp",
     "server_name": "io.github.pedro-rivas/android-puppeteer-mcp"
   },
-  "https://github.com/pkolawa/krs-poland-mcp-server": {
+  "io.github.pkolawa/krs-poland-mcp-server:https://github.com/pkolawa/krs-poland-mcp-server": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "The publisher is a personal user (pkolawa) and not an official organization operating the KRS registry.",
-    "cached_at": "2025-09-30 21:48:48 UTC",
+    "ai_reason": "Repo is owned by a personal user (pkolawa), not the official KRS/Polish government organization.",
+    "cached_at": "2025-09-30 23:48:59 UTC",
     "repository_url": "https://github.com/pkolawa/krs-poland-mcp-server",
     "server_name": "io.github.pkolawa/krs-poland-mcp-server"
   },
-  "https://github.com/pkolawa/mcp-krs-poland": {
+  "io.github.pkolawa/mcp-krs-poland:https://github.com/pkolawa/mcp-krs-poland": {
     "ai_decision": "community",
-    "ai_confidence": 0.9,
-    "ai_reason": "GitHub repo is under a user account ('pkolawa'), not an organizational account matching the official Polish government registry.",
-    "cached_at": "2025-09-30 21:48:50 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repo is owned by a personal user (pkolawa) and not an official Polish government organization.",
+    "cached_at": "2025-09-30 23:49:01 UTC",
     "repository_url": "https://github.com/pkolawa/mcp-krs-poland",
     "server_name": "io.github.pkolawa/mcp-krs-poland"
   },
-  "https://github.com/pree-dew/mcp-bookmark": {
+  "io.github.pree-dew/mcp-bookmark:https://github.com/pree-dew/mcp-bookmark": {
     "ai_decision": "community",
-    "ai_confidence": 0.95,
-    "ai_reason": "The GitHub owner is a user (pree-dew) and not OpenAI; no official OpenAI signals.",
-    "cached_at": "2025-09-30 21:48:52 UTC",
+    "ai_confidence": 1.0,
+    "ai_reason": "Repo is user-owned (pree-dew), not an org related to OpenAI or a clear product brand owner.",
+    "cached_at": "2025-09-30 23:49:02 UTC",
     "repository_url": "https://github.com/pree-dew/mcp-bookmark",
     "server_name": "io.github.pree-dew/mcp-bookmark"
   },
-  "https://github.com/priyankark/lighthouse-mcp": {
+  "io.github.priyankark/lighthouse-mcp:https://github.com/priyankark/lighthouse-mcp": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "Repository owner 'priyankark' is a personal user and not Google, but the service integrates with Google Lighthouse.",
-    "cached_at": "2025-09-30 21:48:54 UTC",
+    "ai_reason": "Repo owner is a personal user (priyankark) and not Google, while service is Google Lighthouse.",
+    "cached_at": "2025-09-30 23:49:04 UTC",
     "repository_url": "https://github.com/priyankark/lighthouse-mcp",
     "server_name": "io.github.priyankark/lighthouse-mcp"
   },
-  "https://github.com/promplate/pyth-on-line": {
+  "io.github.promplate/hmr:https://github.com/promplate/pyth-on-line": {
     "ai_decision": "community",
-    "ai_confidence": 0.8,
-    "ai_reason": "The GitHub org 'promplate' does not clearly represent a widely recognized product/service brand, and the project is hosted under a user-like org for a tool rather than an official integration.",
-    "cached_at": "2025-09-30 21:48:57 UTC",
+    "ai_confidence": 0.85,
+    "ai_reason": "The publisher (promplate) is not the owner of any underlying product/service named 'hmr'; signals suggest a community library for generic Python HMR functionality.",
+    "cached_at": "2025-09-30 23:49:07 UTC",
     "repository_url": "https://github.com/promplate/pyth-on-line",
     "server_name": "io.github.promplate/hmr"
   },
-  "https://github.com/pshivapr/selenium-mcp": {
+  "io.github.pshivapr/selenium-mcp:https://github.com/pshivapr/selenium-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.95,
-    "ai_reason": "The repository is owned by a personal GitHub user (pshivapr) and not the Selenium organization, so it is a community implementation.",
-    "cached_at": "2025-09-30 21:48:59 UTC",
+    "ai_confidence": 0.9,
+    "ai_reason": "Repository is owned by an individual user (pshivapr), not the Selenium organization, for a service ('selenium') they do not own.",
+    "cached_at": "2025-09-30 23:49:09 UTC",
     "repository_url": "https://github.com/pshivapr/selenium-mcp",
     "server_name": "io.github.pshivapr/selenium-mcp"
   },
-  "https://github.com/pubnub/pubnub-mcp-server": {
-    "ai_decision": "official",
-    "ai_confidence": 0.95,
-    "ai_reason": "GitHub org 'pubnub' matches the service 'PubNub' in server name and repo, with strong brand alignment.",
-    "cached_at": "2025-09-30 21:49:01 UTC",
-    "repository_url": "https://github.com/pubnub/pubnub-mcp-server",
-    "server_name": "io.github.pubnub/mcp-server"
-  },
-  "https://github.com/r-huijts/strava-mcp": {
+  "io.github.r-huijts/strava-mcp:https://github.com/r-huijts/strava-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 1.0,
-    "ai_reason": "The repository is owned by a personal user (r-huijts), not Strava’s official organization.",
-    "cached_at": "2025-09-30 21:49:03 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub org 'r-huijts' is a user, not the official Strava org; no strong evidence of Strava's direct involvement.",
+    "cached_at": "2025-09-30 23:49:11 UTC",
     "repository_url": "https://github.com/r-huijts/strava-mcp",
     "server_name": "io.github.r-huijts/strava-mcp"
   },
-  "https://github.com/railwayapp/railway-mcp-server": {
-    "ai_decision": "official",
-    "ai_confidence": 0.98,
-    "ai_reason": "The server is published by the verified GitHub organization railwayapp which matches the Railway product, and the npm package is under the @railway scope.",
-    "cached_at": "2025-09-30 21:49:05 UTC",
-    "repository_url": "https://github.com/railwayapp/railway-mcp-server",
-    "server_name": "io.github.railwayapp/mcp-server"
-  },
-  "https://github.com/rbonestell/ap-mcp-server": {
+  "io.github.rbonestell/ap-mcp-server:https://github.com/rbonestell/ap-mcp-server": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "Repository is published under a personal user (rbonestell) not the Associated Press org; no evidence of official branding.",
-    "cached_at": "2025-09-30 21:49:07 UTC",
+    "ai_reason": "Repo is under user rbonestell and not the Associated Press org; no strong official ownership signal.",
+    "cached_at": "2025-09-30 23:49:12 UTC",
     "repository_url": "https://github.com/rbonestell/ap-mcp-server",
     "server_name": "io.github.rbonestell/ap-mcp-server"
   },
-  "https://github.com/ref-tools/ref-tools-mcp": {
-    "ai_decision": "community",
-    "ai_confidence": 0.65,
-    "ai_reason": "The GitHub org 'ref-tools' may relate to 'Ref', but there's no strong evidence it is run by the brand owner; org is not a major known company and domain matching is insufficient.",
-    "cached_at": "2025-09-30 21:49:08 UTC",
-    "repository_url": "https://github.com/ref-tools/ref-tools-mcp",
-    "server_name": "io.github.ref-tools/ref-tools-mcp"
-  },
-  "https://github.com/ruvnet/claude-flow": {
+  "io.github.rfdez/pvpc-mcp-server:https://github.com/rfdez/pvpc-mcp-server": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "The repo is under the 'ruvnet' user/org, not Anthropic, and references Claude (an Anthropic product) via user environment variables.",
-    "cached_at": "2025-09-30 21:49:11 UTC",
-    "repository_url": "https://github.com/ruvnet/claude-flow",
-    "server_name": "io.github.ruvnet/claude-flow"
+    "ai_reason": "The GitHub organization and npm scope are 'rfdez', which appears to be an individual, not Red Eléctrica, the owner of the PVPC tariffs service.",
+    "cached_at": "2025-09-30 23:49:15 UTC",
+    "repository_url": "https://github.com/rfdez/pvpc-mcp-server",
+    "server_name": "io.github.rfdez/pvpc-mcp-server"
   },
-  "https://github.com/ruvnet/flow-nexus": {
+  "io.github.ruvnet/flow-nexus:https://github.com/ruvnet/flow-nexus": {
     "ai_decision": "community",
-    "ai_confidence": 0.5,
-    "ai_reason": "The GitHub org 'ruvnet' does not clearly match the product/service 'flow-nexus', and there is insufficient evidence of official brand ownership.",
-    "cached_at": "2025-09-30 21:49:13 UTC",
+    "ai_confidence": 0.8,
+    "ai_reason": "The GitHub org 'ruvnet' does not clearly match 'Flow Nexus' as a product/brand, and no strong evidence ties the publisher to official service ownership.",
+    "cached_at": "2025-09-30 23:49:16 UTC",
     "repository_url": "https://github.com/ruvnet/flow-nexus",
     "server_name": "io.github.ruvnet/flow-nexus"
   },
-  "https://github.com/ruvnet/ruv-FANN": {
+  "io.github.ruvnet/ruv-swarm:https://github.com/ruvnet/ruv-FANN": {
     "ai_decision": "community",
-    "ai_confidence": 0.8,
-    "ai_reason": "The GitHub org 'ruvnet' matches the project but there is no evidence it controls a widely recognized product/service; not a known brand, so this is community.",
-    "cached_at": "2025-09-30 21:49:15 UTC",
+    "ai_confidence": 0.7,
+    "ai_reason": "The GitHub org 'ruvnet' operates the repo, but there's no evidence that 'ruvnet' is an established product/service outside this user/org and no strong brand-product match.",
+    "cached_at": "2025-09-30 23:49:18 UTC",
     "repository_url": "https://github.com/ruvnet/ruv-FANN",
     "server_name": "io.github.ruvnet/ruv-swarm"
   },
-  "https://github.com/ryaker/appstore-connect-mcp": {
+  "io.github.ryaker/appstore-connect-mcp:https://github.com/ryaker/appstore-connect-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 1.0,
-    "ai_reason": "The GitHub org ryaker does not match Apple or App Store Connect branding; all evidence points to a third-party implementation.",
-    "cached_at": "2025-09-30 21:49:16 UTC",
+    "ai_confidence": 0.96,
+    "ai_reason": "The repository is published by user/org 'ryaker', not Apple (the owner of App Store Connect), so it is a third-party integration.",
+    "cached_at": "2025-09-30 23:49:20 UTC",
     "repository_url": "https://github.com/ryaker/appstore-connect-mcp",
     "server_name": "io.github.ryaker/appstore-connect-mcp"
   },
-  "https://github.com/googlemaps/platform-ai": {
-    "ai_decision": "official",
-    "ai_confidence": 0.97,
-    "ai_reason": "Published by the GoogleMaps GitHub organization with matching npm scope (@googlemaps); strong signal of official Google Maps Platform integration.",
-    "cached_at": "2025-09-30 21:49:18 UTC",
-    "repository_url": "https://github.com/googlemaps/platform-ai",
-    "server_name": "io.github.ryanbaumann/platform-ai"
-  },
-  "https://github.com/saucelabs/sauce-api-mcp": {
-    "ai_decision": "official",
-    "ai_confidence": 0.95,
-    "ai_reason": "Repository is published by the 'saucelabs' GitHub organization (matching Sauce Labs API), not a fork, and integrates directly with their product.",
-    "cached_at": "2025-09-30 21:49:20 UTC",
-    "repository_url": "https://github.com/saucelabs/sauce-api-mcp",
-    "server_name": "io.github.saucelabs-sample-test-frameworks/sauce-api-mcp"
-  },
-  "https://github.com/savhascelik/meta-api-mcp-server": {
+  "io.github.savhascelik/meta-api-mcp-server:https://github.com/savhascelik/meta-api-mcp-server": {
     "ai_decision": "community",
-    "ai_confidence": 0.9,
-    "ai_reason": "The repository is under a personal user (savhascelik), not an organization, and does not match an official brand for a specific product.",
-    "cached_at": "2025-09-30 21:49:22 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "The repo is owned by a personal user (savhascelik), not an org; there is no clear brand or product match indicating official status.",
+    "cached_at": "2025-09-30 23:49:22 UTC",
     "repository_url": "https://github.com/savhascelik/meta-api-mcp-server",
     "server_name": "io.github.savhascelik/meta-api-mcp-server"
   },
-  "https://github.com/schemacrawler/SchemaCrawler-AI": {
-    "ai_decision": "official",
-    "ai_confidence": 0.95,
-    "ai_reason": "GitHub org 'schemacrawler' matches the server and package names, and the Docker image is under the same org.",
-    "cached_at": "2025-09-30 21:49:25 UTC",
-    "repository_url": "https://github.com/schemacrawler/SchemaCrawler-AI",
-    "server_name": "io.github.schemacrawler/schemacrawler-ai"
-  },
-  "https://github.com/sellisd/mcp-units": {
+  "io.github.sellisd/mcp-units:https://github.com/sellisd/mcp-units": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "The repository owner (sellisd) is a personal GitHub user, not an organization or brand matching the product/service ('units conversions'), indicating a community project.",
-    "cached_at": "2025-09-30 21:49:27 UTC",
+    "ai_reason": "Published by a personal user (sellisd), not an organization, and no evidence of ownership of a branded product/service.",
+    "cached_at": "2025-09-30 23:49:24 UTC",
     "repository_url": "https://github.com/sellisd/mcp-units",
     "server_name": "io.github.sellisd/mcp-units"
   },
-  "https://github.com/mcp-s-ai/image-recognition-mcp": {
+  "io.github.shalevshalit/image-recognition-mcp:https://github.com/mcp-s-ai/image-recognition-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 1.0,
-    "ai_reason": "Publisher 'mcp-s-ai' is not OpenAI nor the brand owner; remote hints and package do not show clear OpenAI ownership.",
-    "cached_at": "2025-09-30 21:49:29 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "Published by 'mcp-s-ai' rather than OpenAI; integrates OpenAI models but not from the official brand owner.",
+    "cached_at": "2025-09-30 23:49:26 UTC",
     "repository_url": "https://github.com/mcp-s-ai/image-recognition-mcp",
     "server_name": "io.github.shalevshalit/image-recognition-mcp"
   },
-  "https://github.com/mcp-s-ai/image-recongnition-mcp": {
+  "io.github.shalevshalit/image-recongnition-mcp:https://github.com/mcp-s-ai/image-recongnition-mcp": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "The publisher (mcp-s-ai) is not OpenAI and there is no evidence of official ownership or branding by OpenAI for the image recognition service.",
-    "cached_at": "2025-09-30 21:49:32 UTC",
+    "ai_reason": "Publisher (mcp-s-ai) is not OpenAI; implements OpenAI-powered image recognition as a third party.",
+    "cached_at": "2025-09-30 23:49:28 UTC",
     "repository_url": "https://github.com/mcp-s-ai/image-recongnition-mcp",
     "server_name": "io.github.shalevshalit/image-recongnition-mcp"
   },
-  "https://github.com/shinpr/mcp-image": {
+  "io.github.shinpr/mcp-image:https://github.com/shinpr/mcp-image": {
     "ai_decision": "community",
-    "ai_confidence": 0.98,
-    "ai_reason": "Repository is owned by personal user 'shinpr', not Google or an official organization, and there is no strong signal linking ownership to the underlying Google Gemini service.",
-    "cached_at": "2025-09-30 21:49:33 UTC",
+    "ai_confidence": 0.97,
+    "ai_reason": "Publisher is a personal GitHub user (shinpr), not the org behind Nano Banana or Google Gemini, and there is no brand-matching org or official domain evidence.",
+    "cached_at": "2025-09-30 23:49:30 UTC",
     "repository_url": "https://github.com/shinpr/mcp-image",
     "server_name": "io.github.shinpr/mcp-image"
   },
-  "https://github.com/spences10/mcp-omnisearch": {
+  "io.github.spences10/mcp-omnisearch:https://github.com/spences10/mcp-omnisearch": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "GitHub owner 'spences10' is a user, not the Omnisearch organization, so this is a third-party implementation.",
-    "cached_at": "2025-09-30 21:49:35 UTC",
+    "ai_reason": "The repo is owned by a user (spences10), not an org matching 'Omnisearch', and lacks any official branding signals.",
+    "cached_at": "2025-09-30 23:49:32 UTC",
     "repository_url": "https://github.com/spences10/mcp-omnisearch",
     "server_name": "io.github.spences10/mcp-omnisearch"
   },
-  "https://github.com/spences10/mcp-sqlite-tools": {
+  "io.github.spences10/mcp-sqlite-tools:https://github.com/spences10/mcp-sqlite-tools": {
     "ai_decision": "community",
-    "ai_confidence": 1.0,
-    "ai_reason": "The repository is owned by spences10 (not the SQLite organization), indicating a third-party implementation for SQLite.",
-    "cached_at": "2025-09-30 21:49:37 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub user 'spences10' is not the owner of SQLite; personal user owner for a generic service is a strong community signal.",
+    "cached_at": "2025-09-30 23:49:34 UTC",
     "repository_url": "https://github.com/spences10/mcp-sqlite-tools",
     "server_name": "io.github.spences10/mcp-sqlite-tools"
   },
-  "https://github.com/spences10/mcp-turso-cloud": {
+  "io.github.spences10/mcp-turso-cloud:https://github.com/spences10/mcp-turso-cloud": {
     "ai_decision": "community",
-    "ai_confidence": 1.0,
-    "ai_reason": "The repo is published by a user (spences10), not an organization related to Turso, with no signals of official brand ownership.",
-    "cached_at": "2025-09-30 21:49:39 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repository is under user spences10, not Turso's official org, and there is no evidence of official brand ownership.",
+    "cached_at": "2025-09-30 23:49:35 UTC",
     "repository_url": "https://github.com/spences10/mcp-turso-cloud",
     "server_name": "io.github.spences10/mcp-turso-cloud"
   },
-  "https://github.com/stefanoamorelli/fred-mcp-server": {
+  "io.github.stefanoamorelli/fred-mcp-server:https://github.com/stefanoamorelli/fred-mcp-server": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "The publisher (stefanoamorelli) is not the Federal Reserve; no signals this is an official integration for FRED.",
-    "cached_at": "2025-09-30 21:49:40 UTC",
+    "ai_reason": "Repo owner is a personal user (stefanoamorelli) not Federal Reserve, and there is no evidence of official brand affiliation.",
+    "cached_at": "2025-09-30 23:49:38 UTC",
     "repository_url": "https://github.com/stefanoamorelli/fred-mcp-server",
     "server_name": "io.github.stefanoamorelli/fred-mcp-server"
   },
-  "https://github.com/stefanoamorelli/sec-edgar-mcp": {
+  "io.github.stefanoamorelli/sec-edgar-mcp:https://github.com/stefanoamorelli/sec-edgar-mcp": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "The publisher is a personal GitHub user (stefanoamorelli) rather than the official SEC organization.",
-    "cached_at": "2025-09-30 21:49:42 UTC",
+    "ai_reason": "The repo is published by a personal user (stefanoamorelli), not by the US SEC or an official org.",
+    "cached_at": "2025-09-30 23:49:40 UTC",
     "repository_url": "https://github.com/stefanoamorelli/sec-edgar-mcp",
     "server_name": "io.github.stefanoamorelli/sec-edgar-mcp"
   },
-  "https://github.com/surendranb/google-analytics-mcp": {
+  "io.github.surendranb/google-analytics-mcp:https://github.com/surendranb/google-analytics-mcp": {
     "ai_decision": "community",
     "ai_confidence": 1.0,
-    "ai_reason": "Repo owner is a personal user (surendranb) and not Google; strong signal this is not official.",
-    "cached_at": "2025-09-30 21:49:44 UTC",
+    "ai_reason": "The repository is published by an individual user (surendranb), not Google, and thus not official for Google Analytics.",
+    "cached_at": "2025-09-30 23:49:41 UTC",
     "repository_url": "https://github.com/surendranb/google-analytics-mcp",
     "server_name": "io.github.surendranb/google-analytics-mcp"
   },
-  "https://github.com/taurgis/sfcc-dev-mcp": {
+  "io.github.taurgis/sfcc-dev-mcp:https://github.com/taurgis/sfcc-dev-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.9,
-    "ai_reason": "The publisher (taurgis) is not an official Salesforce org and the package namespace is generic with no evidence of Salesforce ownership.",
-    "cached_at": "2025-09-30 21:49:46 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "Taurgis is not Salesforce; the server integrates with Salesforce B2C Commerce Cloud but is published by a third-party org.",
+    "cached_at": "2025-09-30 23:49:46 UTC",
     "repository_url": "https://github.com/taurgis/sfcc-dev-mcp",
     "server_name": "io.github.taurgis/sfcc-dev-mcp"
   },
-  "https://github.com/tedfytw1209/mcp-server-EVEfleet": {
+  "io.github.tedfytw1209/mcp-server-EVEfleet:https://github.com/tedfytw1209/mcp-server-EVEfleet": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "GitHub repo is owned by a user (tedfytw1209), not the official EVE Online org; lacks official branding or verified signals.",
-    "cached_at": "2025-09-30 21:49:48 UTC",
+    "ai_reason": "Published by a personal user (tedfytw1209) not affiliated with EVE Online's owner; no official branding or org signals.",
+    "cached_at": "2025-09-30 23:49:47 UTC",
     "repository_url": "https://github.com/tedfytw1209/mcp-server-EVEfleet",
     "server_name": "io.github.tedfytw1209/mcp-server-EVEfleet"
   },
-  "https://github.com/therealtimex/un-datacommons-mcp": {
+  "io.github.therealtimex/un-datacommons-mcp:https://github.com/therealtimex/un-datacommons-mcp": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "The publisher 'therealtimex' is not the official Data Commons organization; no signals indicate official brand ownership.",
-    "cached_at": "2025-09-30 21:49:50 UTC",
+    "ai_reason": "Published by a personal GitHub user (therealtimex) not affiliated with Data Commons or the UN, with no official org or branding.",
+    "cached_at": "2025-09-30 23:49:50 UTC",
     "repository_url": "https://github.com/therealtimex/un-datacommons-mcp",
     "server_name": "io.github.therealtimex/un-datacommons-mcp"
   },
-  "https://github.com/timheuer/sampledotnetmcpserver": {
+  "io.github.timheuer/sampledotnetmcpserver:https://github.com/timheuer/sampledotnetmcpserver": {
     "ai_decision": "community",
-    "ai_confidence": 0.9,
-    "ai_reason": "Published by a personal GitHub user (timheuer) and lacks any clear official organization affiliation.",
-    "cached_at": "2025-09-30 21:49:51 UTC",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repository is under a personal GitHub user (timheuer) and not tied to an official brand/org.",
+    "cached_at": "2025-09-30 23:49:53 UTC",
     "repository_url": "https://github.com/timheuer/sampledotnetmcpserver",
     "server_name": "io.github.timheuer/sampledotnetmcpserver"
   },
-  "https://github.com/toby/mirror-mcp": {
+  "io.github.toby/mirror-mcp:https://github.com/toby/mirror-mcp": {
     "ai_decision": "community",
     "ai_confidence": 0.9,
-    "ai_reason": "Repository is owned by a personal user (toby), not an organization, with no evidence of official product/service ownership.",
-    "cached_at": "2025-09-30 21:49:54 UTC",
+    "ai_reason": "Repo is owned by a personal user ('toby'), not an organization, and there is no evidence of brand ownership or official affiliation.",
+    "cached_at": "2025-09-30 23:49:55 UTC",
     "repository_url": "https://github.com/toby/mirror-mcp",
     "server_name": "io.github.toby/mirror-mcp"
   },
-  "https://github.com/tschoonj/repology-mcp-server": {
+  "io.github.tschoonj/repology-mcp-server:https://github.com/tschoonj/repology-mcp-server": {
     "ai_decision": "community",
-    "ai_confidence": 0.9,
-    "ai_reason": "The repository is owned by a user (tschoonj), not the Repology organization, indicating it is a third-party community implementation.",
-    "cached_at": "2025-09-30 21:49:55 UTC",
+    "ai_confidence": 1.0,
+    "ai_reason": "Published by personal user 'tschoonj', not the official 'repology' org; nothing indicates ownership by Repology.",
+    "cached_at": "2025-09-30 23:49:58 UTC",
     "repository_url": "https://github.com/tschoonj/repology-mcp-server",
     "server_name": "io.github.tschoonj/repology-mcp-server"
   },
-  "https://github.com/tuananh/hyper-mcp": {
+  "io.github.tuannvm/mcp-trino:https://github.com/tuannvm/mcp-trino": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "Repository is owned by personal user 'tuananh', not a product/service organization.",
-    "cached_at": "2025-09-30 21:49:57 UTC",
-    "repository_url": "https://github.com/tuananh/hyper-mcp",
-    "server_name": "io.github.tuananh/hyper-mcp"
-  },
-  "https://github.com/tuannvm/mcp-trino": {
-    "ai_decision": "community",
-    "ai_confidence": 0.97,
-    "ai_reason": "The publisher is a personal user (tuannvm), not the official Trino organization, indicating it is a community implementation.",
-    "cached_at": "2025-09-30 21:49:59 UTC",
+    "ai_reason": "GitHub repo is published by a personal user (tuannvm) not the Trino organization, and no signals of official ownership.",
+    "cached_at": "2025-09-30 23:50:00 UTC",
     "repository_url": "https://github.com/tuannvm/mcp-trino",
     "server_name": "io.github.tuannvm/mcp-trino"
   },
-  "https://github.com/ubaumann/mkdocs-mcp": {
+  "io.github.ubaumann/mkdocs-mcp:https://github.com/ubaumann/mkdocs-mcp": {
     "ai_decision": "community",
     "ai_confidence": 0.95,
-    "ai_reason": "GitHub owner is a personal user (ubaumann), not the MkDocs organization, so this is a third-party implementation.",
-    "cached_at": "2025-09-30 21:50:00 UTC",
+    "ai_reason": "Repository is owned by a user (ubaumann) not an organization associated with MkDocs, and no official MkDocs branding is present.",
+    "cached_at": "2025-09-30 23:50:02 UTC",
     "repository_url": "https://github.com/ubaumann/mkdocs-mcp",
     "server_name": "io.github.ubaumann/mkdocs-mcp"
   },
-  "https://github.com/variflight/variflight-mcp": {
-    "ai_decision": "official",
-    "ai_confidence": 0.98,
-    "ai_reason": "GitHub org variflight matches service name and domain, npm scope @variflight-ai is owned by org, and description claims official status.",
-    "cached_at": "2025-09-30 21:50:03 UTC",
-    "repository_url": "https://github.com/variflight/variflight-mcp",
-    "server_name": "io.github.variflight/variflight-mcp"
-  },
-  "https://github.com/vfarcic/dot-ai": {
+  "io.github.vfarcic/dot-ai:https://github.com/vfarcic/dot-ai": {
     "ai_decision": "community",
     "ai_confidence": 0.9,
-    "ai_reason": "Repository owner vfarcic is a GitHub user, not an organization, and there is no clear indication of an underlying branded platform.",
-    "cached_at": "2025-09-30 21:50:04 UTC",
+    "ai_reason": "The repository owner 'vfarcic' is a personal user, not a brand/org matching the product, so this is a third-party community server.",
+    "cached_at": "2025-09-30 23:50:04 UTC",
     "repository_url": "https://github.com/vfarcic/dot-ai",
     "server_name": "io.github.vfarcic/dot-ai"
   },
-  "https://github.com/wonderwhy-er/DesktopCommanderMCP": {
+  "io.github.xkelxmc/uranium-mcp:https://github.com/xkelxmc/uranium-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.9,
-    "ai_reason": "The GitHub owner 'wonderwhy-er' is a user, not an organization, and there is no evidence of underlying product/service brand ownership.",
-    "cached_at": "2025-09-30 21:50:06 UTC",
-    "repository_url": "https://github.com/wonderwhy-er/DesktopCommanderMCP",
-    "server_name": "io.github.wonderwhy-er/desktop-commander"
-  },
-  "https://github.com/xkelxmc/uranium-mcp": {
-    "ai_decision": "community",
-    "ai_confidence": 0.8,
-    "ai_reason": "The GitHub repo is under a user account (xkelxmc), not an org matching Uranium, and there is no strong brand signal.",
-    "cached_at": "2025-09-30 21:50:08 UTC",
+    "ai_confidence": 0.7,
+    "ai_reason": "The GitHub owner 'xkelxmc' is a personal user, not an org matching 'uranium', with no strong official brand evidence.",
+    "cached_at": "2025-09-30 23:50:06 UTC",
     "repository_url": "https://github.com/xkelxmc/uranium-mcp",
     "server_name": "io.github.xkelxmc/uranium-mcp"
   },
-  "https://github.com/xorrkaz/cml-mcp": {
+  "io.github.xorrkaz/cml-mcp:https://github.com/xorrkaz/cml-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.85,
-    "ai_reason": "The publisher is a personal user (xorrkaz), not Cisco or a Cisco-verified organization, for the Cisco Modeling Labs service.",
-    "cached_at": "2025-09-30 21:50:10 UTC",
+    "ai_confidence": 0.9,
+    "ai_reason": "The GitHub org 'xorrkaz' is a user, not Cisco; no strong evidence links this repo to Cisco, the CML product owner.",
+    "cached_at": "2025-09-30 23:50:07 UTC",
     "repository_url": "https://github.com/xorrkaz/cml-mcp",
     "server_name": "io.github.xorrkaz/cml-mcp"
   },
-  "https://github.com/ycjcl868/mcp-server-fear-greed": {
+  "io.github.ycjcl868/mcp-server-fear-greed:https://github.com/ycjcl868/mcp-server-fear-greed": {
     "ai_decision": "community",
-    "ai_confidence": 0.95,
-    "ai_reason": "The repository is under a user account (ycjcl868), not an organization matching a known product/brand, with no evidence of brand ownership.",
-    "cached_at": "2025-09-30 21:50:12 UTC",
+    "ai_confidence": 0.9,
+    "ai_reason": "The GitHub repo is under a user (ycjcl868), not an organization matching a product/brand, and there are no official org or domain signals.",
+    "cached_at": "2025-09-30 23:50:10 UTC",
     "repository_url": "https://github.com/ycjcl868/mcp-server-fear-greed",
     "server_name": "io.github.ycjcl868/mcp-server-fear-greed"
   },
-  "https://github.com/web-infra-dev/rsdoctor": {
+  "io.github.yuna0x0/anilist-mcp:https://github.com/yuna0x0/anilist-mcp": {
     "ai_decision": "community",
-    "ai_confidence": 0.8,
-    "ai_reason": "The publishing GitHub org is 'web-infra-dev' which does not match Rspack product branding, and there is no strong evidence of official status.",
-    "cached_at": "2025-09-30 21:50:17 UTC",
-    "repository_url": "https://github.com/web-infra-dev/rsdoctor",
-    "server_name": "io.github.yifancong/rsdoctor"
+    "ai_confidence": 0.98,
+    "ai_reason": "The GitHub owner 'yuna0x0' is a personal user, not the official AniList organization, and there are no official AniList domains or signals.",
+    "cached_at": "2025-09-30 23:50:12 UTC",
+    "repository_url": "https://github.com/yuna0x0/anilist-mcp",
+    "server_name": "io.github.yuna0x0/anilist-mcp"
   },
-  "https://github.com/zenml-io/mcp-zenml": {
-    "ai_decision": "official",
-    "ai_confidence": 0.95,
-    "ai_reason": "The GitHub org 'zenml-io' matches the ZenML product and is publishing under its own branding with remotes referencing its domain.",
-    "cached_at": "2025-09-30 21:50:19 UTC",
-    "repository_url": "https://github.com/zenml-io/mcp-zenml",
-    "server_name": "io.github.zenml-io/mcp-zenml"
-  },
-  "https://github.com/zhongweili/nanobanana-mcp-server": {
+  "io.github.yuna0x0/hackmd-mcp:https://github.com/yuna0x0/hackmd-mcp": {
     "ai_decision": "community",
     "ai_confidence": 1.0,
-    "ai_reason": "The repository is owned by a user (zhongweili), not an organization affiliated with a known product or brand.",
-    "cached_at": "2025-09-30 21:50:20 UTC",
+    "ai_reason": "The server is published by a user (yuna0x0) not the HackMD org, and there is no evidence of official HackMD brand ownership.",
+    "cached_at": "2025-09-30 23:50:15 UTC",
+    "repository_url": "https://github.com/yuna0x0/hackmd-mcp",
+    "server_name": "io.github.yuna0x0/hackmd-mcp"
+  },
+  "io.github.zhongweili/nanobanana-mcp-server:https://github.com/zhongweili/nanobanana-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "The repository is under a personal GitHub user (zhongweili) and not an organization matching the product or service name.",
+    "cached_at": "2025-09-30 23:50:17 UTC",
     "repository_url": "https://github.com/zhongweili/nanobanana-mcp-server",
     "server_name": "io.github.zhongweili/nanobanana-mcp-server"
   },
-  "https://github.com/jsdelivr/globalping-mcp-server": {
+  "io.ignission/mcp:https://github.com/ignission-io/mcp": {
     "ai_decision": "official",
     "ai_confidence": 0.95,
-    "ai_reason": "GitHub org jsdelivr matches globalping service brand and remotes use globalping.io domain.",
-    "cached_at": "2025-09-30 21:50:23 UTC",
-    "repository_url": "https://github.com/jsdelivr/globalping-mcp-server",
-    "server_name": "io.globalping/mcp"
-  },
-  "https://github.com/ignission-io/mcp": {
-    "ai_decision": "community",
-    "ai_confidence": 0.85,
-    "ai_reason": "Organization (ignission-io) does not match TikTok's brand; strong signals indicate this is a third-party integration.",
-    "cached_at": "2025-09-30 21:50:24 UTC",
+    "ai_reason": "GitHub org 'ignission-io' matches remote domain 'ignission.io' and server_name 'io.ignission/mcp', indicating official origin.",
+    "cached_at": "2025-09-30 23:50:18 UTC",
     "repository_url": "https://github.com/ignission-io/mcp",
     "server_name": "io.ignission/mcp"
   },
-  "https://github.com/scorecard-ai/scorecard-node": {
-    "ai_decision": "official",
-    "ai_confidence": 1.0,
-    "ai_reason": "The GitHub org 'scorecard-ai' matches the product (Scorecard), remotes are on scorecard.io, and all evidence points to direct ownership.",
-    "cached_at": "2025-09-30 21:50:27 UTC",
-    "repository_url": "https://github.com/scorecard-ai/scorecard-node",
-    "server_name": "io.scorecard/mcp"
-  },
-  "https://github.com/snyk/snyk-ls": {
-    "ai_decision": "official",
-    "ai_confidence": 0.98,
-    "ai_reason": "GitHub org 'snyk' matches product 'Snyk', publishes npm package 'snyk', and integrates directly with Snyk platform.",
-    "cached_at": "2025-09-30 21:50:28 UTC",
-    "repository_url": "https://github.com/snyk/snyk-ls",
-    "server_name": "io.snyk/mcp"
-  },
-  "https://github.com/gepuro/company-lens-mcp-registry": {
-    "ai_decision": "official",
-    "ai_confidence": 0.85,
-    "ai_reason": "The GitHub org (gepuro) matches the domain in the remote (gepuro.net) and server name, indicating this is published by the brand owner.",
-    "cached_at": "2025-09-30 21:50:30 UTC",
-    "repository_url": "https://github.com/gepuro/company-lens-mcp-registry",
-    "server_name": "net.gepuro.mcp-company-lens-v1/company-lens-mcp-registry"
-  },
-  "https://github.com/609NFT/solana-mcp": {
+  "trade.neglect/mcp-server:https://github.com/609NFT/solana-mcp": {
     "ai_decision": "community",
     "ai_confidence": 0.7,
-    "ai_reason": "The GitHub org '609NFT' does not match the 'neglect.trade' or 'trade' brands, and there is no evidence the publisher is the brand owner.",
-    "cached_at": "2025-09-30 21:50:32 UTC",
+    "ai_reason": "GitHub org 609NFT does not match the product or domain neglect.trade nor is it a known Solana, trade, or neglect brand owner.",
+    "cached_at": "2025-09-30 23:50:22 UTC",
     "repository_url": "https://github.com/609NFT/solana-mcp",
     "server_name": "trade.neglect/mcp-server"
   }

--- a/scripts/upstream_sync/ai_categorization_cache.json
+++ b/scripts/upstream_sync/ai_categorization_cache.json
@@ -1,0 +1,2434 @@
+{
+  "https://github.com/embeddedlayers/mcp-analytics": {
+    "ai_decision": "community",
+    "ai_confidence": 0.7,
+    "ai_reason": "The GitHub org 'embeddedlayers' does not match the product/brand 'mcpanalytics', and there is no strong evidence of organizational ownership of 'mcpanalytics'.",
+    "cached_at": "2025-09-30 21:25:49 UTC",
+    "repository_url": "https://github.com/embeddedlayers/mcp-analytics",
+    "server_name": "ai.mcpanalytics/analytics"
+  },
+  "https://github.com/Aman-Amith-Shastry/scientific_computation_mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.7,
+    "ai_reason": "Repo is owned by a personal GitHub user (Aman-Amith-Shastry), not the Smithery org, despite remotes being on smithery.ai.",
+    "cached_at": "2025-09-30 21:25:54 UTC",
+    "repository_url": "https://github.com/Aman-Amith-Shastry/scientific_computation_mcp",
+    "server_name": "ai.smithery/Aman-Amith-Shastry-scientific_computation_mcp"
+  },
+  "https://github.com/BadRooBot/test_m": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "The GitHub org 'BadRooBot' does not match the product/service 'smithery.ai', and there is no evidence the repository is published by the official Smithery organization.",
+    "cached_at": "2025-09-30 21:25:55 UTC",
+    "repository_url": "https://github.com/BadRooBot/test_m",
+    "server_name": "ai.smithery/BadRooBot-test_m"
+  },
+  "https://github.com/BigVik193/reddit-ads-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "The repository is published under the BigVik193 user, not Reddit; no evidence of Reddit (the brand owner) operating or affiliating with the server.",
+    "cached_at": "2025-09-30 21:25:57 UTC",
+    "repository_url": "https://github.com/BigVik193/reddit-ads-mcp",
+    "server_name": "ai.smithery/BigVik193-reddit-ads-mcp"
+  },
+  "https://github.com/BigVik193/reddit-ads-mcp-api": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repo is by user BigVik193, not official Reddit org, and remotes are hosted on smithery.ai, not reddit.com.",
+    "cached_at": "2025-09-30 21:25:59 UTC",
+    "repository_url": "https://github.com/BigVik193/reddit-ads-mcp-api",
+    "server_name": "ai.smithery/BigVik193-reddit-ads-mcp-api"
+  },
+  "https://github.com/BigVik193/reddit-user-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.98,
+    "ai_reason": "Publisher 'BigVik193' is not Reddit; GitHub user is not an official Reddit org and remote is not on a Reddit-owned domain.",
+    "cached_at": "2025-09-30 21:26:02 UTC",
+    "repository_url": "https://github.com/BigVik193/reddit-user-mcp",
+    "server_name": "ai.smithery/BigVik193-reddit-user-mcp"
+  },
+  "https://github.com/CryptoCultCurt/appfolio-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repo is owned by CryptoCultCurt, not Appfolio; no evidence of involvement by the official Appfolio organization.",
+    "cached_at": "2025-09-30 21:26:04 UTC",
+    "repository_url": "https://github.com/CryptoCultCurt/appfolio-mcp-server",
+    "server_name": "ai.smithery/CryptoCultCurt-appfolio-mcp-server"
+  },
+  "https://github.com/Danushkumar-V/mcp-discord": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "The repo is under a user account (Danushkumar-V) and not the official Discord org; no evidence of Discord brand ownership.",
+    "cached_at": "2025-09-30 21:26:08 UTC",
+    "repository_url": "https://github.com/Danushkumar-V/mcp-discord",
+    "server_name": "ai.smithery/Danushkumar-V-mcp-discord"
+  },
+  "https://github.com/DynamicEndpoints/Autogen_MCP": {
+    "ai_decision": "community",
+    "ai_confidence": 0.8,
+    "ai_reason": "The GitHub org (DynamicEndpoints) does not match the underlying product/service domain (smithery.ai), indicating this is a third-party integration.",
+    "cached_at": "2025-09-30 21:26:10 UTC",
+    "repository_url": "https://github.com/DynamicEndpoints/Autogen_MCP",
+    "server_name": "ai.smithery/DynamicEndpoints-autogen_mcp"
+  },
+  "https://github.com/DynamicEndpoints/m365-core-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.98,
+    "ai_reason": "DynamicEndpoints is not Microsoft and there is no evidence that the org owns Microsoft 365; remote domain is smithery.ai, not a Microsoft property.",
+    "cached_at": "2025-09-30 21:26:12 UTC",
+    "repository_url": "https://github.com/DynamicEndpoints/m365-core-mcp",
+    "server_name": "ai.smithery/DynamicEndpoints-m365-core-mcp"
+  },
+  "https://github.com/DynamicEndpoints/PowerShell-Exec-MCP-Server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "DynamicEndpoints is not the owner of PowerShell; remote endpoint is on smithery.ai but service is for generic PowerShell execution.",
+    "cached_at": "2025-09-30 21:26:14 UTC",
+    "repository_url": "https://github.com/DynamicEndpoints/PowerShell-Exec-MCP-Server",
+    "server_name": "ai.smithery/DynamicEndpoints-powershell-exec-mcp-server"
+  },
+  "https://github.com/HARJAP-SINGH-3105/Splitwise_MCP": {
+    "ai_decision": "community",
+    "ai_confidence": 0.98,
+    "ai_reason": "Publisher is a personal user (HARJAP-SINGH-3105), not Splitwise's official org, for a third-party integration with Splitwise.",
+    "cached_at": "2025-09-30 21:26:16 UTC",
+    "repository_url": "https://github.com/HARJAP-SINGH-3105/Splitwise_MCP",
+    "server_name": "ai.smithery/HARJAP-SINGH-3105-splitwise_mcp"
+  },
+  "https://github.com/Hint-Services/obsidian-github-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "Hint-Services is not the owner of GitHub or Obsidian; org name and remote domains do not match either core product brand.",
+    "cached_at": "2025-09-30 21:26:18 UTC",
+    "repository_url": "https://github.com/Hint-Services/obsidian-github-mcp",
+    "server_name": "ai.smithery/Hint-Services-obsidian-github-mcp"
+  },
+  "https://github.com/IlyaGusev/academia_mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "The repository is owned by a personal user (IlyaGusev), not the organizations behind arXiv or ACL Anthology, and there is no direct evidence of official product ownership.",
+    "cached_at": "2025-09-30 21:26:20 UTC",
+    "repository_url": "https://github.com/IlyaGusev/academia_mcp",
+    "server_name": "ai.smithery/IlyaGusev-academia_mcp"
+  },
+  "https://github.com/ImRonAI/mcp-server-browserbase": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "ImRonAI is not the owner of Browserbase, and there is no evidence the publisher operates the underlying product or service.",
+    "cached_at": "2025-09-30 21:26:24 UTC",
+    "repository_url": "https://github.com/ImRonAI/mcp-server-browserbase",
+    "server_name": "ai.smithery/ImRonAI-mcp-server-browserbase"
+  },
+  "https://github.com/JMoak/chrono-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.7,
+    "ai_reason": "The GitHub owner (JMoak) does not match the Smithery.ai brand and is a personal user, indicating a third-party/community implementation.",
+    "cached_at": "2025-09-30 21:26:26 UTC",
+    "repository_url": "https://github.com/JMoak/chrono-mcp",
+    "server_name": "ai.smithery/JMoak-chrono-mcp"
+  },
+  "https://github.com/Kim-soung-won/mcp-smithery-exam": {
+    "ai_decision": "community",
+    "ai_confidence": 0.75,
+    "ai_reason": "GitHub owner is a user (Kim-soung-won), not an organization matching 'smithery.ai', despite using smithery.ai remote.",
+    "cached_at": "2025-09-30 21:26:28 UTC",
+    "repository_url": "https://github.com/Kim-soung-won/mcp-smithery-exam",
+    "server_name": "ai.smithery/Kim-soung-won-mcp-smithery-exam"
+  },
+  "https://github.com/Leghis/Smart-Thinking": {
+    "ai_decision": "community",
+    "ai_confidence": 0.8,
+    "ai_reason": "Repo is under user 'Leghis', not org 'Smithery', despite using smithery.ai endpoints and naming.",
+    "cached_at": "2025-09-30 21:26:30 UTC",
+    "repository_url": "https://github.com/Leghis/Smart-Thinking",
+    "server_name": "ai.smithery/Leghis-smart-thinking"
+  },
+  "https://github.com/MetehanGZL/PokeMCP": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "Repository is owned by user 'MetehanGZL' not an org, not affiliated with Pokémon brand owner, and no official signals present.",
+    "cached_at": "2025-09-30 21:26:32 UTC",
+    "repository_url": "https://github.com/MetehanGZL/PokeMCP",
+    "server_name": "ai.smithery/MetehanGZL-pokemcp"
+  },
+  "https://github.com/MisterSandFR/Supabase-MCP-SelfHosted": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "The publisher 'MisterSandFR' is not Supabase; no evidence of ownership by Supabase org for this integration.",
+    "cached_at": "2025-09-30 21:26:33 UTC",
+    "repository_url": "https://github.com/MisterSandFR/Supabase-MCP-SelfHosted",
+    "server_name": "ai.smithery/MisterSandFR-supabase-mcp-selfhosted"
+  },
+  "https://github.com/Nekzus/npm-sentinel-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.8,
+    "ai_reason": "GitHub org 'Nekzus' does not match the underlying service 'npm' or 'npmjs', and there is no indication it's operated by the owners of npm.",
+    "cached_at": "2025-09-30 21:26:35 UTC",
+    "repository_url": "https://github.com/Nekzus/npm-sentinel-mcp",
+    "server_name": "ai.smithery/Nekzus-npm-sentinel-mcp"
+  },
+  "https://github.com/PabloLec/KeyProbe-MCP": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "GitHub owner is a user (PabloLec) and not the Smithery org, despite remotes using smithery.ai.",
+    "cached_at": "2025-09-30 21:26:37 UTC",
+    "repository_url": "https://github.com/PabloLec/KeyProbe-MCP",
+    "server_name": "ai.smithery/PabloLec-keyprobe-mcp"
+  },
+  "https://github.com/PixdataOrg/coderide-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "Repo is owned by PixdataOrg, but the integrated service is smithery.ai; org name and domain do not match, indicating third-party integration.",
+    "cached_at": "2025-09-30 21:26:39 UTC",
+    "repository_url": "https://github.com/PixdataOrg/coderide-mcp",
+    "server_name": "ai.smithery/PixdataOrg-coderide"
+  },
+  "https://github.com/aamangeldi/dad-jokes-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "The repository is owned by user 'aamangeldi', not a Smithery organization, and the server provides a general dad jokes service, not a Smithery-owned product.",
+    "cached_at": "2025-09-30 21:26:41 UTC",
+    "repository_url": "https://github.com/aamangeldi/dad-jokes-mcp",
+    "server_name": "ai.smithery/aamangeldi-dad-jokes-mcp"
+  },
+  "https://github.com/adamamer20/paper-search-mcp-openai": {
+    "ai_decision": "community",
+    "ai_confidence": 0.98,
+    "ai_reason": "The publisher (adamamer20) is a personal user and not the owner of any underlying product/service listed (arXiv, PubMed, Scholar, etc.), with no evidence of official affiliation.",
+    "cached_at": "2025-09-30 21:26:43 UTC",
+    "repository_url": "https://github.com/adamamer20/paper-search-mcp-openai",
+    "server_name": "ai.smithery/adamamer20-paper-search-mcp-openai"
+  },
+  "https://github.com/airmang/hwpx-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.8,
+    "ai_reason": "Repo is under the 'airmang' user/org which does not match 'HWPX' brand; no evidence publisher owns the HWPX product.",
+    "cached_at": "2025-09-30 21:26:45 UTC",
+    "repository_url": "https://github.com/airmang/hwpx-mcp",
+    "server_name": "ai.smithery/airmang-hwpx-mcp"
+  },
+  "https://github.com/alex-llm/attAck-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.7,
+    "ai_reason": "GitHub org alex-llm does not match the underlying service Smithery; no evidence Smithery publishes this server.",
+    "cached_at": "2025-09-30 21:26:47 UTC",
+    "repository_url": "https://github.com/alex-llm/attAck-mcp-server",
+    "server_name": "ai.smithery/alex-llm-attack-mcp-server"
+  },
+  "https://github.com/alphago2580/naramarketmcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "GitHub repo is under 'alphago2580' (not a G2B/Nara Market org), remotes are on smithery.ai (not an official government domain), so not published by the original data source owner.",
+    "cached_at": "2025-09-30 21:26:50 UTC",
+    "repository_url": "https://github.com/alphago2580/naramarketmcp",
+    "server_name": "ai.smithery/alphago2580-naramarketmcp"
+  },
+  "https://github.com/anirbanbasu/frankfurtermcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub user anirbanbasu is not affiliated with the Frankfurter API brand, and remotes reference smithery.ai, not frankfurter.app.",
+    "cached_at": "2025-09-30 21:26:52 UTC",
+    "repository_url": "https://github.com/anirbanbasu/frankfurtermcp",
+    "server_name": "ai.smithery/anirbanbasu-frankfurtermcp"
+  },
+  "https://github.com/anirbanbasu/pymcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.8,
+    "ai_reason": "Repository is owned by a personal user (anirbanbasu), not by the Smithery organization, and functions as a template rather than an official server.",
+    "cached_at": "2025-09-30 21:26:54 UTC",
+    "repository_url": "https://github.com/anirbanbasu/pymcp",
+    "server_name": "ai.smithery/anirbanbasu-pymcp"
+  },
+  "https://github.com/arjunkmrm/ahoy": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "Repo owned by user arjunkmrm, not Smithery org; not published by the smithery.ai organization.",
+    "cached_at": "2025-09-30 21:26:56 UTC",
+    "repository_url": "https://github.com/arjunkmrm/ahoy",
+    "server_name": "ai.smithery/arjunkmrm-ahoy"
+  },
+  "https://github.com/arjunkmrm/clock": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "The repo is owned by a user (arjunkmrm), not the Smithery organization, and the remote is hosted on smithery.ai but without evidence it is published by Smithery itself.",
+    "cached_at": "2025-09-30 21:26:58 UTC",
+    "repository_url": "https://github.com/arjunkmrm/clock",
+    "server_name": "ai.smithery/arjunkmrm-clock"
+  },
+  "https://github.com/arjunkmrm/lta-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "GitHub user 'arjunkmrm' (not an org) publishes the repo and the MCP remote is hosted under smithery.ai, which does not match the brand or official domain for Singapore LTA.",
+    "cached_at": "2025-09-30 21:27:01 UTC",
+    "repository_url": "https://github.com/arjunkmrm/lta-mcp",
+    "server_name": "ai.smithery/arjunkmrm-lta-mcp"
+  },
+  "https://github.com/arjunkmrm/perplexity-search": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repo owner arjunkmrm is a user, not Perplexity or its org; no Perplexity brand evidence in GitHub org, repo, or remotes.",
+    "cached_at": "2025-09-30 21:27:02 UTC",
+    "repository_url": "https://github.com/arjunkmrm/perplexity-search",
+    "server_name": "ai.smithery/arjunkmrm-perplexity-search"
+  },
+  "https://github.com/arjunkmrm/ScraperMcp_el": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "Repository is owned by a user (arjunkmrm), not the Smithery org; no direct evidence Smithery operates or publishes this server.",
+    "cached_at": "2025-09-30 21:27:04 UTC",
+    "repository_url": "https://github.com/arjunkmrm/ScraperMcp_el",
+    "server_name": "ai.smithery/arjunkmrm-scrapermcp_el"
+  },
+  "https://github.com/arjunkmrm/tutorials": {
+    "ai_decision": "community",
+    "ai_confidence": 0.8,
+    "ai_reason": "The publisher is a personal GitHub user (arjunkmrm), not an organization owning Smithery; remotes are on smithery.ai but without evidence the repo is official.",
+    "cached_at": "2025-09-30 21:27:14 UTC",
+    "repository_url": "https://github.com/arjunkmrm/tutorials",
+    "server_name": "ai.smithery/arjunkmrm-tutorials"
+  },
+  "https://github.com/aryankeluskar/poke-video-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "GitHub repo is under a personal user (aryankeluskar), not the Smithery org, and no evidence links it officially to the Smithery product or organization.",
+    "cached_at": "2025-09-30 21:27:16 UTC",
+    "repository_url": "https://github.com/aryankeluskar/poke-video-mcp",
+    "server_name": "ai.smithery/aryankeluskar-poke-video-mcp"
+  },
+  "https://github.com/bergeramit/bergeramit-hw3-tech": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "The repo owner is a user (bergeramit), not the Smithery org, so this is a third-party implementation for Smithery.",
+    "cached_at": "2025-09-30 21:27:18 UTC",
+    "repository_url": "https://github.com/bergeramit/bergeramit-hw3-tech",
+    "server_name": "ai.smithery/bergeramit-bergeramit-hw3-tech"
+  },
+  "https://github.com/bielacki/igdb-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "The repository is owned by user 'bielacki', not IGDB or its brand org, and remote is hosted on smithery.ai; no signals of official IGDB involvement.",
+    "cached_at": "2025-09-30 21:27:21 UTC",
+    "repository_url": "https://github.com/bielacki/igdb-mcp-server",
+    "server_name": "ai.smithery/bielacki-igdb-mcp-server"
+  },
+  "https://github.com/blacklotusdev8/test_m": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "The GitHub org 'blacklotusdev8' does not match the Smithery brand, and the remote is a user namespace; no evidence the publisher owns the 'smithery.ai' service.",
+    "cached_at": "2025-09-30 21:27:23 UTC",
+    "repository_url": "https://github.com/blacklotusdev8/test_m",
+    "server_name": "ai.smithery/blacklotusdev8-test_m"
+  },
+  "https://github.com/blbl147/xhs-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.97,
+    "ai_reason": "The GitHub org ('blbl147') does not match the brand of the integrated service ('小红书' / xiaohongshu), indicating this is a third-party implementation.",
+    "cached_at": "2025-09-30 21:27:32 UTC",
+    "repository_url": "https://github.com/blbl147/xhs-mcp",
+    "server_name": "ai.smithery/blbl147-xhs-mcp"
+  },
+  "https://github.com/blockscout/mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.7,
+    "ai_reason": "Remotes are hosted on smithery.ai rather than blockscout.com, suggesting third-party (Smithery) deployment for Blockscout.",
+    "cached_at": "2025-09-30 21:27:35 UTC",
+    "repository_url": "https://github.com/blockscout/mcp-server",
+    "server_name": "ai.smithery/blockscout-mcp-server"
+  },
+  "https://github.com/brave/brave-search-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "The server integrates with Brave Search, but is published by Smithery (ai.smithery) and remotes are hosted on smithery.ai, not Brave's domain.",
+    "cached_at": "2025-09-30 21:27:37 UTC",
+    "repository_url": "https://github.com/brave/brave-search-mcp-server",
+    "server_name": "ai.smithery/brave"
+  },
+  "https://github.com/callmybot/cookbook-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.8,
+    "ai_reason": "GitHub org 'callmybot' differs from Smithery (the referenced domain), and there is no evidence that 'callmybot' owns or operates Smithery.",
+    "cached_at": "2025-09-30 21:27:39 UTC",
+    "repository_url": "https://github.com/callmybot/cookbook-mcp-server",
+    "server_name": "ai.smithery/callmybot-cookbook-mcp-server"
+  },
+  "https://github.com/callmybot/domoticz": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "The GitHub org 'callmybot' is not the owner of Domoticz and the remote domain is smithery.ai, not domoticz.com.",
+    "cached_at": "2025-09-30 21:41:32 UTC",
+    "repository_url": "https://github.com/callmybot/domoticz",
+    "server_name": "ai.smithery/callmybot-domoticz"
+  },
+  "https://github.com/callmybot/hello-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "Publisher is 'callmybot', while the product/service referenced in the remote is 'smithery.ai'; no evidence 'callmybot' owns Smithery.",
+    "cached_at": "2025-09-30 21:41:35 UTC",
+    "repository_url": "https://github.com/callmybot/hello-mcp-server",
+    "server_name": "ai.smithery/callmybot-hello-mcp-server"
+  },
+  "https://github.com/cc25a/openai-api-agent-project": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "Smithery is not OpenAI, and there is no clear evidence that the repo is published by OpenAI; this is a third-party implementation.",
+    "cached_at": "2025-09-30 21:41:37 UTC",
+    "repository_url": "https://github.com/cc25a/openai-api-agent-project",
+    "server_name": "ai.smithery/cc25a-openai-api-agent-project123123123"
+  },
+  "https://github.com/cindyloo/dropbox-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "Publisher is 'cindyloo' and not Dropbox, so this is a third-party implementation for Dropbox.",
+    "cached_at": "2025-09-30 21:41:39 UTC",
+    "repository_url": "https://github.com/cindyloo/dropbox-mcp-server",
+    "server_name": "ai.smithery/cindyloo-dropbox-mcp-server"
+  },
+  "https://github.com/ctaylor86/mcp-video-download-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "The repository is published by a user (ctaylor86), not the Smithery org, indicating a third-party implementation despite remotes on smithery.ai.",
+    "cached_at": "2025-09-30 21:41:41 UTC",
+    "repository_url": "https://github.com/ctaylor86/mcp-video-download-server",
+    "server_name": "ai.smithery/ctaylor86-mcp-video-download-server"
+  },
+  "https://github.com/demomagic/duckchain-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.8,
+    "ai_reason": "GitHub org 'demomagic' does not match Smithery brand in server name or remote domain; remote is on smithery.ai but repo owner is third-party.",
+    "cached_at": "2025-09-30 21:41:45 UTC",
+    "repository_url": "https://github.com/demomagic/duckchain-mcp",
+    "server_name": "ai.smithery/demomagic-duckchain-mcp"
+  },
+  "https://github.com/devbrother2024/typescript-mcp-server-boilerplate": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "The GitHub org 'devbrother2024' differs from the product/service ('smithery.ai') and there is no evidence this is published by Smithery itself.",
+    "cached_at": "2025-09-30 21:41:48 UTC",
+    "repository_url": "https://github.com/devbrother2024/typescript-mcp-server-boilerplate",
+    "server_name": "ai.smithery/devbrother2024-typescript-mcp-server-boilerplate"
+  },
+  "https://github.com/docfork/docfork-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.8,
+    "ai_reason": "Repository is under the 'docfork' org, but the remote is on smithery.ai, so it is a third-party integration for Smithery, not published by Smithery itself.",
+    "cached_at": "2025-09-30 21:41:50 UTC",
+    "repository_url": "https://github.com/docfork/docfork-mcp",
+    "server_name": "ai.smithery/docfork-mcp"
+  },
+  "https://github.com/faithk7/gmail-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "The repository is published by 'faithk7' (not Google) for Gmail, which is generic and requires Google as publisher for official status.",
+    "cached_at": "2025-09-30 21:41:53 UTC",
+    "repository_url": "https://github.com/faithk7/gmail-mcp",
+    "server_name": "ai.smithery/faithk7-gmail-mcp"
+  },
+  "https://github.com/fengyinxia/jimeng-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "Repository is owned by user 'fengyinxia' (not an org), while remotes reference smithery.ai; no evidence the repo is published by Smithery's organization.",
+    "cached_at": "2025-09-30 21:41:55 UTC",
+    "repository_url": "https://github.com/fengyinxia/jimeng-mcp",
+    "server_name": "ai.smithery/fengyinxia-jimeng-mcp"
+  },
+  "https://github.com/hithereiamaliff/mcp-datagovmy": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repository owner 'hithereiamaliff' and org 'smithery.ai' do not match or represent Malaysia's government open data brand; no signals of official ownership.",
+    "cached_at": "2025-09-30 21:41:57 UTC",
+    "repository_url": "https://github.com/hithereiamaliff/mcp-datagovmy",
+    "server_name": "ai.smithery/hithereiamaliff-mcp-datagovmy"
+  },
+  "https://github.com/hithereiamaliff/mcp-nextcloud": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "The repository is owned by user 'hithereiamaliff', not by Nextcloud's official organization, and there is no evidence of official branding.",
+    "cached_at": "2025-09-30 21:41:59 UTC",
+    "repository_url": "https://github.com/hithereiamaliff/mcp-nextcloud",
+    "server_name": "ai.smithery/hithereiamaliff-mcp-nextcloud"
+  },
+  "https://github.com/hollaugo/tutorials": {
+    "ai_decision": "community",
+    "ai_confidence": 0.6,
+    "ai_reason": "The GitHub org 'hollaugo' does not match the product/service brand 'smithery', and the repo is under 'hollaugo', not a verified 'smithery' org.",
+    "cached_at": "2025-09-30 21:42:01 UTC",
+    "repository_url": "https://github.com/hollaugo/tutorials",
+    "server_name": "ai.smithery/hollaugo-financial-research-mcp-server"
+  },
+  "https://github.com/hustcc/mcp-mermaid": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "The GitHub org 'hustcc' does not match the 'mermaid' product/brand; remote is on 'smithery.ai' which does not indicate ownership by Mermaid's creators.",
+    "cached_at": "2025-09-30 21:42:04 UTC",
+    "repository_url": "https://github.com/hustcc/mcp-mermaid",
+    "server_name": "ai.smithery/hustcc-mcp-mermaid"
+  },
+  "https://github.com/isnow890/data4library-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repository is under a personal user (isnow890), not an org related to data4library; no evidence of brand ownership.",
+    "cached_at": "2025-09-30 21:42:07 UTC",
+    "repository_url": "https://github.com/isnow890/data4library-mcp",
+    "server_name": "ai.smithery/isnow890-data4library-mcp"
+  },
+  "https://github.com/jessicayanwang/frankfurtermcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.98,
+    "ai_reason": "GitHub repo owner jessicayanwang does not match the Frankfurter service brand; strong signal of community implementation.",
+    "cached_at": "2025-09-30 21:42:09 UTC",
+    "repository_url": "https://github.com/jessicayanwang/frankfurtermcp",
+    "server_name": "ai.smithery/jessicayanwang-test"
+  },
+  "https://github.com/jirispilka/actors-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "The GitHub owner 'jirispilka' is a user, not an organization, and there is no match between the repo owner and the 'smithery.ai' brand.",
+    "cached_at": "2025-09-30 21:42:12 UTC",
+    "repository_url": "https://github.com/jirispilka/actors-mcp-server",
+    "server_name": "ai.smithery/jirispilka-actors-mcp-server"
+  },
+  "https://github.com/jjlabsio/korea-stock-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.8,
+    "ai_reason": "Organization jjlabsio is not the owner/operator of the Korean stock market data; server integrates an external product with no strong evidence of first-party ownership.",
+    "cached_at": "2025-09-30 21:42:14 UTC",
+    "repository_url": "https://github.com/jjlabsio/korea-stock-mcp",
+    "server_name": "ai.smithery/jjlabsio-korea-stock-mcp"
+  },
+  "https://github.com/keithah/hostex-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "Repo is under keithah user, not the official Hostex org; no evidence Hostex is the publisher.",
+    "cached_at": "2025-09-30 21:42:16 UTC",
+    "repository_url": "https://github.com/keithah/hostex-mcp",
+    "server_name": "ai.smithery/keithah-hostex-mcp"
+  },
+  "https://github.com/keithah/tessie-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "The repository is under the 'keithah' user (not an org), the description calls it 'Unofficial', and there is no strong link to a product-owning organization.",
+    "cached_at": "2025-09-30 21:42:19 UTC",
+    "repository_url": "https://github.com/keithah/tessie-mcp",
+    "server_name": "ai.smithery/keithah-tessie-mcp"
+  },
+  "https://github.com/kesslerio/attio-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.8,
+    "ai_reason": "Repository is owned by 'kesslerio', not Attio, so it is a third-party integration for Attio CRM.",
+    "cached_at": "2025-09-30 21:42:21 UTC",
+    "repository_url": "https://github.com/kesslerio/attio-mcp-server",
+    "server_name": "ai.smithery/kesslerio-attio-mcp-server"
+  },
+  "https://github.com/kkjdaniel/bgg-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repo owned by user kkjdaniel, not BoardGameGeek; no evidence of official brand org involvement.",
+    "cached_at": "2025-09-30 21:42:23 UTC",
+    "repository_url": "https://github.com/kkjdaniel/bgg-mcp",
+    "server_name": "ai.smithery/kkjdaniel-bgg-mcp"
+  },
+  "https://github.com/kwp-lab/rss-reader-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "RSS is a generic service and kwp-lab is not the owner of any major RSS product; remotes reference smithery.ai but no clear brand ownership.",
+    "cached_at": "2025-09-30 21:42:25 UTC",
+    "repository_url": "https://github.com/kwp-lab/rss-reader-mcp",
+    "server_name": "ai.smithery/kwp-lab-rss-reader-mcp"
+  },
+  "https://github.com/lineex/pubmed-mcp-smithery": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "The publisher (lineex) and remotes (smithery.ai) are not affiliated with PubMed; PubMed is owned by NCBI/NLM/NIH.",
+    "cached_at": "2025-09-30 21:42:27 UTC",
+    "repository_url": "https://github.com/lineex/pubmed-mcp-smithery",
+    "server_name": "ai.smithery/lineex-pubmed-mcp-smithery"
+  },
+  "https://github.com/lukaskostka99/marketing-miner-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "GitHub user lukaskostka99 published integration for Marketing Miner but is not the official brand/org; remote is smithery.ai, unrelated to marketingminer.com.",
+    "cached_at": "2025-09-30 21:42:29 UTC",
+    "repository_url": "https://github.com/lukaskostka99/marketing-miner-mcp",
+    "server_name": "ai.smithery/lukaskostka99-marketing-miner-mcp"
+  },
+  "https://github.com/magenie33/quality-dimension-generator": {
+    "ai_decision": "community",
+    "ai_confidence": 0.8,
+    "ai_reason": "The GitHub org 'magenie33' does not match or represent 'smithery.ai', and there is no evidence it is officially published by Smithery; appears to be a third-party integration.",
+    "cached_at": "2025-09-30 21:42:31 UTC",
+    "repository_url": "https://github.com/magenie33/quality-dimension-generator",
+    "server_name": "ai.smithery/magenie33-quality-dimension-generator"
+  },
+  "https://github.com/mfukushim/map-traveler-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "The repository is owned by 'mfukushim' (not Google), while it integrates with Google Maps, so it is a third-party community server.",
+    "cached_at": "2025-09-30 21:42:33 UTC",
+    "repository_url": "https://github.com/mfukushim/map-traveler-mcp",
+    "server_name": "ai.smithery/mfukushim-map-traveler-mcp"
+  },
+  "https://github.com/miguelgarzons/mcp-cun": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "Repository is under a user account (miguelgarzons), not the smithery organization, despite using a smithery.ai remote.",
+    "cached_at": "2025-09-30 21:42:35 UTC",
+    "repository_url": "https://github.com/miguelgarzons/mcp-cun",
+    "server_name": "ai.smithery/miguelgarzons-mcp-cun"
+  },
+  "https://github.com/minionszyw/bazi": {
+    "ai_decision": "community",
+    "ai_confidence": 0.8,
+    "ai_reason": "The GitHub org 'minionszyw' does not match 'smithery' or 'smithery.ai', and there is no evidence the repo owner is the brand/service operator.",
+    "cached_at": "2025-09-30 21:42:37 UTC",
+    "repository_url": "https://github.com/minionszyw/bazi",
+    "server_name": "ai.smithery/minionszyw-bazi"
+  },
+  "https://github.com/mjucius/cozi_mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.97,
+    "ai_reason": "Repo owned by user 'mjucius', not Cozi org; remotes and org are unrelated to Cozi brand.",
+    "cached_at": "2025-09-30 21:42:39 UTC",
+    "repository_url": "https://github.com/mjucius/cozi_mcp",
+    "server_name": "ai.smithery/mjucius-cozi_mcp"
+  },
+  "https://github.com/morosss/sdfsdf": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub repo is under user 'morosss', not the Smithery org, despite remotes on smithery.ai.",
+    "cached_at": "2025-09-30 21:42:41 UTC",
+    "repository_url": "https://github.com/morosss/sdfsdf",
+    "server_name": "ai.smithery/morosss-sdfsdf"
+  },
+  "https://github.com/mrugankpednekar/bill_splitter_mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.75,
+    "ai_reason": "GitHub repo is under a user (mrugankpednekar) and not the org that owns the product (Smithery); no evidence it's published by Smithery.",
+    "cached_at": "2025-09-30 21:42:43 UTC",
+    "repository_url": "https://github.com/mrugankpednekar/bill_splitter_mcp",
+    "server_name": "ai.smithery/mrugankpednekar-bill_splitter_mcp"
+  },
+  "https://github.com/neverinfamous/memory-journal-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.7,
+    "ai_reason": "The repository is under the 'neverinfamous' org and not 'smithery'; main remote is on smithery.ai but publisher is a third party.",
+    "cached_at": "2025-09-30 21:42:45 UTC",
+    "repository_url": "https://github.com/neverinfamous/memory-journal-mcp",
+    "server_name": "ai.smithery/neverinfamous-memory-journal-mcp"
+  },
+  "https://github.com/oxylabs/oxylabs-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "Although the repository is under the oxylabs org and the integration is for Oxylabs, the remote endpoint is hosted on smithery.ai, not an official Oxylabs domain, indicating third-party implementation.",
+    "cached_at": "2025-09-30 21:42:47 UTC",
+    "repository_url": "https://github.com/oxylabs/oxylabs-mcp",
+    "server_name": "ai.smithery/oxylabs-oxylabs-mcp"
+  },
+  "https://github.com/pinion05/supabase-mcp-lite": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repo owner 'pinion05' is not Supabase; remotes use 'smithery.ai', not an official Supabase domain.",
+    "cached_at": "2025-09-30 21:42:48 UTC",
+    "repository_url": "https://github.com/pinion05/supabase-mcp-lite",
+    "server_name": "ai.smithery/pinion05-supabase-mcp-lite"
+  },
+  "https://github.com/pinkpixel-dev/web-scout-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.8,
+    "ai_reason": "The GitHub org 'pinkpixel-dev' differs from 'smithery.ai', indicating a third-party implementation for Smithery's service.",
+    "cached_at": "2025-09-30 21:42:50 UTC",
+    "repository_url": "https://github.com/pinkpixel-dev/web-scout-mcp",
+    "server_name": "ai.smithery/pinkpixel-dev-web-scout-mcp"
+  },
+  "https://github.com/plainyogurt21/sec-edgar-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "The publisher 'plainyogurt21' is not the SEC or an official government organization; no evidence of SEC brand ownership.",
+    "cached_at": "2025-09-30 21:42:51 UTC",
+    "repository_url": "https://github.com/plainyogurt21/sec-edgar-mcp",
+    "server_name": "ai.smithery/plainyogurt21-sec-edgar-mcp"
+  },
+  "https://github.com/rainbowgore/stealthee-MCP-tools": {
+    "ai_decision": "community",
+    "ai_confidence": 0.75,
+    "ai_reason": "GitHub org (rainbowgore) and repository do not match the product (smithery.ai) in remote; lacks official branding signals.",
+    "cached_at": "2025-09-30 21:42:53 UTC",
+    "repository_url": "https://github.com/rainbowgore/stealthee-MCP-tools",
+    "server_name": "ai.smithery/rainbowgore-stealthee-mcp-tools"
+  },
+  "https://github.com/ramadasmr/networkcalc-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "The repo is under a personal user (ramadasmr) and not the Smithery organization; remotes use Smithery's domain but publisher is third-party.",
+    "cached_at": "2025-09-30 21:42:56 UTC",
+    "repository_url": "https://github.com/ramadasmr/networkcalc-mcp",
+    "server_name": "ai.smithery/ramadasmr-networkcalc-mcp"
+  },
+  "https://github.com/renCosta2025/context7fork": {
+    "ai_decision": "community",
+    "ai_confidence": 0.8,
+    "ai_reason": "GitHub org 'renCosta2025' does not match 'smithery', and there is no evidence it is operated by the Smithery organization.",
+    "cached_at": "2025-09-30 21:42:58 UTC",
+    "repository_url": "https://github.com/renCosta2025/context7fork",
+    "server_name": "ai.smithery/renCosta2025-context7fork"
+  },
+  "https://github.com/rfdez/pvpc-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "The repo is owned by a personal user ('rfdez'), not Red Eléctrica, and the remote is hosted on smithery.ai—a third party.",
+    "cached_at": "2025-09-30 21:43:00 UTC",
+    "repository_url": "https://github.com/rfdez/pvpc-mcp-server",
+    "server_name": "ai.smithery/rfdez-pvpc-mcp-server"
+  },
+  "https://github.com/sebastianall1977/gmail-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "Publisher is a user (sebastianall1977) and not Google; 'gmail' is a generic service requiring Google ownership for Official status.",
+    "cached_at": "2025-09-30 21:43:02 UTC",
+    "repository_url": "https://github.com/sebastianall1977/gmail-mcp",
+    "server_name": "ai.smithery/sebastianall1977-gmail-mcp"
+  },
+  "https://github.com/serkan-ozal/driflyte-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "Repository owner is a user (serkan-ozal), not an organization matching 'Smithery' or 'Driflyte', despite remote referencing smithery.ai.",
+    "cached_at": "2025-09-30 21:43:05 UTC",
+    "repository_url": "https://github.com/serkan-ozal/driflyte-mcp-server",
+    "server_name": "ai.smithery/serkan-ozal-driflyte-mcp-server"
+  },
+  "https://github.com/slhad/aha-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "The GitHub org 'slhad' and domain 'smithery.ai' do not belong to the Home Assistant project, indicating a third-party integration.",
+    "cached_at": "2025-09-30 21:43:07 UTC",
+    "repository_url": "https://github.com/slhad/aha-mcp",
+    "server_name": "ai.smithery/slhad-aha-mcp"
+  },
+  "https://github.com/smithery-ai/smithery-cookbook": {
+    "ai_decision": "official",
+    "ai_confidence": 0.95,
+    "ai_reason": "The GitHub org 'smithery-ai' matches the product/brand 'smithery.ai', the remote is on the smithery.ai domain, and there is no indication the repo is a fork or archived.",
+    "cached_at": "2025-09-30 21:43:10 UTC",
+    "repository_url": "https://github.com/smithery-ai/smithery-cookbook",
+    "server_name": "ai.smithery/smithery-ai-cookbook-python-quickstart"
+  },
+  "https://github.com/smithery-ai/mcp-servers": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "Smithery-ai is not owned by GitHub and thus is a third-party publisher for a generic service (GitHub).",
+    "cached_at": "2025-09-30 21:43:13 UTC",
+    "repository_url": "https://github.com/smithery-ai/mcp-servers",
+    "server_name": "ai.smithery/smithery-ai-github"
+  },
+  "https://github.com/sunub/obsidian-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.8,
+    "ai_reason": "The GitHub org 'sunub' does not match Obsidian's brand, and there is no evidence Smithery owns Obsidian.",
+    "cached_at": "2025-09-30 21:43:16 UTC",
+    "repository_url": "https://github.com/sunub/obsidian-mcp-server",
+    "server_name": "ai.smithery/sunub-obsidian-mcp-server"
+  },
+  "https://github.com/xinkuang/china-stock-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "Repo is by org 'xinkuang' and integrates with Smithery ('smithery.ai') but 'xinkuang' does not appear to own or operate Smithery, indicating third-party implementation.",
+    "cached_at": "2025-09-30 21:43:18 UTC",
+    "repository_url": "https://github.com/xinkuang/china-stock-mcp",
+    "server_name": "ai.smithery/xinkuang-china-stock-mcp"
+  },
+  "https://github.com/yuna0x0/anilist-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "The publisher is yuna0x0 (user, not an organization) and does not match AniList, indicating a third-party implementation.",
+    "cached_at": "2025-09-30 21:43:20 UTC",
+    "repository_url": "https://github.com/yuna0x0/anilist-mcp",
+    "server_name": "ai.smithery/yuna0x0-anilist-mcp"
+  },
+  "https://github.com/yuna0x0/hackmd-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "Publisher yuna0x0 is not the HackMD organization; remote uses smithery.ai, indicating third-party integration, not official HackMD ownership.",
+    "cached_at": "2025-09-30 21:43:21 UTC",
+    "repository_url": "https://github.com/yuna0x0/hackmd-mcp",
+    "server_name": "ai.smithery/yuna0x0-hackmd-mcp"
+  },
+  "https://github.com/zeta-chain/cli": {
+    "ai_decision": "community",
+    "ai_confidence": 0.7,
+    "ai_reason": "The GitHub organization 'zeta-chain' develops the CLI but remote endpoints are hosted under 'smithery.ai', indicating integration by Smithery and not ZetaChain.",
+    "cached_at": "2025-09-30 21:43:23 UTC",
+    "repository_url": "https://github.com/zeta-chain/cli",
+    "server_name": "ai.smithery/zeta-chain-cli"
+  },
+  "https://github.com/zhaoganghao/hellomcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.7,
+    "ai_reason": "Repo owner is a user (zhaoganghao), not the Smithery org, so it is a third-party implementation despite using Smithery's domain.",
+    "cached_at": "2025-09-30 21:43:26 UTC",
+    "repository_url": "https://github.com/zhaoganghao/hellomcp",
+    "server_name": "ai.smithery/zhaoganghao-hellomcp"
+  },
+  "https://github.com/zwldarren/akshare-one-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repo is owned by a personal user (zwldarren), not an organization matching 'akshare' or 'smithery', so it is a third-party implementation.",
+    "cached_at": "2025-09-30 21:43:28 UTC",
+    "repository_url": "https://github.com/zwldarren/akshare-one-mcp",
+    "server_name": "ai.smithery/zwldarren-akshare-one-mcp"
+  },
+  "https://github.com/toolprint/hypertool-mcp": {
+    "ai_decision": "official",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub organization 'toolprint' matches the product in server name and npm package scope is '@toolprint', indicating official ownership.",
+    "cached_at": "2025-09-30 21:43:31 UTC",
+    "repository_url": "https://github.com/toolprint/hypertool-mcp",
+    "server_name": "ai.toolprint/hypertool-mcp"
+  },
+  "https://github.com/waystation-ai/mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.98,
+    "ai_reason": "The GitHub org (waystation-ai) does not match Airtable's brand, and for a generic service like Airtable, only Airtable Inc. itself would be official.",
+    "cached_at": "2025-09-30 21:43:33 UTC",
+    "repository_url": "https://github.com/waystation-ai/mcp",
+    "server_name": "ai.waystation/airtable"
+  },
+  "https://github.com/thoughtspot/mcp-server": {
+    "ai_decision": "official",
+    "ai_confidence": 1.0,
+    "ai_reason": "GitHub org 'thoughtspot' matches product 'ThoughtSpot' and all remotes use 'thoughtspot.app' domain.",
+    "cached_at": "2025-09-30 21:43:37 UTC",
+    "repository_url": "https://github.com/thoughtspot/mcp-server",
+    "server_name": "app.thoughtspot/mcp-server"
+  },
+  "https://github.com/martinellich/jooq-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "GitHub org/user 'martinellich' does not match the jOOQ brand (jooq.org), so this is a third-party implementation.",
+    "cached_at": "2025-09-30 21:43:39 UTC",
+    "repository_url": "https://github.com/martinellich/jooq-mcp",
+    "server_name": "ch.martinelli/jooq-mcp"
+  },
+  "https://github.com/wei/mymlh-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.8,
+    "ai_reason": "GitHub user 'wei' is not the MyMLH organization, and there is no evidence of official MyMLH branding or verified org status.",
+    "cached_at": "2025-09-30 21:43:41 UTC",
+    "repository_url": "https://github.com/wei/mymlh-mcp-server",
+    "server_name": "ci.git/mymlh-mcp-server"
+  },
+  "https://github.com/axiomhq/mcp": {
+    "ai_decision": "official",
+    "ai_confidence": 0.97,
+    "ai_reason": "GitHub org 'axiomhq' and remote endpoints 'mcp.axiom.co' both match the Axiom brand, indicating official ownership.",
+    "cached_at": "2025-09-30 21:43:42 UTC",
+    "repository_url": "https://github.com/axiomhq/mcp",
+    "server_name": "co.axiom/mcp"
+  },
+  "https://github.com/apify/apify-mcp-server": {
+    "ai_decision": "official",
+    "ai_confidence": 0.98,
+    "ai_reason": "Published by GitHub org 'apify' matching product and uses apify.com remote, signaling strong brand ownership.",
+    "cached_at": "2025-09-30 21:43:44 UTC",
+    "repository_url": "https://github.com/apify/apify-mcp-server",
+    "server_name": "com.apify/apify-mcp-server"
+  },
+  "https://github.com/BingoWon/apple-rag-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repository is under user 'BingoWon', not an Apple org, despite Apple branding in the name and description.",
+    "cached_at": "2025-09-30 21:43:46 UTC",
+    "repository_url": "https://github.com/BingoWon/apple-rag-mcp",
+    "server_name": "com.apple-rag/mcp-server"
+  },
+  "https://github.com/DevCycleHQ/cli": {
+    "ai_decision": "official",
+    "ai_confidence": 0.95,
+    "ai_reason": "The GitHub org 'DevCycleHQ' matches the product 'DevCycle' in the server and remote domain, with branded endpoints and no negative signals.",
+    "cached_at": "2025-09-30 21:43:50 UTC",
+    "repository_url": "https://github.com/DevCycleHQ/cli",
+    "server_name": "com.devcycle/mcp"
+  },
+  "https://github.com/FalkorDB/QueryWeaver": {
+    "ai_decision": "community",
+    "ai_confidence": 0.75,
+    "ai_reason": "FalkorDB appears to be the publisher but the service is generic SQL, not tied to a proprietary FalkorDB product.",
+    "cached_at": "2025-09-30 21:43:53 UTC",
+    "repository_url": "https://github.com/FalkorDB/QueryWeaver",
+    "server_name": "com.falkordb/QueryWeaver"
+  },
+  "https://github.com/gibsonai/mcp": {
+    "ai_decision": "official",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub organization (gibsonai) and remote domain (gibsonai.com) both match the product/brand in server name (GibsonAI), indicating this is published by the brand owner.",
+    "cached_at": "2025-09-30 21:43:55 UTC",
+    "repository_url": "https://github.com/gibsonai/mcp",
+    "server_name": "com.gibsonai/mcp"
+  },
+  "https://github.com/iunera/druid-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.97,
+    "ai_reason": "The server is published by iunera, not Apache or the Druid project, so it is a third-party implementation.",
+    "cached_at": "2025-09-30 21:43:58 UTC",
+    "repository_url": "https://github.com/iunera/druid-mcp-server",
+    "server_name": "com.iunera/druid-mcp-server"
+  },
+  "https://github.com/joelverhagen/Knapcode.SampleMcpServer.git": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "Owned by a personal user (joelverhagen) and relates to a sample server, not an official product or service.",
+    "cached_at": "2025-09-30 21:43:59 UTC",
+    "repository_url": "https://github.com/joelverhagen/Knapcode.SampleMcpServer.git",
+    "server_name": "com.joelverhagen.mcp/Knapcode.SampleMcpServer"
+  },
+  "https://github.com/mintmcp/servers": {
+    "ai_decision": "community",
+    "ai_confidence": 0.98,
+    "ai_reason": "The org 'mintmcp' is not Google, and the integration is for Google Calendar; strong signal this is a third-party/community server.",
+    "cached_at": "2025-09-30 21:44:01 UTC",
+    "repository_url": "https://github.com/mintmcp/servers",
+    "server_name": "com.mintmcp/gcal"
+  },
+  "https://github.com/muxinc/mux-node-sdk": {
+    "ai_decision": "official",
+    "ai_confidence": 0.98,
+    "ai_reason": "GitHub org muxinc matches Mux brand; npm package under @mux and remote at mcp.mux.com confirm brand ownership.",
+    "cached_at": "2025-09-30 21:44:04 UTC",
+    "repository_url": "https://github.com/muxinc/mux-node-sdk",
+    "server_name": "com.mux/mcp"
+  },
+  "https://github.com/onkernel/kernel-mcp-server": {
+    "ai_decision": "official",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub organization 'onkernel' matches the product 'Kernel'; remote is on onkernel.com; clear brand ownership.",
+    "cached_at": "2025-09-30 21:44:07 UTC",
+    "repository_url": "https://github.com/onkernel/kernel-mcp-server",
+    "server_name": "com.onkernel/kernel-mcp-server"
+  },
+  "https://github.com/pulsemcp/mcp-servers": {
+    "ai_decision": "official",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub org pulsemcp matches server and npm scope (@pulsemcp), signaling official ownership of this PulseMCP product.",
+    "cached_at": "2025-09-30 21:44:11 UTC",
+    "repository_url": "https://github.com/pulsemcp/mcp-servers",
+    "server_name": "com.pulsemcp.servers/pulse-fetch"
+  },
+  "https://github.com/redpanda-data/docs-site": {
+    "ai_decision": "official",
+    "ai_confidence": 0.98,
+    "ai_reason": "GitHub org redpanda-data matches the product Redpanda and remote is on docs.redpanda.com.",
+    "cached_at": "2025-09-30 21:44:12 UTC",
+    "repository_url": "https://github.com/redpanda-data/docs-site",
+    "server_name": "com.redpanda/docs-mcp"
+  },
+  "https://github.com/jaw9c/mcp-registry-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.6,
+    "ai_reason": "Repository is under user jaw9c, not an organization matching remote-mcp or registry-mcp, with no clear official branding.",
+    "cached_at": "2025-09-30 21:44:14 UTC",
+    "repository_url": "https://github.com/jaw9c/mcp-registry-mcp",
+    "server_name": "com.remote-mcp/registry-mcp"
+  },
+  "https://github.com/ritza-co/acme-todo": {
+    "ai_decision": "community",
+    "ai_confidence": 0.8,
+    "ai_reason": "The acme-todo server is published by ritzaco (ritza-co), not an organization clearly matching 'acme' or an established todo product brand.",
+    "cached_at": "2025-09-30 21:44:16 UTC",
+    "repository_url": "https://github.com/ritza-co/acme-todo",
+    "server_name": "com.ritzademo/acme-todo"
+  },
+  "https://github.com/SmartBear/smartbear-mcp": {
+    "ai_decision": "official",
+    "ai_confidence": 1.0,
+    "ai_reason": "Published by the SmartBear organization on GitHub with product-matching org name and npm scope, not a fork or archived.",
+    "cached_at": "2025-09-30 21:44:18 UTC",
+    "repository_url": "https://github.com/SmartBear/smartbear-mcp",
+    "server_name": "com.smartbear/smartbear-mcp"
+  },
+  "https://github.com/teamwork/mcp": {
+    "ai_decision": "official",
+    "ai_confidence": 1.0,
+    "ai_reason": "GitHub org 'teamwork' exactly matches the product Teamwork.com, repository is not a fork or archived, and remotes are on the official teamwork.com domain.",
+    "cached_at": "2025-09-30 21:44:20 UTC",
+    "repository_url": "https://github.com/teamwork/mcp",
+    "server_name": "com.teamwork/mcp"
+  },
+  "https://github.com/cameroncooke/XcodeBuildMCP": {
+    "ai_decision": "community",
+    "ai_confidence": 0.98,
+    "ai_reason": "Repository is owned by user 'cameroncooke' rather than Apple, and Xcode is an Apple product.",
+    "cached_at": "2025-09-30 21:44:21 UTC",
+    "repository_url": "https://github.com/cameroncooke/XcodeBuildMCP",
+    "server_name": "com.xcodebuildmcp/XcodeBuildMCP"
+  },
+  "https://github.com/Zomato/mcp-server-manifest": {
+    "ai_decision": "official",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub org 'Zomato' matches the product in server name and remote is zomato.com.",
+    "cached_at": "2025-09-30 21:44:24 UTC",
+    "repository_url": "https://github.com/Zomato/mcp-server-manifest",
+    "server_name": "com.zomato/mcp"
+  },
+  "https://github.com/augmnt/augments-mcp-server": {
+    "ai_decision": "official",
+    "ai_confidence": 0.95,
+    "ai_reason": "The GitHub org ('augmnt') matches the product/brand in the server name and remote ('augments'), server remotes are on the augments.dev domain, and the package is under the same brand.",
+    "cached_at": "2025-09-30 21:44:26 UTC",
+    "repository_url": "https://github.com/augmnt/augments-mcp-server",
+    "server_name": "dev.augments/mcp"
+  },
+  "https://github.com/ComposioHQ/Rube": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "ComposioHQ is not the brand owner for Gmail, Slack, GitHub, or Notion; this is a third-party community integration for multiple services.",
+    "cached_at": "2025-09-30 21:44:28 UTC",
+    "repository_url": "https://github.com/ComposioHQ/Rube",
+    "server_name": "dev.composio.rube/rube"
+  },
+  "https://github.com/promplate/hmr": {
+    "ai_decision": "official",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub org 'promplate' matches server name 'promplate/hmr' and remotes use promplate.dev subdomain.",
+    "cached_at": "2025-09-30 21:44:30 UTC",
+    "repository_url": "https://github.com/promplate/hmr",
+    "server_name": "dev.promplate/hmr"
+  },
+  "https://github.com/francis-ros/rostro-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.7,
+    "ai_reason": "The repo is owned by a personal user (francis-ros), not an organization matching 'rostro' or 'rostro.dev'; no clear evidence of official brand ownership.",
+    "cached_at": "2025-09-30 21:44:31 UTC",
+    "repository_url": "https://github.com/francis-ros/rostro-mcp-server",
+    "server_name": "dev.rostro/rostro"
+  },
+  "https://github.com/khromov/svelte-llm-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repository is owned by a personal user (khromov), not an official Svelte organization, with no signals linking to the product's brand owner.",
+    "cached_at": "2025-09-30 21:44:33 UTC",
+    "repository_url": "https://github.com/khromov/svelte-llm-mcp",
+    "server_name": "garden.stanislav.svelte-llm/svelte-llm-mcp"
+  },
+  "https://github.com/balldontlie-api/mcp": {
+    "ai_decision": "official",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub org 'balldontlie-api' matches the service 'balldontlie', the remote is on balldontlie.io, and all signals indicate direct ownership.",
+    "cached_at": "2025-09-30 21:44:36 UTC",
+    "repository_url": "https://github.com/balldontlie-api/mcp",
+    "server_name": "io.balldontlie/mcp"
+  },
+  "https://github.com/foqal/mcp": {
+    "ai_decision": "official",
+    "ai_confidence": 0.97,
+    "ai_reason": "GitHub org ('foqal') matches product/brand in server name and remote endpoint is on the organization's domain.",
+    "cached_at": "2025-09-30 21:44:38 UTC",
+    "repository_url": "https://github.com/foqal/mcp",
+    "server_name": "io.foqal/Foqal"
+  },
+  "https://github.com/8beeeaaat/touchdesigner-mcp.git": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "The GitHub org '8beeeaaat' does not match the TouchDesigner brand; no evidence links the publisher to the official TouchDesigner organization.",
+    "cached_at": "2025-09-30 21:44:39 UTC",
+    "repository_url": "https://github.com/8beeeaaat/touchdesigner-mcp.git",
+    "server_name": "io.github.8beeeaaat/touchdesigner-mcp-server"
+  },
+  "https://github.com/Antonytm/mcp-all": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "The GitHub org 'Antonytm' does not match a known product/service brand, and evidence points to a personal or third-party community implementation.",
+    "cached_at": "2025-09-30 21:44:41 UTC",
+    "repository_url": "https://github.com/Antonytm/mcp-all",
+    "server_name": "io.github.Antonytm/mcp-all"
+  },
+  "https://github.com/Antonytm/mcp-sitecore-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub org 'Antonytm' does not match Sitecore brand, and Sitecore ownership is not evidenced.",
+    "cached_at": "2025-09-30 21:44:43 UTC",
+    "repository_url": "https://github.com/Antonytm/mcp-sitecore-server",
+    "server_name": "io.github.Antonytm/mcp-sitecore-server"
+  },
+  "https://github.com/AungMyoKyaw/betterprompt-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "The publisher is a personal GitHub user (AungMyoKyaw) and not an organization owning a recognizable underlying product or service.",
+    "cached_at": "2025-09-30 21:44:44 UTC",
+    "repository_url": "https://github.com/AungMyoKyaw/betterprompt-mcp",
+    "server_name": "io.github.AungMyoKyaw/betterprompt-mcp"
+  },
+  "https://github.com/BenAHammond/code-auditor-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "The repository owner is a personal user (BenAHammond), with no evidence of organization or brand ownership for 'code-auditor'; signals indicate a community project.",
+    "cached_at": "2025-09-30 21:44:46 UTC",
+    "repository_url": "https://github.com/BenAHammond/code-auditor-mcp",
+    "server_name": "io.github.BenAHammond/code-auditor-mcp"
+  },
+  "https://github.com/ChengJiale150/jupyter-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "Repository is published by a personal user (ChengJiale150) and not the official Jupyter organization.",
+    "cached_at": "2025-09-30 21:44:48 UTC",
+    "repository_url": "https://github.com/ChengJiale150/jupyter-mcp-server",
+    "server_name": "io.github.ChengJiale150/jupyter-mcp-server"
+  },
+  "https://github.com/ChiR24/Unreal_mcp.git": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "The GitHub owner 'ChiR24' is a user, not the Unreal Engine brand owner (Epic Games), indicating this is a third-party implementation.",
+    "cached_at": "2025-09-30 21:44:50 UTC",
+    "repository_url": "https://github.com/ChiR24/Unreal_mcp.git",
+    "server_name": "io.github.ChiR24/unreal-engine-mcp"
+  },
+  "https://github.com/ChromeDevTools/chrome-devtools-mcp": {
+    "ai_decision": "official",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub organization name ChromeDevTools exactly matches the integrated product, indicating direct brand ownership.",
+    "cached_at": "2025-09-30 21:44:52 UTC",
+    "repository_url": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
+    "server_name": "io.github.ChromeDevTools/chrome-devtools-mcp"
+  },
+  "https://github.com/CodeAlive-AI/codealive-mcp.git": {
+    "ai_decision": "official",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub Organization 'CodeAlive-AI' matches the product 'CodeAlive' in the server name, and all key signals (repo name, org, package namespace) are consistent with official ownership.",
+    "cached_at": "2025-09-30 21:44:56 UTC",
+    "repository_url": "https://github.com/CodeAlive-AI/codealive-mcp.git",
+    "server_name": "io.github.CodeAlive-AI/codealive-mcp"
+  },
+  "https://github.com/CodeLogicIncEngineering/codelogic-mcp-server": {
+    "ai_decision": "official",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub org CodeLogicIncEngineering matches the product CodeLogic referenced in server name, repo, and remotes.",
+    "cached_at": "2025-09-30 21:44:58 UTC",
+    "repository_url": "https://github.com/CodeLogicIncEngineering/codelogic-mcp-server",
+    "server_name": "io.github.CodeLogicIncEngineering/codelogic-mcp-server"
+  },
+  "https://github.com/CursorTouch/Windows-MCP": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "CursorTouch is not an official Microsoft or Windows organization, and there is no evidence it is published by the Windows brand owner.",
+    "cached_at": "2025-09-30 21:45:01 UTC",
+    "repository_url": "https://github.com/CursorTouch/Windows-MCP",
+    "server_name": "io.github.CursorTouch/Windows-MCP"
+  },
+  "https://github.com/DeanWard/HAL": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "Repository is owned by a user (DeanWard), not an organization, and does not match a major proprietary product/brand.",
+    "cached_at": "2025-09-30 21:45:03 UTC",
+    "repository_url": "https://github.com/DeanWard/HAL",
+    "server_name": "io.github.DeanWard/HAL"
+  },
+  "https://github.com/Decodo/mcp-web-scraper": {
+    "ai_decision": "community",
+    "ai_confidence": 0.8,
+    "ai_reason": "Decodo is not a widely recognized web scraping brand; package, repo, and org are self-published and not tied to a major product/service.",
+    "cached_at": "2025-09-30 21:45:05 UTC",
+    "repository_url": "https://github.com/Decodo/mcp-web-scraper",
+    "server_name": "io.github.Decodo/mcp-web-scraper"
+  },
+  "https://github.com/Flightradar24/fr24api-mcp": {
+    "ai_decision": "official",
+    "ai_confidence": 0.97,
+    "ai_reason": "GitHub org Flightradar24 matches the product name and owns both the repo and npm package namespace.",
+    "cached_at": "2025-09-30 21:45:07 UTC",
+    "repository_url": "https://github.com/Flightradar24/fr24api-mcp",
+    "server_name": "io.github.Flightradar24/fr24api-mcp"
+  },
+  "https://github.com/GLips/Figma-Context-MCP": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "The publisher GLips is not associated with Figma, and there is no evidence of official Figma branding in the organization, repo, or npm package.",
+    "cached_at": "2025-09-30 21:45:11 UTC",
+    "repository_url": "https://github.com/GLips/Figma-Context-MCP",
+    "server_name": "io.github.GLips/Figma-Context-MCP"
+  },
+  "https://github.com/testing9384/mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "Repository is owned by a personal GitHub user ('testing9384'), not an organization matching Microsoft or any product brand mentioned.",
+    "cached_at": "2025-09-30 21:45:12 UTC",
+    "repository_url": "https://github.com/testing9384/mcp-server",
+    "server_name": "io.github.GabrielaHdzMicrosoft/mcp-server"
+  },
+  "https://github.com/GitHub30/note-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "The repository is under a user account (GitHub30) not affiliated with note.com, indicating a third-party implementation for the note.com service.",
+    "cached_at": "2025-09-30 21:45:14 UTC",
+    "repository_url": "https://github.com/GitHub30/note-mcp-server",
+    "server_name": "io.github.GitHub30/note-mcp-server"
+  },
+  "https://github.com/GitHub30/qiita-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "The repository is owned by a personal user (GitHub30), not by Qiita's official organization.",
+    "cached_at": "2025-09-30 21:45:15 UTC",
+    "repository_url": "https://github.com/GitHub30/qiita-mcp-server",
+    "server_name": "io.github.GitHub30/qiita-mcp-server"
+  },
+  "https://github.com/GitHub30/zenn-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "GitHub repo owner is a user (GitHub30), not the Zenn organization, with no strong signals of official Zenn ownership.",
+    "cached_at": "2025-09-30 21:45:18 UTC",
+    "repository_url": "https://github.com/GitHub30/zenn-mcp-server",
+    "server_name": "io.github.GitHub30/zenn-mcp-server"
+  },
+  "https://github.com/GoneTone/mcp-server-taiwan-weather": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "The publisher (GoneTone) is not the official owner of the Taiwan Central Weather Administration API; organization and package names do not match the official brand.",
+    "cached_at": "2025-09-30 21:45:20 UTC",
+    "repository_url": "https://github.com/GoneTone/mcp-server-taiwan-weather",
+    "server_name": "io.github.GoneTone/mcp-server-taiwan-weather"
+  },
+  "https://github.com/GoogleCloudPlatform/gemini-cloud-assist-mcp": {
+    "ai_decision": "official",
+    "ai_confidence": 1.0,
+    "ai_reason": "Published by the verified GoogleCloudPlatform organization with npm package under @google-cloud, matching an official Google Cloud service.",
+    "cached_at": "2025-09-30 21:45:21 UTC",
+    "repository_url": "https://github.com/GoogleCloudPlatform/gemini-cloud-assist-mcp",
+    "server_name": "io.github.GoogleCloudPlatform/gemini-cloud-assist-mcp"
+  },
+  "https://github.com/IvanMurzak/Unity-MCP": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "The repository is owned by a personal user (IvanMurzak) and not by Unity Technologies, which owns Unity Engine.",
+    "cached_at": "2025-09-30 21:45:23 UTC",
+    "repository_url": "https://github.com/IvanMurzak/Unity-MCP",
+    "server_name": "io.github.IvanMurzak/Unity-MCP"
+  },
+  "https://github.com/JustasMonkev/mcp-accessibility-scanner": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "Repository is owned by a personal GitHub user (JustasMonkev), not by the maintainers of Playwright or Axe-core.",
+    "cached_at": "2025-09-30 21:45:25 UTC",
+    "repository_url": "https://github.com/JustasMonkev/mcp-accessibility-scanner",
+    "server_name": "io.github.JustasMonkev/mcp-accessibility-scanner"
+  },
+  "https://github.com/KylinMountain/web-fetch-mcp.git": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "The publisher is the 'KylinMountain' GitHub user (not a Gemini/Google org), and 'Gemini' is a generic service requiring actual brand ownership for official.",
+    "cached_at": "2025-09-30 21:45:28 UTC",
+    "repository_url": "https://github.com/KylinMountain/web-fetch-mcp.git",
+    "server_name": "io.github.KylinMountain/web-fetch-mcp"
+  },
+  "https://github.com/LinuxSuRen/atest-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "LinuxSuRen is a personal username not a verified org, and no strong product/brand ownership ties to any known product.",
+    "cached_at": "2025-09-30 21:45:30 UTC",
+    "repository_url": "https://github.com/LinuxSuRen/atest-mcp-server",
+    "server_name": "io.github.LinuxSuRen/atest-mcp-server"
+  },
+  "https://github.com/Lyellr88/MARM-Systems": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "Published by a personal user (Lyellr88) rather than an official organization for the underlying service.",
+    "cached_at": "2025-09-30 21:45:32 UTC",
+    "repository_url": "https://github.com/Lyellr88/MARM-Systems",
+    "server_name": "io.github.Lyellr88/marm-mcp-server"
+  },
+  "https://github.com/MR901/mcp-plots": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "Publisher MR901 is a personal user, not the Mermaid brand or organization.",
+    "cached_at": "2025-09-30 21:45:33 UTC",
+    "repository_url": "https://github.com/MR901/mcp-plots",
+    "server_name": "io.github.MR901/mcp-plots"
+  },
+  "https://github.com/MR901/plots-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "The GitHub owner MR901 is a user, does not match a known product or brand, and there is no evidence of official brand ownership.",
+    "cached_at": "2025-09-30 21:45:36 UTC",
+    "repository_url": "https://github.com/MR901/plots-mcp",
+    "server_name": "io.github.MR901/plots-mcp"
+  },
+  "https://github.com/MasonChow/source-map-parser-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repository is owned by a personal user (MasonChow) rather than an organization associated with source maps or JavaScript tooling brands.",
+    "cached_at": "2025-09-30 21:45:38 UTC",
+    "repository_url": "https://github.com/MasonChow/source-map-parser-mcp",
+    "server_name": "io.github.MasonChow/source-map-parser-mcp"
+  },
+  "https://github.com/NitishGourishetty/contextual-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repo owned by personal user (NitishGourishetty), not Contextual AI organization.",
+    "cached_at": "2025-09-30 21:45:40 UTC",
+    "repository_url": "https://github.com/NitishGourishetty/contextual-mcp-server",
+    "server_name": "io.github.NitishGourishetty/contextual-mcp-server"
+  },
+  "https://github.com/OpenCageData/opencage-geocoding-mcp": {
+    "ai_decision": "official",
+    "ai_confidence": 0.98,
+    "ai_reason": "The GitHub organization (OpenCageData) matches the product (OpenCage geocoding), is not generic, and package namespace (@opencage) is controlled by the org.",
+    "cached_at": "2025-09-30 21:45:42 UTC",
+    "repository_url": "https://github.com/OpenCageData/opencage-geocoding-mcp",
+    "server_name": "io.github.OpenCageData/opencage-geocoding-mcp"
+  },
+  "https://github.com/OtherVibes/mcp-as-a-judge": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "GitHub org 'OtherVibes' does not match a known product/service brand in the server name or description.",
+    "cached_at": "2025-09-30 21:45:44 UTC",
+    "repository_url": "https://github.com/OtherVibes/mcp-as-a-judge",
+    "server_name": "io.github.OtherVibes/mcp-as-a-judge"
+  },
+  "https://github.com/PV-Bhat/vibe-check-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repo is owned by a personal user (PV-Bhat), not an organization matching a recognized product/service brand.",
+    "cached_at": "2025-09-30 21:45:45 UTC",
+    "repository_url": "https://github.com/PV-Bhat/vibe-check-mcp-server",
+    "server_name": "io.github.PV-Bhat/vibe-check-mcp-server"
+  },
+  "https://github.com/Raistlin82/btp-sap-odata-to-mcp-server-optimized": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub repo is owned by a user (Raistlin82), not by SAP or an SAP-verified org.",
+    "cached_at": "2025-09-30 21:45:48 UTC",
+    "repository_url": "https://github.com/Raistlin82/btp-sap-odata-to-mcp-server-optimized",
+    "server_name": "io.github.Raistlin82/btp-sap-odata-to-mcp-server-optimized"
+  },
+  "https://github.com/Saidiibrahim/search-papers": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "Repo is under a user account (Saidiibrahim) not the arXiv org, with no official branding or verified signals.",
+    "cached_at": "2025-09-30 21:45:52 UTC",
+    "repository_url": "https://github.com/Saidiibrahim/search-papers",
+    "server_name": "io.github.Saidiibrahim/search-papers"
+  },
+  "https://github.com/Selenium39/mcp-server-tempmail": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "The publisher is the GitHub user Selenium39, not the ChatTempMail organization, and there is no evidence of official association.",
+    "cached_at": "2025-09-30 21:45:53 UTC",
+    "repository_url": "https://github.com/Selenium39/mcp-server-tempmail",
+    "server_name": "io.github.Selenium39/mcp-server-tempmail"
+  },
+  "https://github.com/SnowLeopard-AI/bigquery-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "Published by SnowLeopard-AI for Google BigQuery, but SnowLeopard-AI is not Google so it is a third-party integration.",
+    "cached_at": "2025-09-30 21:45:55 UTC",
+    "repository_url": "https://github.com/SnowLeopard-AI/bigquery-mcp",
+    "server_name": "io.github.SnowLeopard-AI/bigquery-mcp"
+  },
+  "https://github.com/SonarSource/sonarqube-mcp-server": {
+    "ai_decision": "official",
+    "ai_confidence": 0.98,
+    "ai_reason": "GitHub organization 'SonarSource' owns both the repo and the SonarQube product brand, with matching naming and no negative signals.",
+    "cached_at": "2025-09-30 21:45:57 UTC",
+    "repository_url": "https://github.com/SonarSource/sonarqube-mcp-server",
+    "server_name": "io.github.SonarSource/sonarqube-mcp-server"
+  },
+  "https://github.com/Synclub-tech/Synclub-dxt": {
+    "ai_decision": "official",
+    "ai_confidence": 0.9,
+    "ai_reason": "The GitHub organization 'Synclub-tech' matches the product name 'SynClub' in the server and repo, indicating direct ownership.",
+    "cached_at": "2025-09-30 21:46:00 UTC",
+    "repository_url": "https://github.com/Synclub-tech/Synclub-dxt",
+    "server_name": "io.github.Synclub-tech/synclub-dxt"
+  },
+  "https://github.com/TonySimonovsky/claude-code-conversation-search-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub repo is owned by a personal user (TonySimonovsky) and not Anthropic, which owns Claude.",
+    "cached_at": "2025-09-30 21:46:03 UTC",
+    "repository_url": "https://github.com/TonySimonovsky/claude-code-conversation-search-mcp",
+    "server_name": "io.github.TonySimonovsky/claude-code-conversation-search-mcp"
+  },
+  "https://github.com/YinTokey/mcp_hackernews": {
+    "ai_decision": "community",
+    "ai_confidence": 0.96,
+    "ai_reason": "The repo owner YinTokey is not affiliated with Hacker News (owned by Y Combinator), so this is a community implementation.",
+    "cached_at": "2025-09-30 21:46:04 UTC",
+    "repository_url": "https://github.com/YinTokey/mcp_hackernews",
+    "server_name": "io.github.YinTokey/mcp_hackernews"
+  },
+  "https://github.com/abelljs/abell": {
+    "ai_decision": "community",
+    "ai_confidence": 0.6,
+    "ai_reason": "The GitHub org 'abelljs' is not a widely recognized brand; insufficient evidence the server integrates with a third-party product/service outside the maintainer's own project.",
+    "cached_at": "2025-09-30 21:46:06 UTC",
+    "repository_url": "https://github.com/abelljs/abell",
+    "server_name": "io.github.abelljs/abell"
+  },
+  "https://github.com/agentailor/slimcontext-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.6,
+    "ai_reason": "Publisher 'agentailor' does not clearly match 'SlimContext' brand; no verified org or strong evidence of official ownership.",
+    "cached_at": "2025-09-30 21:46:08 UTC",
+    "repository_url": "https://github.com/agentailor/slimcontext-mcp-server",
+    "server_name": "io.github.agentailor/slimcontext-mcp-server"
+  },
+  "https://github.com/alex-feel/mcp-context-server": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "The repository belongs to a personal GitHub user (alex-feel) and does not match any known product/service organization.",
+    "cached_at": "2025-09-30 21:46:10 UTC",
+    "repository_url": "https://github.com/alex-feel/mcp-context-server",
+    "server_name": "io.github.alex-feel/mcp-context-server"
+  },
+  "https://github.com/andrasfe/vulnicheck": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "The repository is owned by a personal GitHub user (andrasfe), not an organization tied to a specific product or brand.",
+    "cached_at": "2025-09-30 21:46:12 UTC",
+    "repository_url": "https://github.com/andrasfe/vulnicheck",
+    "server_name": "io.github.andrasfe/vulnicheck"
+  },
+  "https://github.com/anyproto/anytype-mcp": {
+    "ai_decision": "official",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub organization and npm scope are both 'anyproto', matching the product 'Anytype', with no negative signals and strong branding alignment.",
+    "cached_at": "2025-09-30 21:46:14 UTC",
+    "repository_url": "https://github.com/anyproto/anytype-mcp",
+    "server_name": "io.github.anyproto/anytype-mcp"
+  },
+  "https://github.com/appwrite/mcp-for-api": {
+    "ai_decision": "official",
+    "ai_confidence": 0.9,
+    "ai_reason": "GitHub organization 'appwrite' matches the product 'Appwrite' in the server name and repo, indicating official ownership.",
+    "cached_at": "2025-09-30 21:46:15 UTC",
+    "repository_url": "https://github.com/appwrite/mcp-for-api",
+    "server_name": "io.github.appwrite/mcp-for-api"
+  },
+  "https://github.com/arielbk/anki-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "The server integrates with Anki but is published by the user 'arielbk', not the Anki organization.",
+    "cached_at": "2025-09-30 21:46:17 UTC",
+    "repository_url": "https://github.com/arielbk/anki-mcp",
+    "server_name": "io.github.arielbk/anki-mcp"
+  },
+  "https://github.com/b1ff/atlassian-dc-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub org is b1ff, not Atlassian; no strong signals the publisher is the Bitbucket brand owner.",
+    "cached_at": "2025-09-30 21:46:19 UTC",
+    "repository_url": "https://github.com/b1ff/atlassian-dc-mcp",
+    "server_name": "io.github.b1ff/atlassian-dc-mcp-bitbucket"
+  },
+  "https://github.com/burningion/video-editing-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.8,
+    "ai_reason": "The GitHub owner 'burningion' is a personal user, not 'video-jungle'; no strong evidence this is published by the Video Jungle organization.",
+    "cached_at": "2025-09-30 21:46:22 UTC",
+    "repository_url": "https://github.com/burningion/video-editing-mcp",
+    "server_name": "io.github.burningion/video-editing-mcp"
+  },
+  "https://github.com/bytedance/UI-TARS-desktop": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "bytedance is not the owner of Chrome, Edge, or Firefox browsers and this server targets generic browser access.",
+    "cached_at": "2025-09-30 21:46:24 UTC",
+    "repository_url": "https://github.com/bytedance/UI-TARS-desktop",
+    "server_name": "io.github.bytedance/mcp-server-browser"
+  },
+  "https://github.com/chris-schra/mcp-funnel": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "The repository is under a personal GitHub user (chris-schra), not an org matching any product/brand; no evidence of official brand ownership.",
+    "cached_at": "2025-09-30 21:46:27 UTC",
+    "repository_url": "https://github.com/chris-schra/mcp-funnel",
+    "server_name": "io.github.chris-schra/mcp-funnel"
+  },
+  "https://github.com/clappia-dev/clappia-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.8,
+    "ai_reason": "The GitHub org 'clappia-dev' is unverified and does not clearly match the official Clappia brand, and the Docker image is under a user namespace ('okaru413').",
+    "cached_at": "2025-09-30 21:46:29 UTC",
+    "repository_url": "https://github.com/clappia-dev/clappia-mcp",
+    "server_name": "io.github.clappia-dev/clappia-mcp"
+  },
+  "https://github.com/cmpxchg16/mcp-ethical-hacking": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repository is owned by a personal user (cmpxchg16) and not by the LinkedIn or Reddit organizations.",
+    "cached_at": "2025-09-30 21:46:31 UTC",
+    "repository_url": "https://github.com/cmpxchg16/mcp-ethical-hacking",
+    "server_name": "io.github.cmpxchg16/mcp-ethical-hacking"
+  },
+  "https://github.com/containers/kubernetes-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "The publisher is the 'containers' GitHub org, which is not owned by Kubernetes or the Kubernetes brand owner, so this is a third-party integration.",
+    "cached_at": "2025-09-30 21:46:32 UTC",
+    "repository_url": "https://github.com/containers/kubernetes-mcp-server",
+    "server_name": "io.github.containers/kubernetes-mcp-server"
+  },
+  "https://github.com/cr7258/elasticsearch-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "GitHub org 'cr7258' does not match Elasticsearch or Elastic and is a personal user, indicating this is a third-party implementation.",
+    "cached_at": "2025-09-30 21:46:34 UTC",
+    "repository_url": "https://github.com/cr7258/elasticsearch-mcp-server",
+    "server_name": "io.github.cr7258/elasticsearch-mcp-server"
+  },
+  "https://github.com/croit/mcp-croit-ceph": {
+    "ai_decision": "official",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub org 'croit' matches product 'Croit', endpoints/reference to 'croit.io', and Docker image is under org—strong alignment with official signals.",
+    "cached_at": "2025-09-30 21:46:36 UTC",
+    "repository_url": "https://github.com/croit/mcp-croit-ceph",
+    "server_name": "io.github.croit/mcp-croit-ceph"
+  },
+  "https://github.com/cyanheads/git-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "The publisher ('cyanheads') is not the owner of Git and no official connection to Git is shown; thus, this is a community implementation.",
+    "cached_at": "2025-09-30 21:46:38 UTC",
+    "repository_url": "https://github.com/cyanheads/git-mcp-server",
+    "server_name": "io.github.cyanheads/git-mcp-server"
+  },
+  "https://github.com/cyanheads/mcp-ts-template": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "GitHub org 'cyanheads' does not match any underlying product/service and repo is a general template, not tied to an official platform.",
+    "cached_at": "2025-09-30 21:46:39 UTC",
+    "repository_url": "https://github.com/cyanheads/mcp-ts-template",
+    "server_name": "io.github.cyanheads/mcp-ts-template"
+  },
+  "https://github.com/cyanheads/pubmed-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "The publisher is cyanheads (not NCBI or PubMed), indicating a third-party community implementation for PubMed.",
+    "cached_at": "2025-09-30 21:46:41 UTC",
+    "repository_url": "https://github.com/cyanheads/pubmed-mcp-server",
+    "server_name": "io.github.cyanheads/pubmed-mcp-server"
+  },
+  "https://github.com/dba-i/mssql-dba": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "The publisher (dba-i) does not match Microsoft, the owner of MSSQL; org is not brand owner of the service.",
+    "cached_at": "2025-09-30 21:46:43 UTC",
+    "repository_url": "https://github.com/dba-i/mssql-dba",
+    "server_name": "io.github.dba-i/mssql-dba"
+  },
+  "https://github.com/delorenj/mcp-server-trello": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "The publisher delorenj is an individual GitHub user, not Atlassian (the owner of Trello), so this is a community implementation.",
+    "cached_at": "2025-09-30 21:46:45 UTC",
+    "repository_url": "https://github.com/delorenj/mcp-server-trello",
+    "server_name": "io.github.delorenj/mcp-server-trello"
+  },
+  "https://github.com/dockersamples/mcp-docker-release-information": {
+    "ai_decision": "community",
+    "ai_confidence": 0.6,
+    "ai_reason": "The repository is under the dockersamples org, which is not the official Docker organization, so brand ownership is not proven.",
+    "cached_at": "2025-09-30 21:46:46 UTC",
+    "repository_url": "https://github.com/dockersamples/mcp-docker-release-information",
+    "server_name": "io.github.dockersamples/mcp-docker-release-information"
+  },
+  "https://github.com/domdomegg/airtable-mcp-server.git": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "Repository is published by domdomegg (not Airtable), so it does not meet the 'official' criteria for generic service 'airtable'.",
+    "cached_at": "2025-09-30 21:46:49 UTC",
+    "repository_url": "https://github.com/domdomegg/airtable-mcp-server.git",
+    "server_name": "io.github.domdomegg/airtable-mcp-server"
+  },
+  "https://github.com/domdomegg/time-mcp-nuget.git": {
+    "ai_decision": "community",
+    "ai_confidence": 0.98,
+    "ai_reason": "The publisher is a personal GitHub user (domdomegg) and not an organization owning a time service; no strong brand ownership evidence.",
+    "cached_at": "2025-09-30 21:46:52 UTC",
+    "repository_url": "https://github.com/domdomegg/time-mcp-nuget.git",
+    "server_name": "io.github.domdomegg/time-mcp-nuget"
+  },
+  "https://github.com/domdomegg/time-mcp-pypi.git": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "The publisher is a personal GitHub user (domdomegg) and not an official organization for a time service product.",
+    "cached_at": "2025-09-30 21:46:54 UTC",
+    "repository_url": "https://github.com/domdomegg/time-mcp-pypi.git",
+    "server_name": "io.github.domdomegg/time-mcp-pypi"
+  },
+  "https://github.com/dubuqingfeng/gitlab-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.98,
+    "ai_reason": "Published by user 'dubuqingfeng', not an official GitLab organization, so not official for GitLab.",
+    "cached_at": "2025-09-30 21:46:56 UTC",
+    "repository_url": "https://github.com/dubuqingfeng/gitlab-mcp-server",
+    "server_name": "io.github.dubuqingfeng/gitlab-mcp-server"
+  },
+  "https://github.com/dynatrace-oss/Dynatrace-mcp": {
+    "ai_decision": "official",
+    "ai_confidence": 0.97,
+    "ai_reason": "GitHub org dynatrace-oss matches Dynatrace product, package namespace is @dynatrace-oss, and repo is not a fork or archived.",
+    "cached_at": "2025-09-30 21:46:58 UTC",
+    "repository_url": "https://github.com/dynatrace-oss/Dynatrace-mcp",
+    "server_name": "io.github.dynatrace-oss/Dynatrace-mcp"
+  },
+  "https://github.com/estruyf/vscode-demo-time": {
+    "ai_decision": "community",
+    "ai_confidence": 0.8,
+    "ai_reason": "The repository is under the estruyf user (not a verified organization) and there is no evidence that estruyf is the Demo Time brand owner.",
+    "cached_at": "2025-09-30 21:47:00 UTC",
+    "repository_url": "https://github.com/estruyf/vscode-demo-time",
+    "server_name": "io.github.estruyf/vscode-demo-time"
+  },
+  "https://github.com/fliptheweb/yazio-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "The publisher GitHub org 'fliptheweb' does not match the Yazio brand and the description states 'unofficial'.",
+    "cached_at": "2025-09-30 21:47:02 UTC",
+    "repository_url": "https://github.com/fliptheweb/yazio-mcp",
+    "server_name": "io.github.fliptheweb/yazio-mcp"
+  },
+  "https://github.com/florentine-ai/mcp": {
+    "ai_decision": "official",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub org florentine-ai matches product Florentine.ai, repo is not a fork or archived, npm package uses org namespace.",
+    "cached_at": "2025-09-30 21:47:05 UTC",
+    "repository_url": "https://github.com/florentine-ai/mcp",
+    "server_name": "io.github.florentine-ai/mcp"
+  },
+  "https://github.com/formulahendry/mcp-server-code-runner": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "The publisher 'formulahendry' is a personal GitHub user not affiliated with an organization or product; server is a general-purpose code runner, not tied to a specific owned service.",
+    "cached_at": "2025-09-30 21:47:06 UTC",
+    "repository_url": "https://github.com/formulahendry/mcp-server-code-runner",
+    "server_name": "io.github.formulahendry/code-runner"
+  },
+  "https://github.com/formulahendry/mcp-server-mcp-registry": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "GitHub org 'formulahendry' does not match a known product/brand and is a personal namespace, not tied to an official underlying service.",
+    "cached_at": "2025-09-30 21:47:09 UTC",
+    "repository_url": "https://github.com/formulahendry/mcp-server-mcp-registry",
+    "server_name": "io.github.formulahendry/mcp-server-mcp-registry"
+  },
+  "https://github.com/formulahendry/mcp-server-spec-driven-development": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "The GitHub owner 'formulahendry' is a personal user, not an official organization for any product/service mentioned.",
+    "cached_at": "2025-09-30 21:47:11 UTC",
+    "repository_url": "https://github.com/formulahendry/mcp-server-spec-driven-development",
+    "server_name": "io.github.formulahendry/spec-driven-development"
+  },
+  "https://github.com/francisco-perez-sorrosal/cv": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repository is owned by a personal user and serves a personal CV, not an organizational product/service.",
+    "cached_at": "2025-09-30 21:47:13 UTC",
+    "repository_url": "https://github.com/francisco-perez-sorrosal/cv",
+    "server_name": "io.github.francisco-perez-sorrosal/cv"
+  },
+  "https://github.com/gjeltep/app-store-connect-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.98,
+    "ai_reason": "The publisher is 'gjeltep' (a personal account, not Apple), for App Store Connect; no evidence of Apple ownership.",
+    "cached_at": "2025-09-30 21:47:14 UTC",
+    "repository_url": "https://github.com/gjeltep/app-store-connect-mcp",
+    "server_name": "io.github.gjeltep/app-store-connect-mcp"
+  },
+  "https://github.com/gradion-ai/ipybox": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "The GitHub org 'gradion-ai' does not match any major product/brand for IPython or Docker; strong signals indicate this is a third-party community server.",
+    "cached_at": "2025-09-30 21:47:17 UTC",
+    "repository_url": "https://github.com/gradion-ai/ipybox",
+    "server_name": "io.github.gradion-ai/ipybox"
+  },
+  "https://github.com/grupo-avispa/dsr_mcp_server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.7,
+    "ai_reason": "GitHub org 'grupo-avispa' does not match or obviously own 'Deep State Representation' and there is no strong brand-product evidence.",
+    "cached_at": "2025-09-30 21:47:19 UTC",
+    "repository_url": "https://github.com/grupo-avispa/dsr_mcp_server",
+    "server_name": "io.github.grupo-avispa/dsr_mcp_server"
+  },
+  "https://github.com/guanqun-yang/mcp-server-r-counter": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "Repository is published by a personal user (guanqun-yang), not an organization, and there is no indication of brand/product ownership.",
+    "cached_at": "2025-09-30 21:47:21 UTC",
+    "repository_url": "https://github.com/guanqun-yang/mcp-server-r-counter",
+    "server_name": "io.github.guanqun-yang/mcp-server-r-counter"
+  },
+  "https://github.com/habedi/omni-lpr": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "Repository is owned by a personal user (habedi), not an organization linked to a brand or product.",
+    "cached_at": "2025-09-30 21:47:22 UTC",
+    "repository_url": "https://github.com/habedi/omni-lpr",
+    "server_name": "io.github.habedi/omni-lpr"
+  },
+  "https://github.com/hellocoop/admin-mcp": {
+    "ai_decision": "official",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub org name 'hellocoop' and npm scope '@hellocoop' match the product in server name and repo, indicating official publication by Hellocoop.",
+    "cached_at": "2025-09-30 21:47:24 UTC",
+    "repository_url": "https://github.com/hellocoop/admin-mcp",
+    "server_name": "io.github.hellocoop/admin-mcp"
+  },
+  "https://github.com/henilcalagiya/google-sheets-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "The repository is owned by a personal GitHub user (henilcalagiya) and not by Google, which is required for official status for Google Sheets.",
+    "cached_at": "2025-09-30 21:47:26 UTC",
+    "repository_url": "https://github.com/henilcalagiya/google-sheets-mcp",
+    "server_name": "io.github.henilcalagiya/google-sheets-mcp"
+  },
+  "https://github.com/henilcalagiya/mcp-apple-notes": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "The publisher is an individual user (henilcalagiya), not Apple, and Apple is the only entity that could publish an official server for Apple Notes.",
+    "cached_at": "2025-09-30 21:47:29 UTC",
+    "repository_url": "https://github.com/henilcalagiya/mcp-apple-notes",
+    "server_name": "io.github.henilcalagiya/mcp-apple-notes"
+  },
+  "https://github.com/himorishige/hatago-mcp-hub": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "The repository is owned by a user (himorishige), not an organization, and there is no brand or product match indicating official ownership.",
+    "cached_at": "2025-09-30 21:47:31 UTC",
+    "repository_url": "https://github.com/himorishige/hatago-mcp-hub",
+    "server_name": "io.github.himorishige/hatago-mcp-hub"
+  },
+  "https://github.com/iggredible/vim-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "The publisher 'iggredible' is not the official Vim organization and there is no evidence of brand ownership; this is a third-party integration.",
+    "cached_at": "2025-09-30 21:47:34 UTC",
+    "repository_url": "https://github.com/iggredible/vim-mcp",
+    "server_name": "io.github.iggredible/vim-mcp"
+  },
+  "https://github.com/imbenrabi/Financial-Modeling-Prep-MCP-Server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "The GitHub owner is a personal user ('imbenrabi'), not an organization matching 'Financial Modeling Prep', indicating a third-party implementation.",
+    "cached_at": "2025-09-30 21:47:36 UTC",
+    "repository_url": "https://github.com/imbenrabi/Financial-Modeling-Prep-MCP-Server",
+    "server_name": "io.github.imbenrabi/financial-modeling-prep-mcp-server"
+  },
+  "https://github.com/indragiek/uniprof": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "The repo is published under a personal user (indragiek), not an org matching a product; no evidence of brand ownership.",
+    "cached_at": "2025-09-30 21:47:38 UTC",
+    "repository_url": "https://github.com/indragiek/uniprof",
+    "server_name": "io.github.indragiek/uniprof"
+  },
+  "https://github.com/receptron/mulmocast-vision": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "The GitHub organization 'receptron' does not clearly match a known product brand and shows no direct evidence of being the official publisher of 'mulmocast-vision'.",
+    "cached_at": "2025-09-30 21:47:39 UTC",
+    "repository_url": "https://github.com/receptron/mulmocast-vision",
+    "server_name": "io.github.isamu/mulmocast-vision"
+  },
+  "https://github.com/iworkist/btcmcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "The GitHub org 'iworkist' does not match the product/service (Binance or Bitcoin), so it's a third-party/community server.",
+    "cached_at": "2025-09-30 21:47:41 UTC",
+    "repository_url": "https://github.com/iworkist/btcmcp",
+    "server_name": "io.github.iworkist/btcmcp"
+  },
+  "https://github.com/jcucci/dotnet-sherlock-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "Repository is under a personal user account (jcucci), not an organization owning .NET or Sherlock, indicating a third-party/community implementation.",
+    "cached_at": "2025-09-30 21:47:43 UTC",
+    "repository_url": "https://github.com/jcucci/dotnet-sherlock-mcp",
+    "server_name": "io.github.jcucci/dotnet-sherlock-mcp"
+  },
+  "https://github.com/jgador/websharp": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "Repository is under a user (jgador), not an organization owning a web search service; no evidence links to an official web search provider.",
+    "cached_at": "2025-09-30 21:47:45 UTC",
+    "repository_url": "https://github.com/jgador/websharp",
+    "server_name": "io.github.jgador/websharp"
+  },
+  "https://github.com/blaideinc/cookwith-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.7,
+    "ai_reason": "The repo is owned by 'blaideinc', not matching the product/service name 'cookwith', with no evidence it's an official organization.",
+    "cached_at": "2025-09-30 21:47:47 UTC",
+    "repository_url": "https://github.com/blaideinc/cookwith-mcp",
+    "server_name": "io.github.jkakar/cookwith-mcp"
+  },
+  "https://github.com/blaideinc/recipe-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.7,
+    "ai_reason": "GitHub org 'blaideinc' does not match the cookwith.co brand referenced in the description and npm scope, lacking strong signals of official ownership.",
+    "cached_at": "2025-09-30 21:47:50 UTC",
+    "repository_url": "https://github.com/blaideinc/recipe-mcp",
+    "server_name": "io.github.jkakar/recipe-mcp"
+  },
+  "https://github.com/jkawamoto/mcp-bear": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "The repository is published by user 'jkawamoto' (not Bear's organization), indicating it is a community implementation for the Bear note-taking software.",
+    "cached_at": "2025-09-30 21:47:52 UTC",
+    "repository_url": "https://github.com/jkawamoto/mcp-bear",
+    "server_name": "io.github.jkawamoto/mcp-bear"
+  },
+  "https://github.com/jkawamoto/mcp-florence2": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "The repo is owned by user 'jkawamoto' not an organization matching the 'Florence-2' brand, indicating a third-party implementation.",
+    "cached_at": "2025-09-30 21:47:54 UTC",
+    "repository_url": "https://github.com/jkawamoto/mcp-florence2",
+    "server_name": "io.github.jkawamoto/mcp-florence2"
+  },
+  "https://github.com/jkawamoto/mcp-youtube-transcript": {
+    "ai_decision": "community",
+    "ai_confidence": 0.98,
+    "ai_reason": "Repo is owned by a personal user (jkawamoto), not YouTube or Google, and no other official signals are present.",
+    "cached_at": "2025-09-30 21:47:55 UTC",
+    "repository_url": "https://github.com/jkawamoto/mcp-youtube-transcript",
+    "server_name": "io.github.jkawamoto/mcp-youtube-transcript"
+  },
+  "https://github.com/jztan/redmine-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "Repository owner is a personal user (jztan), not Redmine's organization, so this is a third-party implementation.",
+    "cached_at": "2025-09-30 21:47:59 UTC",
+    "repository_url": "https://github.com/jztan/redmine-mcp-server",
+    "server_name": "io.github.jztan/redmine-mcp-server"
+  },
+  "https://github.com/karanb192/reddit-mcp-buddy": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "Repository is published by a user (karanb192), not the official Reddit org, so it is a community implementation.",
+    "cached_at": "2025-09-30 21:48:01 UTC",
+    "repository_url": "https://github.com/karanb192/reddit-mcp-buddy",
+    "server_name": "io.github.karanb192/reddit-mcp-buddy"
+  },
+  "https://github.com/kayembahamid/cybersim-pro": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "The publisher is a personal GitHub user (kayembahamid) and not an organization owning a product/service called 'cybersim-pro'.",
+    "cached_at": "2025-09-30 21:48:03 UTC",
+    "repository_url": "https://github.com/kayembahamid/cybersim-pro",
+    "server_name": "io.github.kayembahamid/cybersim-pro"
+  },
+  "https://github.com/kemalersin/fonparam-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "GitHub user kemalersin (not an org) published the server for FonParam API, with no signals of official affiliation.",
+    "cached_at": "2025-09-30 21:48:04 UTC",
+    "repository_url": "https://github.com/kemalersin/fonparam-mcp",
+    "server_name": "io.github.kemalersin/fonparam-mcp"
+  },
+  "https://github.com/king-of-the-grackles/reddit-research-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub org king-of-the-grackles is not affiliated with Reddit, so this is a third-party community implementation.",
+    "cached_at": "2025-09-30 21:48:06 UTC",
+    "repository_url": "https://github.com/king-of-the-grackles/reddit-research-mcp",
+    "server_name": "io.github.king-of-the-grackles/reddit-research-mcp"
+  },
+  "https://github.com/kirbah/mcp-youtube": {
+    "ai_decision": "community",
+    "ai_confidence": 0.98,
+    "ai_reason": "Published by 'kirbah', not YouTube/Google org; YouTube is a generic/ubiquitous service and only Google can be official.",
+    "cached_at": "2025-09-30 21:48:09 UTC",
+    "repository_url": "https://github.com/kirbah/mcp-youtube",
+    "server_name": "io.github.kirbah/mcp-youtube"
+  },
+  "https://github.com/koki-develop/esa-mcp-server.git": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "The GitHub org 'koki-develop' does not match the esa.io brand, indicating this is a third-party implementation.",
+    "cached_at": "2025-09-30 21:48:10 UTC",
+    "repository_url": "https://github.com/koki-develop/esa-mcp-server.git",
+    "server_name": "io.github.koki-develop/esa-mcp-server"
+  },
+  "https://github.com/lapfelix/XcodeMCP": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "The GitHub org is a user ('lapfelix'), not Apple; thus, this is not published by the Xcode brand owner.",
+    "cached_at": "2025-09-30 21:48:12 UTC",
+    "repository_url": "https://github.com/lapfelix/XcodeMCP",
+    "server_name": "io.github.lapfelix/xcodemcp"
+  },
+  "https://github.com/leshchenko1979/fast-mcp-telegram": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "The repository is owned by an individual (leshchenko1979), not by Telegram or its official org.",
+    "cached_at": "2025-09-30 21:48:14 UTC",
+    "repository_url": "https://github.com/leshchenko1979/fast-mcp-telegram",
+    "server_name": "io.github.leshchenko1979/fast-mcp-telegram"
+  },
+  "https://github.com/linxule/lotus-wisdom-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "The publisher 'linxule' is a user, not an organization, and does not match a recognizable brand or product.",
+    "cached_at": "2025-09-30 21:48:16 UTC",
+    "repository_url": "https://github.com/linxule/lotus-wisdom-mcp",
+    "server_name": "io.github.linxule/lotus-wisdom"
+  },
+  "https://github.com/localstack/localstack-mcp-server": {
+    "ai_decision": "official",
+    "ai_confidence": 0.97,
+    "ai_reason": "GitHub org 'localstack' matches product 'LocalStack', repo is not a fork/archived, and npm scope '@localstack' shows ownership.",
+    "cached_at": "2025-09-30 21:48:18 UTC",
+    "repository_url": "https://github.com/localstack/localstack-mcp-server",
+    "server_name": "io.github.localstack/localstack-mcp-server"
+  },
+  "https://github.com/macuse-app/macuse": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "macuse-app is not the publisher of macOS, and the server integrates with native macOS functionality rather than being published by Apple.",
+    "cached_at": "2025-09-30 21:48:20 UTC",
+    "repository_url": "https://github.com/macuse-app/macuse",
+    "server_name": "io.github.macuse-app/macuse"
+  },
+  "https://github.com/mapbox/mcp-server": {
+    "ai_decision": "official",
+    "ai_confidence": 0.98,
+    "ai_reason": "Repository is under the verified Mapbox organization and npm package uses the @mapbox scope, both matching the product name.",
+    "cached_at": "2025-09-30 21:48:22 UTC",
+    "repository_url": "https://github.com/mapbox/mcp-server",
+    "server_name": "io.github.mapbox/mcp-server"
+  },
+  "https://github.com/marianfoo/mcp-sap-docs": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repository is owned by a personal user (marianfoo), not the SAP organization, so it is a third-party implementation for SAP Docs.",
+    "cached_at": "2025-09-30 21:48:23 UTC",
+    "repository_url": "https://github.com/marianfoo/mcp-sap-docs",
+    "server_name": "io.github.marianfoo/mcp-sap-docs"
+  },
+  "https://github.com/marlenezw/publish-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "Repo is owned by an individual user (marlenezw), not an organization or brand owner.",
+    "cached_at": "2025-09-30 21:48:24 UTC",
+    "repository_url": "https://github.com/marlenezw/publish-mcp-server",
+    "server_name": "io.github.marlenezw/publish-mcp-server"
+  },
+  "https://github.com/mobile-next/mobile-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.7,
+    "ai_reason": "The GitHub organization 'mobile-next' does not clearly correspond to a well-known mobile platform owner (e.g., Apple or Google), and there is no strong brand linkage.",
+    "cached_at": "2025-09-30 21:48:27 UTC",
+    "repository_url": "https://github.com/mobile-next/mobile-mcp",
+    "server_name": "io.github.mobile-next/mobile-mcp"
+  },
+  "https://github.com/moonolgerd/game-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "The GitHub org 'moonolgerd' does not match the brands (Steam, Epic, GOG, Xbox) mentioned in the description and appears to be a personal or third-party publisher.",
+    "cached_at": "2025-09-30 21:48:29 UTC",
+    "repository_url": "https://github.com/moonolgerd/game-mcp",
+    "server_name": "io.github.moonolgerd/game-mcp"
+  },
+  "https://github.com/morinokami/astro-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.8,
+    "ai_reason": "The repository is owned by a user (morinokami), not the Astro org, and there's no strong evidence this is an official Astro project.",
+    "cached_at": "2025-09-30 21:48:31 UTC",
+    "repository_url": "https://github.com/morinokami/astro-mcp",
+    "server_name": "io.github.morinokami/astro-mcp"
+  },
+  "https://github.com/motherduckdb/mcp-server-motherduck": {
+    "ai_decision": "official",
+    "ai_confidence": 0.98,
+    "ai_reason": "GitHub organization name 'motherduckdb' matches the product 'MotherDuck', repository is not a fork/archived, indicating organizational ownership.",
+    "cached_at": "2025-09-30 21:48:32 UTC",
+    "repository_url": "https://github.com/motherduckdb/mcp-server-motherduck",
+    "server_name": "io.github.motherduckdb/mcp-server-motherduck"
+  },
+  "https://github.com/nerfels/mind-map": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "GitHub organization 'nerfels' does not match 'Claude' or any major product/brand in the description; signals indicate third-party implementation.",
+    "cached_at": "2025-09-30 21:48:34 UTC",
+    "repository_url": "https://github.com/nerfels/mind-map",
+    "server_name": "io.github.nerfels/mind-map"
+  },
+  "https://github.com/nesquikm/mcp-rubber-duck": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "The repository is published by a user (nesquikm), bridges to multiple OpenAI-compatible LLMs, and is not from any of the relevant official organizations (OpenAI, Google, Groq).",
+    "cached_at": "2025-09-30 21:48:36 UTC",
+    "repository_url": "https://github.com/nesquikm/mcp-rubber-duck",
+    "server_name": "io.github.nesquikm/rubber-duck"
+  },
+  "https://github.com/nickzren/opentargets-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "The repository is owned by a personal user (nickzren), not the official Open Targets organization.",
+    "cached_at": "2025-09-30 21:48:38 UTC",
+    "repository_url": "https://github.com/nickzren/opentargets-mcp",
+    "server_name": "io.github.nickzren/opentargets"
+  },
+  "https://github.com/nrwl/nx-console": {
+    "ai_decision": "official",
+    "ai_confidence": 0.9,
+    "ai_reason": "Organization nrwl owns Nx and the repository nx-console is under nrwl GitHub org in primary namespace.",
+    "cached_at": "2025-09-30 21:48:39 UTC",
+    "repository_url": "https://github.com/nrwl/nx-console",
+    "server_name": "io.github.nrwl/nx-console"
+  },
+  "https://github.com/overstarry/qweather-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "GitHub org 'overstarry' does not match the Qweather brand and there is no evidence of official affiliation.",
+    "cached_at": "2025-09-30 21:48:41 UTC",
+    "repository_url": "https://github.com/overstarry/qweather-mcp",
+    "server_name": "io.github.overstarry/qweather-mcp"
+  },
+  "https://github.com/p1va/symbols": {
+    "ai_decision": "community",
+    "ai_confidence": 0.8,
+    "ai_reason": "The publisher 'p1va' is a personal namespace and not the brand owner of a specific product/service referenced by the server.",
+    "cached_at": "2025-09-30 21:48:43 UTC",
+    "repository_url": "https://github.com/p1va/symbols",
+    "server_name": "io.github.p1va/symbols"
+  },
+  "https://github.com/pab1it0/prometheus-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "The publisher is a personal user (pab1it0), not the official Prometheus organization.",
+    "cached_at": "2025-09-30 21:48:44 UTC",
+    "repository_url": "https://github.com/pab1it0/prometheus-mcp-server",
+    "server_name": "io.github.pab1it0/prometheus-mcp-server"
+  },
+  "https://github.com/pedro-rivas/android-puppeteer-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "The repository is owned by a personal user (pedro-rivas), not an official organization associated with Android or Puppeteer.",
+    "cached_at": "2025-09-30 21:48:46 UTC",
+    "repository_url": "https://github.com/pedro-rivas/android-puppeteer-mcp",
+    "server_name": "io.github.pedro-rivas/android-puppeteer-mcp"
+  },
+  "https://github.com/pkolawa/krs-poland-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "The publisher is a personal user (pkolawa) and not an official organization operating the KRS registry.",
+    "cached_at": "2025-09-30 21:48:48 UTC",
+    "repository_url": "https://github.com/pkolawa/krs-poland-mcp-server",
+    "server_name": "io.github.pkolawa/krs-poland-mcp-server"
+  },
+  "https://github.com/pkolawa/mcp-krs-poland": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "GitHub repo is under a user account ('pkolawa'), not an organizational account matching the official Polish government registry.",
+    "cached_at": "2025-09-30 21:48:50 UTC",
+    "repository_url": "https://github.com/pkolawa/mcp-krs-poland",
+    "server_name": "io.github.pkolawa/mcp-krs-poland"
+  },
+  "https://github.com/pree-dew/mcp-bookmark": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "The GitHub owner is a user (pree-dew) and not OpenAI; no official OpenAI signals.",
+    "cached_at": "2025-09-30 21:48:52 UTC",
+    "repository_url": "https://github.com/pree-dew/mcp-bookmark",
+    "server_name": "io.github.pree-dew/mcp-bookmark"
+  },
+  "https://github.com/priyankark/lighthouse-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repository owner 'priyankark' is a personal user and not Google, but the service integrates with Google Lighthouse.",
+    "cached_at": "2025-09-30 21:48:54 UTC",
+    "repository_url": "https://github.com/priyankark/lighthouse-mcp",
+    "server_name": "io.github.priyankark/lighthouse-mcp"
+  },
+  "https://github.com/promplate/pyth-on-line": {
+    "ai_decision": "community",
+    "ai_confidence": 0.8,
+    "ai_reason": "The GitHub org 'promplate' does not clearly represent a widely recognized product/service brand, and the project is hosted under a user-like org for a tool rather than an official integration.",
+    "cached_at": "2025-09-30 21:48:57 UTC",
+    "repository_url": "https://github.com/promplate/pyth-on-line",
+    "server_name": "io.github.promplate/hmr"
+  },
+  "https://github.com/pshivapr/selenium-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "The repository is owned by a personal GitHub user (pshivapr) and not the Selenium organization, so it is a community implementation.",
+    "cached_at": "2025-09-30 21:48:59 UTC",
+    "repository_url": "https://github.com/pshivapr/selenium-mcp",
+    "server_name": "io.github.pshivapr/selenium-mcp"
+  },
+  "https://github.com/pubnub/pubnub-mcp-server": {
+    "ai_decision": "official",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub org 'pubnub' matches the service 'PubNub' in server name and repo, with strong brand alignment.",
+    "cached_at": "2025-09-30 21:49:01 UTC",
+    "repository_url": "https://github.com/pubnub/pubnub-mcp-server",
+    "server_name": "io.github.pubnub/mcp-server"
+  },
+  "https://github.com/r-huijts/strava-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "The repository is owned by a personal user (r-huijts), not Strava’s official organization.",
+    "cached_at": "2025-09-30 21:49:03 UTC",
+    "repository_url": "https://github.com/r-huijts/strava-mcp",
+    "server_name": "io.github.r-huijts/strava-mcp"
+  },
+  "https://github.com/railwayapp/railway-mcp-server": {
+    "ai_decision": "official",
+    "ai_confidence": 0.98,
+    "ai_reason": "The server is published by the verified GitHub organization railwayapp which matches the Railway product, and the npm package is under the @railway scope.",
+    "cached_at": "2025-09-30 21:49:05 UTC",
+    "repository_url": "https://github.com/railwayapp/railway-mcp-server",
+    "server_name": "io.github.railwayapp/mcp-server"
+  },
+  "https://github.com/rbonestell/ap-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repository is published under a personal user (rbonestell) not the Associated Press org; no evidence of official branding.",
+    "cached_at": "2025-09-30 21:49:07 UTC",
+    "repository_url": "https://github.com/rbonestell/ap-mcp-server",
+    "server_name": "io.github.rbonestell/ap-mcp-server"
+  },
+  "https://github.com/ref-tools/ref-tools-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.65,
+    "ai_reason": "The GitHub org 'ref-tools' may relate to 'Ref', but there's no strong evidence it is run by the brand owner; org is not a major known company and domain matching is insufficient.",
+    "cached_at": "2025-09-30 21:49:08 UTC",
+    "repository_url": "https://github.com/ref-tools/ref-tools-mcp",
+    "server_name": "io.github.ref-tools/ref-tools-mcp"
+  },
+  "https://github.com/ruvnet/claude-flow": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "The repo is under the 'ruvnet' user/org, not Anthropic, and references Claude (an Anthropic product) via user environment variables.",
+    "cached_at": "2025-09-30 21:49:11 UTC",
+    "repository_url": "https://github.com/ruvnet/claude-flow",
+    "server_name": "io.github.ruvnet/claude-flow"
+  },
+  "https://github.com/ruvnet/flow-nexus": {
+    "ai_decision": "community",
+    "ai_confidence": 0.5,
+    "ai_reason": "The GitHub org 'ruvnet' does not clearly match the product/service 'flow-nexus', and there is insufficient evidence of official brand ownership.",
+    "cached_at": "2025-09-30 21:49:13 UTC",
+    "repository_url": "https://github.com/ruvnet/flow-nexus",
+    "server_name": "io.github.ruvnet/flow-nexus"
+  },
+  "https://github.com/ruvnet/ruv-FANN": {
+    "ai_decision": "community",
+    "ai_confidence": 0.8,
+    "ai_reason": "The GitHub org 'ruvnet' matches the project but there is no evidence it controls a widely recognized product/service; not a known brand, so this is community.",
+    "cached_at": "2025-09-30 21:49:15 UTC",
+    "repository_url": "https://github.com/ruvnet/ruv-FANN",
+    "server_name": "io.github.ruvnet/ruv-swarm"
+  },
+  "https://github.com/ryaker/appstore-connect-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "The GitHub org ryaker does not match Apple or App Store Connect branding; all evidence points to a third-party implementation.",
+    "cached_at": "2025-09-30 21:49:16 UTC",
+    "repository_url": "https://github.com/ryaker/appstore-connect-mcp",
+    "server_name": "io.github.ryaker/appstore-connect-mcp"
+  },
+  "https://github.com/googlemaps/platform-ai": {
+    "ai_decision": "official",
+    "ai_confidence": 0.97,
+    "ai_reason": "Published by the GoogleMaps GitHub organization with matching npm scope (@googlemaps); strong signal of official Google Maps Platform integration.",
+    "cached_at": "2025-09-30 21:49:18 UTC",
+    "repository_url": "https://github.com/googlemaps/platform-ai",
+    "server_name": "io.github.ryanbaumann/platform-ai"
+  },
+  "https://github.com/saucelabs/sauce-api-mcp": {
+    "ai_decision": "official",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repository is published by the 'saucelabs' GitHub organization (matching Sauce Labs API), not a fork, and integrates directly with their product.",
+    "cached_at": "2025-09-30 21:49:20 UTC",
+    "repository_url": "https://github.com/saucelabs/sauce-api-mcp",
+    "server_name": "io.github.saucelabs-sample-test-frameworks/sauce-api-mcp"
+  },
+  "https://github.com/savhascelik/meta-api-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "The repository is under a personal user (savhascelik), not an organization, and does not match an official brand for a specific product.",
+    "cached_at": "2025-09-30 21:49:22 UTC",
+    "repository_url": "https://github.com/savhascelik/meta-api-mcp-server",
+    "server_name": "io.github.savhascelik/meta-api-mcp-server"
+  },
+  "https://github.com/schemacrawler/SchemaCrawler-AI": {
+    "ai_decision": "official",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub org 'schemacrawler' matches the server and package names, and the Docker image is under the same org.",
+    "cached_at": "2025-09-30 21:49:25 UTC",
+    "repository_url": "https://github.com/schemacrawler/SchemaCrawler-AI",
+    "server_name": "io.github.schemacrawler/schemacrawler-ai"
+  },
+  "https://github.com/sellisd/mcp-units": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "The repository owner (sellisd) is a personal GitHub user, not an organization or brand matching the product/service ('units conversions'), indicating a community project.",
+    "cached_at": "2025-09-30 21:49:27 UTC",
+    "repository_url": "https://github.com/sellisd/mcp-units",
+    "server_name": "io.github.sellisd/mcp-units"
+  },
+  "https://github.com/mcp-s-ai/image-recognition-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "Publisher 'mcp-s-ai' is not OpenAI nor the brand owner; remote hints and package do not show clear OpenAI ownership.",
+    "cached_at": "2025-09-30 21:49:29 UTC",
+    "repository_url": "https://github.com/mcp-s-ai/image-recognition-mcp",
+    "server_name": "io.github.shalevshalit/image-recognition-mcp"
+  },
+  "https://github.com/mcp-s-ai/image-recongnition-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "The publisher (mcp-s-ai) is not OpenAI and there is no evidence of official ownership or branding by OpenAI for the image recognition service.",
+    "cached_at": "2025-09-30 21:49:32 UTC",
+    "repository_url": "https://github.com/mcp-s-ai/image-recongnition-mcp",
+    "server_name": "io.github.shalevshalit/image-recongnition-mcp"
+  },
+  "https://github.com/shinpr/mcp-image": {
+    "ai_decision": "community",
+    "ai_confidence": 0.98,
+    "ai_reason": "Repository is owned by personal user 'shinpr', not Google or an official organization, and there is no strong signal linking ownership to the underlying Google Gemini service.",
+    "cached_at": "2025-09-30 21:49:33 UTC",
+    "repository_url": "https://github.com/shinpr/mcp-image",
+    "server_name": "io.github.shinpr/mcp-image"
+  },
+  "https://github.com/spences10/mcp-omnisearch": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub owner 'spences10' is a user, not the Omnisearch organization, so this is a third-party implementation.",
+    "cached_at": "2025-09-30 21:49:35 UTC",
+    "repository_url": "https://github.com/spences10/mcp-omnisearch",
+    "server_name": "io.github.spences10/mcp-omnisearch"
+  },
+  "https://github.com/spences10/mcp-sqlite-tools": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "The repository is owned by spences10 (not the SQLite organization), indicating a third-party implementation for SQLite.",
+    "cached_at": "2025-09-30 21:49:37 UTC",
+    "repository_url": "https://github.com/spences10/mcp-sqlite-tools",
+    "server_name": "io.github.spences10/mcp-sqlite-tools"
+  },
+  "https://github.com/spences10/mcp-turso-cloud": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "The repo is published by a user (spences10), not an organization related to Turso, with no signals of official brand ownership.",
+    "cached_at": "2025-09-30 21:49:39 UTC",
+    "repository_url": "https://github.com/spences10/mcp-turso-cloud",
+    "server_name": "io.github.spences10/mcp-turso-cloud"
+  },
+  "https://github.com/stefanoamorelli/fred-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "The publisher (stefanoamorelli) is not the Federal Reserve; no signals this is an official integration for FRED.",
+    "cached_at": "2025-09-30 21:49:40 UTC",
+    "repository_url": "https://github.com/stefanoamorelli/fred-mcp-server",
+    "server_name": "io.github.stefanoamorelli/fred-mcp-server"
+  },
+  "https://github.com/stefanoamorelli/sec-edgar-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "The publisher is a personal GitHub user (stefanoamorelli) rather than the official SEC organization.",
+    "cached_at": "2025-09-30 21:49:42 UTC",
+    "repository_url": "https://github.com/stefanoamorelli/sec-edgar-mcp",
+    "server_name": "io.github.stefanoamorelli/sec-edgar-mcp"
+  },
+  "https://github.com/surendranb/google-analytics-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "Repo owner is a personal user (surendranb) and not Google; strong signal this is not official.",
+    "cached_at": "2025-09-30 21:49:44 UTC",
+    "repository_url": "https://github.com/surendranb/google-analytics-mcp",
+    "server_name": "io.github.surendranb/google-analytics-mcp"
+  },
+  "https://github.com/taurgis/sfcc-dev-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "The publisher (taurgis) is not an official Salesforce org and the package namespace is generic with no evidence of Salesforce ownership.",
+    "cached_at": "2025-09-30 21:49:46 UTC",
+    "repository_url": "https://github.com/taurgis/sfcc-dev-mcp",
+    "server_name": "io.github.taurgis/sfcc-dev-mcp"
+  },
+  "https://github.com/tedfytw1209/mcp-server-EVEfleet": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub repo is owned by a user (tedfytw1209), not the official EVE Online org; lacks official branding or verified signals.",
+    "cached_at": "2025-09-30 21:49:48 UTC",
+    "repository_url": "https://github.com/tedfytw1209/mcp-server-EVEfleet",
+    "server_name": "io.github.tedfytw1209/mcp-server-EVEfleet"
+  },
+  "https://github.com/therealtimex/un-datacommons-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "The publisher 'therealtimex' is not the official Data Commons organization; no signals indicate official brand ownership.",
+    "cached_at": "2025-09-30 21:49:50 UTC",
+    "repository_url": "https://github.com/therealtimex/un-datacommons-mcp",
+    "server_name": "io.github.therealtimex/un-datacommons-mcp"
+  },
+  "https://github.com/timheuer/sampledotnetmcpserver": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "Published by a personal GitHub user (timheuer) and lacks any clear official organization affiliation.",
+    "cached_at": "2025-09-30 21:49:51 UTC",
+    "repository_url": "https://github.com/timheuer/sampledotnetmcpserver",
+    "server_name": "io.github.timheuer/sampledotnetmcpserver"
+  },
+  "https://github.com/toby/mirror-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "Repository is owned by a personal user (toby), not an organization, with no evidence of official product/service ownership.",
+    "cached_at": "2025-09-30 21:49:54 UTC",
+    "repository_url": "https://github.com/toby/mirror-mcp",
+    "server_name": "io.github.toby/mirror-mcp"
+  },
+  "https://github.com/tschoonj/repology-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "The repository is owned by a user (tschoonj), not the Repology organization, indicating it is a third-party community implementation.",
+    "cached_at": "2025-09-30 21:49:55 UTC",
+    "repository_url": "https://github.com/tschoonj/repology-mcp-server",
+    "server_name": "io.github.tschoonj/repology-mcp-server"
+  },
+  "https://github.com/tuananh/hyper-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "Repository is owned by personal user 'tuananh', not a product/service organization.",
+    "cached_at": "2025-09-30 21:49:57 UTC",
+    "repository_url": "https://github.com/tuananh/hyper-mcp",
+    "server_name": "io.github.tuananh/hyper-mcp"
+  },
+  "https://github.com/tuannvm/mcp-trino": {
+    "ai_decision": "community",
+    "ai_confidence": 0.97,
+    "ai_reason": "The publisher is a personal user (tuannvm), not the official Trino organization, indicating it is a community implementation.",
+    "cached_at": "2025-09-30 21:49:59 UTC",
+    "repository_url": "https://github.com/tuannvm/mcp-trino",
+    "server_name": "io.github.tuannvm/mcp-trino"
+  },
+  "https://github.com/ubaumann/mkdocs-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub owner is a personal user (ubaumann), not the MkDocs organization, so this is a third-party implementation.",
+    "cached_at": "2025-09-30 21:50:00 UTC",
+    "repository_url": "https://github.com/ubaumann/mkdocs-mcp",
+    "server_name": "io.github.ubaumann/mkdocs-mcp"
+  },
+  "https://github.com/variflight/variflight-mcp": {
+    "ai_decision": "official",
+    "ai_confidence": 0.98,
+    "ai_reason": "GitHub org variflight matches service name and domain, npm scope @variflight-ai is owned by org, and description claims official status.",
+    "cached_at": "2025-09-30 21:50:03 UTC",
+    "repository_url": "https://github.com/variflight/variflight-mcp",
+    "server_name": "io.github.variflight/variflight-mcp"
+  },
+  "https://github.com/vfarcic/dot-ai": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "Repository owner vfarcic is a GitHub user, not an organization, and there is no clear indication of an underlying branded platform.",
+    "cached_at": "2025-09-30 21:50:04 UTC",
+    "repository_url": "https://github.com/vfarcic/dot-ai",
+    "server_name": "io.github.vfarcic/dot-ai"
+  },
+  "https://github.com/wonderwhy-er/DesktopCommanderMCP": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "The GitHub owner 'wonderwhy-er' is a user, not an organization, and there is no evidence of underlying product/service brand ownership.",
+    "cached_at": "2025-09-30 21:50:06 UTC",
+    "repository_url": "https://github.com/wonderwhy-er/DesktopCommanderMCP",
+    "server_name": "io.github.wonderwhy-er/desktop-commander"
+  },
+  "https://github.com/xkelxmc/uranium-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.8,
+    "ai_reason": "The GitHub repo is under a user account (xkelxmc), not an org matching Uranium, and there is no strong brand signal.",
+    "cached_at": "2025-09-30 21:50:08 UTC",
+    "repository_url": "https://github.com/xkelxmc/uranium-mcp",
+    "server_name": "io.github.xkelxmc/uranium-mcp"
+  },
+  "https://github.com/xorrkaz/cml-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "The publisher is a personal user (xorrkaz), not Cisco or a Cisco-verified organization, for the Cisco Modeling Labs service.",
+    "cached_at": "2025-09-30 21:50:10 UTC",
+    "repository_url": "https://github.com/xorrkaz/cml-mcp",
+    "server_name": "io.github.xorrkaz/cml-mcp"
+  },
+  "https://github.com/ycjcl868/mcp-server-fear-greed": {
+    "ai_decision": "community",
+    "ai_confidence": 0.95,
+    "ai_reason": "The repository is under a user account (ycjcl868), not an organization matching a known product/brand, with no evidence of brand ownership.",
+    "cached_at": "2025-09-30 21:50:12 UTC",
+    "repository_url": "https://github.com/ycjcl868/mcp-server-fear-greed",
+    "server_name": "io.github.ycjcl868/mcp-server-fear-greed"
+  },
+  "https://github.com/web-infra-dev/rsdoctor": {
+    "ai_decision": "community",
+    "ai_confidence": 0.8,
+    "ai_reason": "The publishing GitHub org is 'web-infra-dev' which does not match Rspack product branding, and there is no strong evidence of official status.",
+    "cached_at": "2025-09-30 21:50:17 UTC",
+    "repository_url": "https://github.com/web-infra-dev/rsdoctor",
+    "server_name": "io.github.yifancong/rsdoctor"
+  },
+  "https://github.com/zenml-io/mcp-zenml": {
+    "ai_decision": "official",
+    "ai_confidence": 0.95,
+    "ai_reason": "The GitHub org 'zenml-io' matches the ZenML product and is publishing under its own branding with remotes referencing its domain.",
+    "cached_at": "2025-09-30 21:50:19 UTC",
+    "repository_url": "https://github.com/zenml-io/mcp-zenml",
+    "server_name": "io.github.zenml-io/mcp-zenml"
+  },
+  "https://github.com/zhongweili/nanobanana-mcp-server": {
+    "ai_decision": "community",
+    "ai_confidence": 1.0,
+    "ai_reason": "The repository is owned by a user (zhongweili), not an organization affiliated with a known product or brand.",
+    "cached_at": "2025-09-30 21:50:20 UTC",
+    "repository_url": "https://github.com/zhongweili/nanobanana-mcp-server",
+    "server_name": "io.github.zhongweili/nanobanana-mcp-server"
+  },
+  "https://github.com/jsdelivr/globalping-mcp-server": {
+    "ai_decision": "official",
+    "ai_confidence": 0.95,
+    "ai_reason": "GitHub org jsdelivr matches globalping service brand and remotes use globalping.io domain.",
+    "cached_at": "2025-09-30 21:50:23 UTC",
+    "repository_url": "https://github.com/jsdelivr/globalping-mcp-server",
+    "server_name": "io.globalping/mcp"
+  },
+  "https://github.com/ignission-io/mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "Organization (ignission-io) does not match TikTok's brand; strong signals indicate this is a third-party integration.",
+    "cached_at": "2025-09-30 21:50:24 UTC",
+    "repository_url": "https://github.com/ignission-io/mcp",
+    "server_name": "io.ignission/mcp"
+  },
+  "https://github.com/scorecard-ai/scorecard-node": {
+    "ai_decision": "official",
+    "ai_confidence": 1.0,
+    "ai_reason": "The GitHub org 'scorecard-ai' matches the product (Scorecard), remotes are on scorecard.io, and all evidence points to direct ownership.",
+    "cached_at": "2025-09-30 21:50:27 UTC",
+    "repository_url": "https://github.com/scorecard-ai/scorecard-node",
+    "server_name": "io.scorecard/mcp"
+  },
+  "https://github.com/snyk/snyk-ls": {
+    "ai_decision": "official",
+    "ai_confidence": 0.98,
+    "ai_reason": "GitHub org 'snyk' matches product 'Snyk', publishes npm package 'snyk', and integrates directly with Snyk platform.",
+    "cached_at": "2025-09-30 21:50:28 UTC",
+    "repository_url": "https://github.com/snyk/snyk-ls",
+    "server_name": "io.snyk/mcp"
+  },
+  "https://github.com/gepuro/company-lens-mcp-registry": {
+    "ai_decision": "official",
+    "ai_confidence": 0.85,
+    "ai_reason": "The GitHub org (gepuro) matches the domain in the remote (gepuro.net) and server name, indicating this is published by the brand owner.",
+    "cached_at": "2025-09-30 21:50:30 UTC",
+    "repository_url": "https://github.com/gepuro/company-lens-mcp-registry",
+    "server_name": "net.gepuro.mcp-company-lens-v1/company-lens-mcp-registry"
+  },
+  "https://github.com/609NFT/solana-mcp": {
+    "ai_decision": "community",
+    "ai_confidence": 0.7,
+    "ai_reason": "The GitHub org '609NFT' does not match the 'neglect.trade' or 'trade' brands, and there is no evidence the publisher is the brand owner.",
+    "cached_at": "2025-09-30 21:50:32 UTC",
+    "repository_url": "https://github.com/609NFT/solana-mcp",
+    "server_name": "trade.neglect/mcp-server"
+  }
+}

--- a/scripts/upstream_sync/ai_categorization_cache.json
+++ b/scripts/upstream_sync/ai_categorization_cache.json
@@ -2206,5 +2206,21 @@
     "cached_at": "2025-09-30 23:50:22 UTC",
     "repository_url": "https://github.com/609NFT/solana-mcp",
     "server_name": "trade.neglect/mcp-server"
+  },
+  "io.github.VictoriaMetrics-Community/mcp-victorialogs:https://github.com/VictoriaMetrics-Community/mcp-victorialogs": {
+    "ai_decision": "community",
+    "ai_confidence": 0.85,
+    "ai_reason": "The publisher is VictoriaMetrics-Community (not the main VictoriaMetrics org), indicating a third-party implementation for VictoriaLogs.",
+    "cached_at": "2025-10-01 01:00:22 UTC",
+    "repository_url": "https://github.com/VictoriaMetrics-Community/mcp-victorialogs",
+    "server_name": "io.github.VictoriaMetrics-Community/mcp-victorialogs"
+  },
+  "io.github.VictoriaMetrics-Community/mcp-victoriametrics:https://github.com/VictoriaMetrics-Community/mcp-victoriametrics": {
+    "ai_decision": "community",
+    "ai_confidence": 0.9,
+    "ai_reason": "Published by 'VictoriaMetrics-Community', not the official 'VictoriaMetrics' org, indicating a third-party implementation.",
+    "cached_at": "2025-10-01 01:00:29 UTC",
+    "repository_url": "https://github.com/VictoriaMetrics-Community/mcp-victoriametrics",
+    "server_name": "io.github.VictoriaMetrics-Community/mcp-victoriametrics"
   }
 }

--- a/scripts/upstream_sync/auto_sync_workflow.py
+++ b/scripts/upstream_sync/auto_sync_workflow.py
@@ -1,0 +1,853 @@
+#!/usr/bin/env python3
+"""
+MCP Registry Sync Workflow
+
+This script synchronizes MCP servers from the official registry with our catalog,
+creating GitHub issues for new servers that meet our criteria.
+"""
+
+import os
+import time
+import json
+import base64
+import re
+import math
+import datetime as dt
+from typing import List, Dict, Optional, Tuple
+from urllib.parse import urlparse, urlunparse
+from difflib import SequenceMatcher
+
+import requests
+import yaml
+from packaging.version import Version, InvalidVersion
+from openai import OpenAI
+
+# =============================================================================
+# CONFIGURATION
+# =============================================================================
+
+# Registry and repository configuration
+REGISTRY_URL = os.getenv("REGISTRY_URL", "https://registry.modelcontextprotocol.io/v0/servers")
+TARGET_REPO_FULL = os.getenv("GITHUB_REPOSITORY", "obot-platform/mcp-catalog")
+CATALOG_OWNER = os.getenv("CATALOG_OWNER", "obot-platform")
+CATALOG_REPO = os.getenv("CATALOG_REPO", "mcp-catalog")
+
+# Authentication tokens
+ISSUE_TOKEN = os.environ["GITHUB_TOKEN"]
+CATALOG_TOKEN = os.environ["GITHUB_TOKEN"]
+
+# Runtime configuration
+ISSUE_LABELS = [s.strip() for s in os.getenv("ISSUE_LABELS", "VerifiedMCPServer").split(",") if s.strip()]
+STAR_MIN = int(os.getenv("STAR_MIN", "500"))
+RECENT_DAYS = int(os.getenv("RECENT_DAYS", "30"))
+
+# State tracking
+ISSUE_NUMBER = 143
+START_MARK = "<!-- BEGIN MCP-SELECTED-SERVERS -->"
+END_MARK = "<!-- END MCP-SELECTED-SERVERS -->"
+
+# Parse repository info
+OWNER, REPO = TARGET_REPO_FULL.split("/", 1)
+
+# Initialize HTTP sessions
+S = requests.Session()
+S.headers.update({"User-Agent": "mcp-registry-sync/1.0"})
+
+GH = requests.Session()
+GH.headers.update({
+    "User-Agent": "mcp-catalog-selector/1.1", 
+    "Accept": "application/vnd.github+json",
+    "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}"
+})
+
+# Initialize OpenAI client
+client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+
+# =============================================================================
+# UTILITY FUNCTIONS
+# =============================================================================
+
+def _auth_headers(token: str) -> Dict[str, str]:
+    """Generate authorization headers for GitHub API."""
+    return {
+        "Authorization": f"Bearer {token}", 
+        "Accept": "application/vnd.github+json"
+    } if token else {"Accept": "application/vnd.github+json"}
+
+def first_str(*vals) -> Optional[str]:
+    """Return the first non-empty string from the arguments."""
+    for v in vals:
+        if isinstance(v, str) and v.strip():
+            return v.strip()
+    return None
+
+def _norm(s: str | None) -> str:
+    """Normalize string for comparison by removing special chars and common suffixes."""
+    if not s: 
+        return ""
+    s = s.lower()
+    s = re.sub(r"[\W_]+", "", s)  # keep alnum only
+    s = re.sub(r"(inc|corp|labs|llc|ltd|hq)$", "", s)  # drop common tails
+    s = re.sub(r"(ai|app)$", "", s)  # mild heuristic
+    return s
+
+def _sim(a: str, b: str) -> float:
+    """Calculate similarity ratio between two normalized strings."""
+    return SequenceMatcher(None, _norm(a), _norm(b)).ratio()
+
+def days_since(iso: str | None) -> float:
+    """Calculate days since an ISO timestamp."""
+    if not iso: 
+        return math.inf
+    t = dt.datetime.fromisoformat(iso.replace("Z", "+00:00"))
+    return (dt.datetime.now(dt.timezone.utc) - t).days
+
+def normalize_url(url):
+    """Normalize URL for comparison."""
+    parsed = urlparse(url)
+    netloc = parsed.hostname.lower()
+    if parsed.port and not (
+        (parsed.scheme == "http" and parsed.port == 80) or
+        (parsed.scheme == "https" and parsed.port == 443)
+    ):
+        netloc += f":{parsed.port}"
+    path = parsed.path or "/"
+    return urlunparse((parsed.scheme.lower(), netloc, path.rstrip("/"), "", "", ""))
+
+# =============================================================================
+# REGISTRY AND VERSION HANDLING
+# =============================================================================
+
+def _server_key(e: dict) -> str:
+    """Generate a unique key for a server entry."""
+    meta = (e.get("_meta") or {}).get("io.modelcontextprotocol.registry/official") or {}
+    if meta.get("serverId"):
+        return f"id:{meta['serverId']}"
+    if e.get("name"):
+        return f"name:{e['name'].lower()}"
+    repo = (e.get("repository") or {}).get("url", "")
+    try:
+        u = urlparse(repo)
+        if u.netloc == "github.com":
+            parts = [p for p in u.path.strip("/").split("/") if p]
+            if len(parts) >= 2:
+                return f"repo:{parts[0].lower()}/{parts[1].removesuffix('.git').lower()}"
+    except Exception:
+        pass
+    return f"obj:{id(e)}"
+
+def _parse_ver_str(v: Optional[str]) -> Optional[Version]:
+    """Parse version string into Version object."""
+    if not isinstance(v, str) or not v:
+        return None
+    try:
+        return Version(v.lstrip("vV"))
+    except InvalidVersion:
+        return None
+
+def fetch_registry_servers() -> list[dict]:
+    """Fetch all servers with pagination; keep only the highest version per server."""
+    best: dict[str, Tuple[Optional[Version], dict]] = {}  # key -> (semver, entry)
+    params, attempts = {"limit": 100}, 0
+
+    while True:
+        r = S.get(REGISTRY_URL, params=params, timeout=30)
+        if r.status_code >= 500 and attempts < 3:
+            attempts += 1
+            time.sleep(2 ** attempts)
+            continue
+        r.raise_for_status()
+        data = r.json()
+        items = data.get("servers") or data.get("items") or data.get("data") or data
+        if not isinstance(items, list):
+            raise RuntimeError(f"Unexpected registry payload keys: {list(data.keys())}")
+
+        for entry in items:
+            e = entry.get("server")
+            if not e:
+                continue
+            e["active"] = entry.get("_meta", {}).get("io.modelcontextprotocol.registry/official", {}).get("status", "").lower()
+            k = _server_key(e)
+            new_v = _parse_ver_str(e.get("version"))
+            old = best.get(k)
+            if not old:
+                best[k] = (new_v, e)
+            else:
+                old_v, _ = old
+                # choose if new_v is strictly newer; otherwise keep existing
+                if new_v is not None and (old_v is None or new_v > old_v):
+                    best[k] = (new_v, e)
+
+        metadata = data.get("metadata")
+        nxt = metadata.get("nextCursor") or metadata.get("next_cursor") or (metadata.get("cursor") or {}).get("next")
+        if not nxt:
+            break
+        params["cursor"] = nxt
+        # TEST
+        break
+
+    return [v[1] for v in best.values()]
+
+# =============================================================================
+# GITHUB API FUNCTIONS
+# =============================================================================
+
+def github_api(url: str, token: str = "", params=None) -> dict:
+    """Make authenticated GitHub API request."""
+    r = S.get(url, headers=_auth_headers(token), params=params or {}, timeout=30)
+    if r.status_code == 403 and "rate limit" in r.text.lower():
+        reset = r.headers.get("x-ratelimit-reset")
+        raise RuntimeError(f"GitHub API rate-limited. Try later. reset={reset}")
+    r.raise_for_status()
+    return r.json()
+
+def parse_repo_url(url: str):
+    """Parse GitHub repository URL into owner/repo tuple."""
+    try:
+        u = urlparse(url)
+        if u.netloc.lower() != "github.com": 
+            return (None, None)
+        parts = [p for p in u.path.strip("/").split("/") if p]
+        if len(parts) < 2: 
+            return (None, None)
+        return (parts[0], parts[1].removesuffix(".git"))
+    except Exception:
+        return (None, None)
+
+def get_default_branch(owner: str, repo: str, token: str = "") -> str:
+    """Get the default branch for a repository."""
+    data = github_api(f"https://api.github.com/repos/{owner}/{repo}", token)
+    return data.get("default_branch", "main")
+
+def repo_info(owner: str, repo: str):
+    """Get repository information using the authenticated session."""
+    r = GH.get(f"https://api.github.com/repos/{owner}/{repo}", timeout=20)
+    r.raise_for_status()
+    d = r.json()
+    return {
+        "owner_login": (d.get("owner") or {}).get("login", ""),
+        "owner_type": (d.get("owner") or {}).get("type", ""),
+        "stars": d.get("stargazers_count", 0),
+        "pushed_at": d.get("pushed_at"),
+        "is_fork": bool(d.get("fork")),
+        "is_archived": bool(d.get("archived")),
+    }
+
+def org_verified(owner_login: str) -> bool:
+    """Check if a GitHub organization is verified."""
+    r = GH.get(f"https://api.github.com/orgs/{owner_login}", timeout=20)
+    if r.status_code == 404:
+        return False
+    r.raise_for_status()
+    return bool(r.json().get("is_verified", False))
+
+# =============================================================================
+# CATALOG MANAGEMENT
+# =============================================================================
+
+def list_yaml_paths(owner: str, repo: str, token: str = "") -> List[str]:
+    """List *.yml/*.yaml files in the root directory only."""
+    branch = get_default_branch(owner, repo, token)
+    tree = github_api(f"https://api.github.com/repos/{owner}/{repo}/git/trees/{branch}", token)
+    paths = []
+    for node in tree.get("tree", []):
+        if (node.get("type") == "blob" and 
+            node.get("path", "").lower().endswith((".yaml", ".yml")) and
+            "/" not in node.get("path", "")):  # Only root directory files
+            paths.append(node["path"])
+    return paths
+
+def read_file_text(owner: str, repo: str, path: str, token: str = "") -> str:
+    """Read file content from GitHub repository."""
+    url = f"https://api.github.com/repos/{owner}/{repo}/contents/{path}"
+    data = github_api(url, token)
+    if isinstance(data, dict) and data.get("encoding") == "base64":
+        return base64.b64decode(data["content"]).decode("utf-8", errors="replace")
+    # fallback if api returns redirect/download_url
+    download_url = data.get("download_url")
+    if download_url:
+        r = S.get(download_url, timeout=30)
+        r.raise_for_status()
+        return r.text
+    raise RuntimeError(f"Unsupported content response shape for {path}")
+
+def load_y_ids_from_catalog(owner: str, repo: str, token: str = "") -> list[dict]:
+    """Load catalog entries from YAML files."""
+    res = []
+    for path in list_yaml_paths(owner, repo, token):
+        try:
+            txt = read_file_text(owner, repo, path, token)
+            doc = yaml.safe_load(txt)
+        except Exception:
+            continue
+        docs = doc if isinstance(doc, list) else [doc]
+        for d in docs:
+            short_desc = d.get("description", "").split("## Features")[0].strip()
+            r = {
+                "name": d.get("name"), 
+                "repoURL": d.get("repoURL"), 
+                "runtime": d.get("runtime"), 
+                "short_desc": short_desc
+            }
+            if r["runtime"] == "remote":
+                r["remoteConfig"] = d.get("remoteConfig")
+            res.append(r)
+    return res
+
+# =============================================================================
+# ISSUE MANAGEMENT
+# =============================================================================
+
+def create_issue_for_server(server: dict) -> tuple[str, int]:
+    """
+    Create a GitHub issue for an MCP server using its metadata.
+    
+    Returns:
+        Tuple of (issue_url, issue_number)
+    """
+    name = server.get('name', 'Unknown')
+    title = f"[MCP Catalog] New MCP server candidate: {name}"
+    
+    # Extract metadata
+    description = server.get('description', '')
+    version = server.get('version', '')
+    repo_info = server.get('repository', {})
+    repo_url = repo_info.get('url', '') if repo_info else ''
+    
+    # Extract packages info
+    packages = server.get('packages', [])
+    pkg_info = []
+    if packages:
+        for pkg in packages:
+            if isinstance(pkg, dict):
+                pkg_id = pkg.get('identifier', '')
+                pkg_version = pkg.get('version', '')
+                registry_type = pkg.get('registryType', '')
+                if pkg_id:
+                    pkg_info.append(f"  - {pkg_id} (v{pkg_version}, {registry_type})")
+    
+    # Extract remotes info
+    remotes = server.get('remotes', [])
+    remote_info = []
+    if remotes:
+        for remote in remotes:
+            if isinstance(remote, dict):
+                remote_type = remote.get('type', '')
+                remote_url = remote.get('url', '')
+                if remote_url:
+                    remote_info.append(f"  - {remote_type}: {remote_url}")
+    
+    # Build the issue body
+    body_parts = [
+        "Automatically Discovered via MCP Registry. **Parent Issue:** #143 (MCP Catalog Sync Tracking)", 
+        ""
+    ]
+    
+    if name:
+        body_parts.append(f"**Name:** {name}")
+    if "kind" in server:
+        body_parts.append(f"**Kind:** {server['kind']}")
+    if description:
+        body_parts.append(f"**Description:** {description}")
+    if version:
+        body_parts.append(f"**Version:** {version}")
+    if repo_url:
+        body_parts.append(f"**Repository:** {repo_url}")
+    
+    if pkg_info:
+        body_parts.extend(["", "**Packages:**"] + pkg_info)
+    
+    if remote_info:
+        body_parts.extend(["", "**Remote Endpoints:**"] + remote_info)
+    
+    if server.get('kind'):
+        body_parts.extend(["", f"**Server Type:** {server['kind']}"])
+    
+    body_parts.extend([
+        "", "---", "", 
+        "If we want to catalog this server, please add/update its YAML in `obot-platform/mcp-catalog` and link the PR here."
+    ])
+    
+    body = "\n".join(body_parts)
+    
+    print("→", title)
+    
+    if not ISSUE_TOKEN:
+        print(f"   [DRY RUN] Would create issue with body:\n{body[:200]}...")
+        return "https://github.com/example/repo/issues/12345", 12345  # Mock for dry run
+    
+    headers = {
+        'Authorization': f'token {ISSUE_TOKEN}',
+        'Accept': 'application/vnd.github+json',
+    }
+    
+    r = requests.post(
+        f"https://api.github.com/repos/{CATALOG_OWNER}/{CATALOG_REPO}/issues",
+        headers=headers,
+        json={"title": title, "body": body, "labels": ISSUE_LABELS or []},
+        timeout=30
+    )
+    r.raise_for_status()
+    
+    issue_data = r.json()
+    issue_url = issue_data.get('html_url', 'unknown URL')
+    issue_number = issue_data.get('number', 0)
+    
+    print(f"   ✓ Created issue #{issue_number}: {issue_url}")
+    return issue_url, issue_number
+
+# =============================================================================
+# STATE MANAGEMENT
+# =============================================================================
+
+def load_selected_servers() -> dict:
+    """Load the selected servers data from the state issue."""
+    if not ISSUE_TOKEN:
+        raise RuntimeError("GITHUB_TOKEN missing; cannot read state issue.")
+    
+    data = github_api(f"https://api.github.com/repos/{OWNER}/{REPO}/issues/{ISSUE_NUMBER}", ISSUE_TOKEN)
+    body = data.get("body") or ""
+    m = re.search(re.escape(START_MARK) + r"(.*?)" + re.escape(END_MARK), body, flags=re.DOTALL)
+    if not m:
+        return {}
+    
+    inner = m.group(1)
+    m2 = re.search(r"```json\s*(.*?)```", inner, flags=re.DOTALL)
+    if not m2:
+        return {}
+    
+    try:
+        data = json.loads(m2.group(1).strip())
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+def save_selected_servers(selected_servers: dict):
+    """Save the selected servers data to the state issue."""
+    data = github_api(f"https://api.github.com/repos/{OWNER}/{REPO}/issues/{ISSUE_NUMBER}", ISSUE_TOKEN)
+    body = data.get("body") or ""
+
+    json_block = json.dumps(selected_servers, indent=2, ensure_ascii=False)
+    new_block = f"{START_MARK}\n```json\n{json_block}\n```\n{END_MARK}"
+    pattern = re.escape(START_MARK) + r".*?" + re.escape(END_MARK)
+
+    if START_MARK in body and END_MARK in body:
+        body = re.sub(pattern, lambda m: new_block, body, count=1, flags=re.DOTALL)
+    else:
+        body = new_block + "\n\n" + body
+
+    r = S.patch(
+        f"https://api.github.com/repos/{OWNER}/{REPO}/issues/{ISSUE_NUMBER}",
+        headers=_auth_headers(ISSUE_TOKEN),
+        json={"body": body},
+        timeout=30
+    )
+    r.raise_for_status()
+    print(f"✓ Saved {len(selected_servers)} selected servers to state issue")
+
+def add_server_to_state(server: dict, issue_url: str, existing_servers: dict) -> dict:
+    """Add a newly processed server to the state dict."""
+    server_name = server.get('name', '')
+    if not server_name:
+        return existing_servers
+    
+    server_record = {
+        'name': server_name,
+        'description': server.get('description', ''),
+        'version': server.get('version', ''),
+        'repository_url': server.get('repository', {}).get('url', ''),
+        'server_type': server.get('kind', ''),
+        'issue_url': issue_url,
+        'processed_at': time.strftime('%Y-%m-%d %H:%M:%S UTC', time.gmtime())
+    }
+    
+    existing_servers[server_name] = server_record
+    return existing_servers
+
+# =============================================================================
+# AI-POWERED CLASSIFICATION
+# =============================================================================
+
+AI_OFFICIAL_JUDGE_PROMPT = """You are a reviewer deciding whether a GitHub MCP server is "official" or "community".
+
+Definition:
+- "Official": Published by the organization that owns/operates the underlying product/service the server integrates with (e.g., Google→Gmail, Teamwork→teamwork.com).
+- "Community": Any third-party implementation for someone else's product/service.
+
+Inputs you may receive:
+- server_name, github_org, repository URL, remotes (URLs), description,
+- repo metadata (owner type Organization/User, verified flag, fork/archived),
+- packages/identifiers (e.g., npm scope, docker repo) if available.
+
+Heuristics (no static allowlists; infer from evidence):
+Strong signals of Official:
+- Organization name matches the product/brand (normalized) found in server_name or repo (e.g., chrome-devtools ⇄ ChromeDevTools; mcpcap ⇄ mcpcap).
+- Remote endpoints are on the organization's domain and reference the product (e.g., mcp.ai.teamwork.com, mcp.blockscout.com, strata.klavis.ai).
+- Verified GitHub Organization; repository is not a fork and not archived.
+- Package namespace owned by the org (e.g., npm scope @brave/*, docker image under the org).
+
+Generic services require stricter proof:
+- For generic/ubiquitous services {"gmail","postgres","postgresql","mysql","slack","github","jira","confluence","notion","airtable","sheets","docs"}:
+  Only mark Official if the publisher is the actual brand owner (e.g., Google for Gmail, Slack for Slack).
+  Otherwise classify as Community, even if the org's domain appears in remotes.
+
+Weak/noisy signals (use with caution):
+- Reversed-domain in server name and domain similarity alone are insufficient for generic services.
+
+Negative signals (reduce confidence):
+- Repo is a fork or archived; owner is a personal user (not an org);
+- Remotes hosted on generic third‑party platforms without clear brand ownership evidence.
+
+Output JSON only:
+{ "decision": "official" | "community" | "uncertain", "confidence": 0.0..1.0, "reason": "<one concise sentence>" }
+Keep reasons short and evidence‑based (mention org, service, and the key signal).
+"""
+
+def gpt5_judge_service_ownership(server):
+    """Use AI to determine if a server is official or community."""
+    response = client.responses.create(
+        model="gpt-4.1",
+        input=AI_OFFICIAL_JUDGE_PROMPT + "\n\nInput:\n" + json.dumps(server)
+    )
+    return response
+
+def name_reversed_domain(name: str | None) -> str | None:
+    """Extract vendor token from reversed domain name."""
+    if not name or "/" not in name: 
+        return None
+    prefix = name.split("/", 1)[0]  # e.g., com.google
+    labels = prefix.split(".")
+    if len(labels) < 2: 
+        return None
+    sld = labels[-1]  # 'google' or 'containers'
+    return _norm(sld)
+
+def remote_domains(remotes: list | None) -> set[str]:
+    """Extract normalized domain names from remote URLs."""
+    out = set()
+    for r in remotes or []:
+        try:
+            host = urlparse(r.get("url", "")).netloc.lower()
+            if host:
+                parts = host.split(".")
+                if len(parts) >= 2:
+                    out.add(_norm(parts[-2]))  # SLD: vercel, atlassian, google
+        except Exception:
+            pass
+    return out
+
+def is_popular_community(repo_meta: dict) -> bool:
+    """Check if a community server meets popularity criteria."""
+    return (
+        repo_meta["stars"] >= STAR_MIN and
+        days_since(repo_meta["pushed_at"]) <= RECENT_DAYS and
+        not repo_meta["is_archived"]
+    )
+
+# =============================================================================
+# FILTERING AND CLASSIFICATION
+# =============================================================================
+
+def filter_group_x_ai(servers: List[dict], catalog_entries: List[dict], existing_servers: List[dict]) -> Tuple[List[dict], List[dict], List[dict]]:
+    """Filter MCP servers using AI judge for official/community classification."""
+    filtered_servers = []
+    non_active = []
+    likely_remote = []
+    
+    print(f"Starting AI-enhanced filtering with {len(servers)} servers...")
+    url_sets = set(normalize_url(y.get("repoURL")) for y in catalog_entries)
+    one_long_name_str = " ".join([y.get("name") for y in catalog_entries]).lower()
+    
+    for i, server in enumerate(servers):
+        # Basic filter: must be active
+        if str(server.get("active", "")).lower() != "active":
+            non_active.append(server)
+            continue
+
+        full_name = server.get("name")
+        if full_name in existing_servers:
+            print(f"Skipping server {full_name} because it already exists in the state index.")
+            continue
+            
+        name = full_name.split("/")[-1].lower()
+        if name != "mcp" and name in one_long_name_str:
+            print(f"[SKIP] Skipping server {full_name} because it is a duplicate of an existing server in the catalog.")
+            continue
+        
+        url = server.get("repository", {}).get("url", "")
+        if url:
+            if normalize_url(url) in url_sets:
+                print(f"Skipping server {server.get('name')} {url} because it already exists in the catalog, URL duplicate.")
+                continue
+                
+        owner, repo = parse_repo_url(url)
+        if not owner:
+            if "remotes" in server:
+                server["kind"] = "remote"
+                likely_remote.append(server)
+            continue
+
+        try:
+            m = repo_info(owner, repo)
+        except Exception as err:
+            print(f"Error fetching repo info for {owner}/{repo}: {err}")
+            continue
+
+        # Use AI judge to determine official vs community
+        ai_response = gpt5_judge_service_ownership(server)
+        ai_result = json.loads(ai_response.output[0].content[0].text)
+        
+        server["_ai_decision"] = ai_result["decision"]
+        server["_ai_confidence"] = ai_result["confidence"]
+        server["_ai_reason"] = ai_result["reason"]
+
+        # Determine final classification
+        if ai_result["decision"] == "official":
+            server["kind"] = "official"
+            print(f"  ✅ Official: {owner}/{repo} (AI confidence: {ai_result['confidence']:.2f})")
+            print(f"    🤖 AI: {ai_result['reason']}")
+            filtered_servers.append(server)
+            
+        elif ai_result["decision"] == "community":
+            # Apply community filtering criteria (stars + recent activity)
+            community_ok = is_popular_community(m)
+            
+            if community_ok:
+                server["kind"] = "community"
+                print(f"  ✓ Community: {owner}/{repo} (AI confidence: {ai_result['confidence']:.2f}, stars: {m['stars']}, recent: {days_since(m['pushed_at']):.0f}d)")
+                print(f"    🤖 AI: {ai_result['reason']}")
+                filtered_servers.append(server)
+            else:
+                print(f"  ✗ Community (filtered): {owner}/{repo} - insufficient stars ({m['stars']}) or not recent ({days_since(m['pushed_at']):.0f}d)")
+                print(f"    🤖 AI: {ai_result['reason']}")
+        
+        else:  # uncertain
+            print(f"  ❓ Uncertain: {owner}/{repo} (AI confidence: {ai_result['confidence']:.2f})")
+            print(f"    🤖 AI: {ai_result['reason']}")
+
+    official_count = len([s for s in filtered_servers if s.get("kind") == "official"])
+    community_count = len([s for s in filtered_servers if s.get("kind") == "community"])
+    
+    print(f"\nFiltered down to {len(filtered_servers)} servers:")
+    print(f"  - Official: {official_count}")
+    print(f"  - Community: {community_count}")
+    
+    return filtered_servers, non_active, likely_remote
+_project_id_cache = {}
+
+def get_project_id(project_number: int, owner: str, token: str = None) -> str:
+    """
+    Get the GitHub project ID from project number (cached).
+    
+    Args:
+        project_number: The project number (e.g., 2)
+        owner: GitHub username or organization name
+        token: GitHub personal access token
+    
+    Returns:
+        Project ID string, or None if not found
+    """
+    cache_key = f"{owner}:{project_number}"
+    
+    # Return cached value if available
+    if cache_key in _project_id_cache:
+        return _project_id_cache[cache_key]
+    
+    if token is None:
+        token = os.getenv('GITHUB_TOKEN')
+    
+    headers = {
+        'Authorization': f'Bearer {token}',
+        'Content-Type': 'application/json',
+    }
+    
+    query = """
+    query($owner: String!, $number: Int!) {
+      organization(login: $owner) {
+        projectV2(number: $number) {
+          id
+        }
+      }
+      user(login: $owner) {
+        projectV2(number: $number) {
+          id
+        }
+      }
+    }
+    """
+    
+    response = requests.post(
+        'https://api.github.com/graphql',
+        json={'query': query, 'variables': {'owner': owner, 'number': project_number}},
+        headers=headers
+    )
+    
+    if response.status_code != 200:
+        print(f"Error getting project: {response.status_code}")
+        return None
+    
+    data = response.json()
+    
+    # Extract project ID
+    project_id = None
+    if data.get('data', {}).get('organization', {}).get('projectV2'):
+        project_id = data['data']['organization']['projectV2']['id']
+    elif data.get('data', {}).get('user', {}).get('projectV2'):
+        project_id = data['data']['user']['projectV2']['id']
+    
+    if project_id:
+        _project_id_cache[cache_key] = project_id
+        print(f"✓ Found project ID: {project_id}")
+    
+    return project_id
+
+def add_issue_to_project(issue_url: str, issue_number: int, project_id: str, token: str = None) -> bool:
+    """
+    Add an existing issue to a GitHub project.
+    
+    Args:
+        issue_url: Full URL of the issue
+        issue_number: Issue number (from create_issue_for_server)
+        project_id: Project ID (from get_project_id - cached)
+        token: GitHub personal access token
+    
+    Returns:
+        True if successful, False otherwise
+    """
+    
+    if token is None:
+        token = os.getenv('GITHUB_TOKEN')
+    
+    headers = {
+        'Authorization': f'Bearer {token}',
+        'Content-Type': 'application/json',
+    }
+    
+    # Parse issue URL to get owner and repo
+    parts = issue_url.rstrip('/').split('/')
+    issue_owner = parts[-4]
+    issue_repo = parts[-3]
+    
+    # Get issue node ID
+    get_issue_query = """
+    query($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        issue(number: $number) {
+          id
+        }
+      }
+    }
+    """
+    
+    response = requests.post(
+        'https://api.github.com/graphql',
+        json={'query': get_issue_query, 'variables': {
+            'owner': issue_owner,
+            'repo': issue_repo,
+            'number': issue_number
+        }},
+        headers=headers
+    )
+    
+    if response.status_code != 200:
+        print(f"Error getting issue ID: {response.status_code}")
+        return False
+    
+    data = response.json()
+    issue_id = data.get('data', {}).get('repository', {}).get('issue', {}).get('id')
+    
+    if not issue_id:
+        print("Error: Could not find issue ID")
+        return False
+    
+    # Add issue to project
+    add_item_mutation = """
+    mutation($projectId: ID!, $contentId: ID!) {
+      addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+        item {
+          id
+        }
+      }
+    }
+    """
+    
+    response = requests.post(
+        'https://api.github.com/graphql',
+        json={'query': add_item_mutation, 'variables': {
+            'projectId': project_id,
+            'contentId': issue_id
+        }},
+        headers=headers
+    )
+    
+    if response.status_code != 200:
+        print(f"Error adding item to project: {response.status_code}")
+        return False
+    
+    data = response.json()
+    
+    if 'errors' in data:
+        print("Error adding item to project:")
+        for error in data['errors']:
+            print(f"  - {error.get('message', error)}")
+        return False
+    
+    print(f"   ✓ Added issue #{issue_number} to project")
+    return True
+# =============================================================================
+# MAIN EXECUTION
+# =============================================================================
+
+def main():
+    """Main execution function."""
+    print("=== MCP Server Catalog Selection Workflow ===\n")
+    PROJECT_NUMBER = 2 # fixed Obot AI project
+    project_id = get_project_id(PROJECT_NUMBER, CATALOG_OWNER, ISSUE_TOKEN)
+    if not project_id:
+        print("Error: Could not get project ID")
+        exit(1)
+    # Step 1: Fetch servers from registry
+    print("Fetching servers from MCP registry...")
+    servers = fetch_registry_servers()
+    print(f"Found {len(servers)} servers from registry")
+
+    # Step 2: Load existing catalog IDs to avoid duplicates
+    print("\nLoading existing catalog IDs...")
+    catalog_entries = load_y_ids_from_catalog(CATALOG_OWNER, CATALOG_REPO, CATALOG_TOKEN)
+    print(f"Found {len(catalog_entries)} existing catalog entries")
+
+    # Step 3: Load existing state
+    print(f"\nLoading existing selected servers state...")
+    existing_servers = load_selected_servers()
+    print(f"Found {len(existing_servers)} previously processed servers")
+
+    # Step 4: Filter and classify servers
+    print("\nFiltering and classifying servers...")
+    filtered_servers, non_active, likely_remote = filter_group_x_ai(servers, catalog_entries, existing_servers)
+
+    # Step 5: Create issues for new servers
+    print(f"\nProcessing {len(filtered_servers + likely_remote)} servers...")
+    new_issues_created = 0
+    merged_servers = filtered_servers + likely_remote
+
+    for server in merged_servers:
+        issue_url, issue_number  = create_issue_for_server(server)
+        add_issue_to_project(issue_url, issue_number, project_id, ISSUE_TOKEN)
+        existing_servers = add_server_to_state(server, issue_url, existing_servers)
+        new_issues_created += 1
+        
+        # TEST
+        break
+
+    # Step 6: Save updated state
+    save_selected_servers(existing_servers)
+
+    # Step 7: Summary
+    print(f"\n=== Summary ===")
+    print(f"New issues created: {new_issues_created}")
+    print(f"Total tracked servers: {len(existing_servers)}")
+    print(f"Non-active servers: {len(non_active)}")
+    print(f"Remote servers: {len(likely_remote)}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/upstream_sync/auto_sync_workflow.py
+++ b/scripts/upstream_sync/auto_sync_workflow.py
@@ -168,7 +168,7 @@ def fetch_registry_servers() -> list[dict]:
 def github_api(url: str, params=None) -> dict:
     """Make authenticated GitHub API request."""
     r = SESSION.get(url, params=params or {}, timeout=30)
-    if r.status_code == 403 and "rate limit" in r.text.lower():
+    if r.status_code == 429 and "rate limit" in r.text.lower():
         reset = r.headers.get("x-ratelimit-reset")
         raise RuntimeError(f"GitHub API rate-limited. Try later. reset={reset}")
     r.raise_for_status()
@@ -452,7 +452,7 @@ Output JSON only:
 Keep reasons short and evidence‑based (mention org, service, and the key signal).
 """
 
-def gpt5_judge_service_ownership(server):
+def gpt_judge_service_ownership(server):
     """Use AI to determine if a server is official or community."""
     response = client.responses.create(
         model="gpt-4.1",
@@ -537,7 +537,7 @@ def filter_group_x_ai(servers: List[dict], catalog_entries: List[dict], existing
             print(f"  💾 Using cached AI decision for {owner}/{repo}")
         else:
             # Call AI judge to determine official vs community
-            ai_response = gpt5_judge_service_ownership(server)
+            ai_response = gpt_judge_service_ownership(server)
             ai_result = json.loads(ai_response.output[0].content[0].text)
             
             # Save to cache

--- a/scripts/upstream_sync/requirements.txt
+++ b/scripts/upstream_sync/requirements.txt
@@ -1,0 +1,5 @@
+requests>=2.31.0
+pyyaml>=6.0.1
+packaging>=23.0
+openai>=1.0.0
+

--- a/scripts/upstream_sync/selected_server.json
+++ b/scripts/upstream_sync/selected_server.json
@@ -1,0 +1,677 @@
+{
+  "ai.mcpcap/mcpcap": {
+    "name": "ai.mcpcap/mcpcap",
+    "description": "An MCP server for analyzing PCAP files.",
+    "version": "0.4.3",
+    "repository_url": "https://github.com/mcpcap/mcpcap",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/146",
+    "processed_at": "2025-09-30 19:38:22 UTC"
+  },
+  "ai.klavis/strata": {
+    "name": "ai.klavis/strata",
+    "description": "MCP server for progressive tool usage at any scale (see https://klavis.ai)",
+    "version": "1.0.0",
+    "repository_url": "https://github.com/Klavis-AI/klavis",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/147",
+    "processed_at": "2025-09-30 19:44:21 UTC"
+  },
+  "ai.smithery/smithery-ai-cookbook-python-quickstart": {
+    "name": "ai.smithery/smithery-ai-cookbook-python-quickstart",
+    "description": "A simple MCP server built with FastMCP and python",
+    "version": "1.13.1",
+    "repository_url": "https://github.com/smithery-ai/smithery-cookbook",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/150",
+    "processed_at": "2025-09-30 21:50:34 UTC"
+  },
+  "ai.smithery/smithery-ai-cookbook-ts-smithery-cli": {
+    "name": "ai.smithery/smithery-ai-cookbook-ts-smithery-cli",
+    "description": "A simple Typescript MCP server built using the official MCP Typescript SDK and smithery/cli. This…",
+    "version": "1.0.0",
+    "repository_url": "https://github.com/smithery-ai/smithery-cookbook",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/151",
+    "processed_at": "2025-09-30 22:05:00 UTC"
+  },
+  "ai.toolprint/hypertool-mcp": {
+    "name": "ai.toolprint/hypertool-mcp",
+    "description": "Dynamically expose tools from proxied servers based on an Agent Persona",
+    "version": "0.0.42",
+    "repository_url": "https://github.com/toolprint/hypertool-mcp",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/152",
+    "processed_at": "2025-09-30 22:05:01 UTC"
+  },
+  "app.thoughtspot/mcp-server": {
+    "name": "app.thoughtspot/mcp-server",
+    "description": "MCP Server for ThoughtSpot - provides OAuth authentication and tools for querying data",
+    "version": "1.0.1",
+    "repository_url": "https://github.com/thoughtspot/mcp-server",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/153",
+    "processed_at": "2025-09-30 22:05:03 UTC"
+  },
+  "co.axiom/mcp": {
+    "name": "co.axiom/mcp",
+    "description": "List datasets, schemas, run APL queries, and use prompts for exploration, anomalies, and monitoring.",
+    "version": "1.0.0",
+    "repository_url": "https://github.com/axiomhq/mcp",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/154",
+    "processed_at": "2025-09-30 22:05:04 UTC"
+  },
+  "com.apify/apify-mcp-server": {
+    "name": "com.apify/apify-mcp-server",
+    "description": "Apify MCP server provides access to a marketplace for web scraping and data extraction tools.",
+    "version": "0.4.15",
+    "repository_url": "https://github.com/apify/apify-mcp-server",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/155",
+    "processed_at": "2025-09-30 22:05:06 UTC"
+  },
+  "com.devcycle/mcp": {
+    "name": "com.devcycle/mcp",
+    "description": "DevCycle MCP server for feature flag management",
+    "version": "6.1.0",
+    "repository_url": "https://github.com/DevCycleHQ/cli",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/156",
+    "processed_at": "2025-09-30 22:05:07 UTC"
+  },
+  "com.gibsonai/mcp": {
+    "name": "com.gibsonai/mcp",
+    "description": "GibsonAI MCP server: manage your databases with natural language",
+    "version": "1.0.0",
+    "repository_url": "https://github.com/gibsonai/mcp",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/157",
+    "processed_at": "2025-09-30 22:05:09 UTC"
+  },
+  "com.mux/mcp": {
+    "name": "com.mux/mcp",
+    "description": "The official MCP Server for the Mux API",
+    "version": "12.8.0",
+    "repository_url": "https://github.com/muxinc/mux-node-sdk",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/158",
+    "processed_at": "2025-09-30 22:05:10 UTC"
+  },
+  "com.onkernel/kernel-mcp-server": {
+    "name": "com.onkernel/kernel-mcp-server",
+    "description": "Access Kernel's cloud-based browsers and app actions via MCP (remote HTTP + OAuth).",
+    "version": "1.0.0",
+    "repository_url": "https://github.com/onkernel/kernel-mcp-server",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/159",
+    "processed_at": "2025-09-30 22:05:13 UTC"
+  },
+  "com.pulsemcp.servers/pulse-fetch": {
+    "name": "com.pulsemcp.servers/pulse-fetch",
+    "description": "MCP server that extracts clean, structured content from web pages with anti-bot bypass capabilities.",
+    "version": "0.2.14",
+    "repository_url": "https://github.com/pulsemcp/mcp-servers",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/160",
+    "processed_at": "2025-09-30 22:05:14 UTC"
+  },
+  "com.redpanda/docs-mcp": {
+    "name": "com.redpanda/docs-mcp",
+    "description": "Get authoritative answers to questions about Redpanda.",
+    "version": "1.0.0",
+    "repository_url": "https://github.com/redpanda-data/docs-site",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/161",
+    "processed_at": "2025-09-30 22:05:16 UTC"
+  },
+  "com.smartbear/smartbear-mcp": {
+    "name": "com.smartbear/smartbear-mcp",
+    "description": "MCP server for AI access to SmartBear tools, including BugSnag, Reflect, API Hub, PactFlow.",
+    "version": "0.6.0",
+    "repository_url": "https://github.com/SmartBear/smartbear-mcp",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/162",
+    "processed_at": "2025-09-30 22:05:17 UTC"
+  },
+  "com.teamwork/mcp": {
+    "name": "com.teamwork/mcp",
+    "description": "The Teamwork.com official MCP server helps teams efficiently manage client projects with AI.",
+    "version": "1.5.6",
+    "repository_url": "https://github.com/teamwork/mcp",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/163",
+    "processed_at": "2025-09-30 22:05:19 UTC"
+  },
+  "com.xcodebuildmcp/XcodeBuildMCP": {
+    "name": "com.xcodebuildmcp/XcodeBuildMCP",
+    "description": "XcodeBuildMCP provides tools for Xcode project management, simulator management, and app utilities.",
+    "version": "1.14.1",
+    "repository_url": "https://github.com/cameroncooke/XcodeBuildMCP",
+    "server_type": "community",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/164",
+    "processed_at": "2025-09-30 22:05:21 UTC"
+  },
+  "com.zomato/mcp": {
+    "name": "com.zomato/mcp",
+    "description": "An MCP server that exposes functionalities to use Zomato's services.",
+    "version": "1.0.0",
+    "repository_url": "https://github.com/Zomato/mcp-server-manifest",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/165",
+    "processed_at": "2025-09-30 22:05:22 UTC"
+  },
+  "dev.augments/mcp": {
+    "name": "dev.augments/mcp",
+    "description": "Augments MCP Server - A comprehensive framework documentation provider for Claude Code",
+    "version": "2.0.2",
+    "repository_url": "https://github.com/augmnt/augments-mcp-server",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/166",
+    "processed_at": "2025-09-30 22:05:24 UTC"
+  },
+  "dev.promplate/hmr": {
+    "name": "dev.promplate/hmr",
+    "description": "Docs for hot-module-reload and reactive programming for Python (`hmr` on PyPI)",
+    "version": "1.0.2",
+    "repository_url": "https://github.com/promplate/hmr",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/167",
+    "processed_at": "2025-09-30 22:05:25 UTC"
+  },
+  "io.balldontlie/mcp": {
+    "name": "io.balldontlie/mcp",
+    "description": "Provides access to live sports data and analytics from BALLDONTLIE: The Sports API",
+    "version": "1.1.0",
+    "repository_url": "https://github.com/balldontlie-api/mcp",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/168",
+    "processed_at": "2025-09-30 22:05:27 UTC"
+  },
+  "io.foqal/Foqal": {
+    "name": "io.foqal/Foqal",
+    "description": "Foqal turns Slack/Teams into efficient support platforms with AI-powered ticketing.",
+    "version": "2.0.1",
+    "repository_url": "https://github.com/foqal/mcp",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/169",
+    "processed_at": "2025-09-30 22:05:29 UTC"
+  },
+  "io.github.ChromeDevTools/chrome-devtools-mcp": {
+    "name": "io.github.ChromeDevTools/chrome-devtools-mcp",
+    "description": "MCP server for Chrome DevTools",
+    "version": "0.5.1",
+    "repository_url": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/170",
+    "processed_at": "2025-09-30 22:05:31 UTC"
+  },
+  "io.github.CodeAlive-AI/codealive-mcp": {
+    "name": "io.github.CodeAlive-AI/codealive-mcp",
+    "description": "Semantic code search and analysis from CodeAlive for AI assistants and agents.",
+    "version": "0.3.0",
+    "repository_url": "https://github.com/CodeAlive-AI/codealive-mcp.git",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/171",
+    "processed_at": "2025-09-30 22:05:32 UTC"
+  },
+  "io.github.CodeLogicIncEngineering/codelogic-mcp-server": {
+    "name": "io.github.CodeLogicIncEngineering/codelogic-mcp-server",
+    "description": "An MCP Server to utilize Codelogic's rich software dependency data in your AI programming assistant.",
+    "version": "1.0.11",
+    "repository_url": "https://github.com/CodeLogicIncEngineering/codelogic-mcp-server",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/172",
+    "processed_at": "2025-09-30 22:05:33 UTC"
+  },
+  "io.github.CursorTouch/Windows-MCP": {
+    "name": "io.github.CursorTouch/Windows-MCP",
+    "description": "An MCP Server for computer-use in Windows OS",
+    "version": "1.0.0",
+    "repository_url": "https://github.com/CursorTouch/Windows-MCP",
+    "server_type": "community",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/173",
+    "processed_at": "2025-09-30 22:05:35 UTC"
+  },
+  "io.github.Flightradar24/fr24api-mcp": {
+    "name": "io.github.Flightradar24/fr24api-mcp",
+    "description": "MCP server providing access to the Flightradar24 API for real-time and historical flight data",
+    "version": "1.0.1",
+    "repository_url": "https://github.com/Flightradar24/fr24api-mcp",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/174",
+    "processed_at": "2025-09-30 22:05:37 UTC"
+  },
+  "io.github.GLips/Figma-Context-MCP": {
+    "name": "io.github.GLips/Figma-Context-MCP",
+    "description": "Give your coding agent access to your Figma data. Implement designs in any framework in one-shot.",
+    "version": "0.6.0",
+    "repository_url": "https://github.com/GLips/Figma-Context-MCP",
+    "server_type": "community",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/175",
+    "processed_at": "2025-09-30 22:05:38 UTC"
+  },
+  "io.github.GoogleCloudPlatform/gemini-cloud-assist-mcp": {
+    "name": "io.github.GoogleCloudPlatform/gemini-cloud-assist-mcp",
+    "description": "MCP Server for understanding, managing & troubleshooting your GCP environment.",
+    "version": "0.1.1",
+    "repository_url": "https://github.com/GoogleCloudPlatform/gemini-cloud-assist-mcp",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/176",
+    "processed_at": "2025-09-30 22:05:40 UTC"
+  },
+  "io.github.OpenCageData/opencage-geocoding-mcp": {
+    "name": "io.github.OpenCageData/opencage-geocoding-mcp",
+    "description": "MCP server for OpenCage geocoding API",
+    "version": "1.0.3",
+    "repository_url": "https://github.com/OpenCageData/opencage-geocoding-mcp",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/177",
+    "processed_at": "2025-09-30 22:05:42 UTC"
+  },
+  "io.github.SonarSource/sonarqube-mcp-server": {
+    "name": "io.github.SonarSource/sonarqube-mcp-server",
+    "description": "An MCP server that enables integration with SonarQube Server or Cloud for code quality and security.",
+    "version": "0.0.8",
+    "repository_url": "https://github.com/SonarSource/sonarqube-mcp-server",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/178",
+    "processed_at": "2025-09-30 22:05:43 UTC"
+  },
+  "io.github.Synclub-tech/synclub-dxt": {
+    "name": "io.github.Synclub-tech/synclub-dxt",
+    "description": "SynClub MCP Server for AI-powered comic creation with script generation and image tools",
+    "version": "0.6.0",
+    "repository_url": "https://github.com/Synclub-tech/Synclub-dxt",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/179",
+    "processed_at": "2025-09-30 22:05:45 UTC"
+  },
+  "io.github.anyproto/anytype-mcp": {
+    "name": "io.github.anyproto/anytype-mcp",
+    "description": "Official MCP server for Anytype API - your encrypted, local and collaborative wiki.",
+    "version": "1.0.7",
+    "repository_url": "https://github.com/anyproto/anytype-mcp",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/180",
+    "processed_at": "2025-09-30 22:05:46 UTC"
+  },
+  "io.github.appwrite/mcp-for-api": {
+    "name": "io.github.appwrite/mcp-for-api",
+    "description": "MCP (Model Context Protocol) server for Appwrite",
+    "version": "0.2.7",
+    "repository_url": "https://github.com/appwrite/mcp-for-api",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/181",
+    "processed_at": "2025-09-30 22:05:48 UTC"
+  },
+  "io.github.augmnt/augments-mcp-server": {
+    "name": "io.github.augmnt/augments-mcp-server",
+    "description": "Augments MCP Server - A comprehensive framework documentation provider for Claude Code",
+    "version": "1.0.2",
+    "repository_url": "https://github.com/augmnt/augments-mcp-server",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/182",
+    "processed_at": "2025-09-30 22:05:50 UTC"
+  },
+  "io.github.bytedance/mcp-server-browser": {
+    "name": "io.github.bytedance/mcp-server-browser",
+    "description": "MCP server for browser use access",
+    "version": "1.0.0",
+    "repository_url": "https://github.com/bytedance/UI-TARS-desktop",
+    "server_type": "community",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/183",
+    "processed_at": "2025-09-30 22:05:51 UTC"
+  },
+  "io.github.bytedance/mcp-server-commands": {
+    "name": "io.github.bytedance/mcp-server-commands",
+    "description": "An MCP server to run arbitrary commands",
+    "version": "1.0.0",
+    "repository_url": "https://github.com/bytedance/UI-TARS-desktop",
+    "server_type": "community",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/184",
+    "processed_at": "2025-09-30 22:05:53 UTC"
+  },
+  "io.github.bytedance/mcp-server-filesystem": {
+    "name": "io.github.bytedance/mcp-server-filesystem",
+    "description": "MCP server for filesystem access",
+    "version": "1.0.0",
+    "repository_url": "https://github.com/bytedance/UI-TARS-desktop",
+    "server_type": "community",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/185",
+    "processed_at": "2025-09-30 22:05:54 UTC"
+  },
+  "io.github.bytedance/mcp-server-search": {
+    "name": "io.github.bytedance/mcp-server-search",
+    "description": "MCP server for web search operations",
+    "version": "1.0.0",
+    "repository_url": "https://github.com/bytedance/UI-TARS-desktop",
+    "server_type": "community",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/186",
+    "processed_at": "2025-09-30 22:05:56 UTC"
+  },
+  "io.github.cameroncooke/XcodeBuildMCP": {
+    "name": "io.github.cameroncooke/XcodeBuildMCP",
+    "description": "XcodeBuildMCP provides tools for Xcode project management, simulator management, and app utilities.",
+    "version": "1.12.8",
+    "repository_url": "https://github.com/cameroncooke/XcodeBuildMCP",
+    "server_type": "community",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/187",
+    "processed_at": "2025-09-30 22:05:58 UTC"
+  },
+  "io.github.containers/kubernetes-mcp-server": {
+    "name": "io.github.containers/kubernetes-mcp-server",
+    "description": "An MCP server that provides [describe what your server does]",
+    "version": "1.0.0",
+    "repository_url": "https://github.com/containers/kubernetes-mcp-server",
+    "server_type": "community",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/188",
+    "processed_at": "2025-09-30 22:06:00 UTC"
+  },
+  "io.github.croit/mcp-croit-ceph": {
+    "name": "io.github.croit/mcp-croit-ceph",
+    "description": "MCP server for Croit Ceph cluster management with dynamic OpenAPI tool generation",
+    "version": "0.2.16",
+    "repository_url": "https://github.com/croit/mcp-croit-ceph",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/189",
+    "processed_at": "2025-09-30 22:06:01 UTC"
+  },
+  "io.github.dynatrace-oss/Dynatrace-mcp": {
+    "name": "io.github.dynatrace-oss/Dynatrace-mcp",
+    "description": "Model Context Protocol server for Dynatrace - access logs, events, metrics from Dynatrace via MCP.",
+    "version": "0.6.0-rc.2",
+    "repository_url": "https://github.com/dynatrace-oss/Dynatrace-mcp",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/190",
+    "processed_at": "2025-09-30 22:06:03 UTC"
+  },
+  "io.github.florentine-ai/mcp": {
+    "name": "io.github.florentine-ai/mcp",
+    "description": "MCP server for Florentine.ai - Natural language to MongoDB aggregations",
+    "version": "0.2.0",
+    "repository_url": "https://github.com/florentine-ai/mcp",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/191",
+    "processed_at": "2025-09-30 22:06:04 UTC"
+  },
+  "io.github.hellocoop/admin-mcp": {
+    "name": "io.github.hellocoop/admin-mcp",
+    "description": "Model Context Protocol (MCP) for Hellō Admin API.",
+    "version": "1.5.7",
+    "repository_url": "https://github.com/hellocoop/admin-mcp",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/192",
+    "processed_at": "2025-09-30 22:06:06 UTC"
+  },
+  "io.github.localstack/localstack-mcp-server": {
+    "name": "io.github.localstack/localstack-mcp-server",
+    "description": "A LocalStack MCP Server providing essential tools for local cloud development & testing",
+    "version": "0.1.5",
+    "repository_url": "https://github.com/localstack/localstack-mcp-server",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/193",
+    "processed_at": "2025-09-30 22:06:08 UTC"
+  },
+  "io.github.mapbox/mcp-server": {
+    "name": "io.github.mapbox/mcp-server",
+    "description": "Geospatial intelligence with Mapbox APIs like geocoding, POI search, directions, isochrones, etc.",
+    "version": "0.5.4-dev-5",
+    "repository_url": "https://github.com/mapbox/mcp-server",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/194",
+    "processed_at": "2025-09-30 22:06:09 UTC"
+  },
+  "io.github.mobile-next/mobile-mcp": {
+    "name": "io.github.mobile-next/mobile-mcp",
+    "description": "MCP server for iOS and Android Mobile Development, Automation and Testing",
+    "version": "0.0.26",
+    "repository_url": "https://github.com/mobile-next/mobile-mcp",
+    "server_type": "community",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/195",
+    "processed_at": "2025-09-30 22:06:11 UTC"
+  },
+  "io.github.motherduckdb/mcp-server-motherduck": {
+    "name": "io.github.motherduckdb/mcp-server-motherduck",
+    "description": "Fast analytics and data processing with DuckDB and MotherDuck",
+    "version": "0.7.0",
+    "repository_url": "https://github.com/motherduckdb/mcp-server-motherduck",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/196",
+    "processed_at": "2025-09-30 22:06:12 UTC"
+  },
+  "io.github.nrwl/nx-console": {
+    "name": "io.github.nrwl/nx-console",
+    "description": "A Model Context Protocol server implementation for Nx",
+    "version": "0.6.12",
+    "repository_url": "https://github.com/nrwl/nx-console",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/197",
+    "processed_at": "2025-09-30 22:06:14 UTC"
+  },
+  "io.github.pubnub/mcp-server": {
+    "name": "io.github.pubnub/mcp-server",
+    "description": "PubNub MCP for Real-time messaging. API Access and SDK documentation.",
+    "version": "1.0.106",
+    "repository_url": "https://github.com/pubnub/pubnub-mcp-server",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/198",
+    "processed_at": "2025-09-30 22:06:15 UTC"
+  },
+  "io.github.railwayapp/mcp-server": {
+    "name": "io.github.railwayapp/mcp-server",
+    "description": "Official Railway MCP server",
+    "version": "0.1.5",
+    "repository_url": "https://github.com/railwayapp/railway-mcp-server",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/199",
+    "processed_at": "2025-09-30 22:06:17 UTC"
+  },
+  "io.github.ref-tools/ref-tools-mcp": {
+    "name": "io.github.ref-tools/ref-tools-mcp",
+    "description": "Token efficient search for coding agents over public and private documentation.",
+    "version": "3.0.1",
+    "repository_url": "https://github.com/ref-tools/ref-tools-mcp",
+    "server_type": "community",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/200",
+    "processed_at": "2025-09-30 22:06:19 UTC"
+  },
+  "io.github.ruvnet/claude-flow": {
+    "name": "io.github.ruvnet/claude-flow",
+    "description": "AI orchestration with hive-mind swarms, neural networks, and 87 MCP tools for enterprise dev.",
+    "version": "2.0.0-alpha.107",
+    "repository_url": "https://github.com/ruvnet/claude-flow",
+    "server_type": "community",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/201",
+    "processed_at": "2025-09-30 22:06:21 UTC"
+  },
+  "io.github.ryanbaumann/platform-ai": {
+    "name": "io.github.ryanbaumann/platform-ai",
+    "description": "Google Maps Platform Code Assist MCP",
+    "version": "0.2.0",
+    "repository_url": "https://github.com/googlemaps/platform-ai",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/202",
+    "processed_at": "2025-09-30 22:06:22 UTC"
+  },
+  "io.github.saucelabs-sample-test-frameworks/sauce-api-mcp": {
+    "name": "io.github.saucelabs-sample-test-frameworks/sauce-api-mcp",
+    "description": "An open-source MCP server that provides LLM access to the Sauce Labs API",
+    "version": "1.0.0",
+    "repository_url": "https://github.com/saucelabs/sauce-api-mcp",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/203",
+    "processed_at": "2025-09-30 22:06:24 UTC"
+  },
+  "io.github.schemacrawler/schemacrawler-ai": {
+    "name": "io.github.schemacrawler/schemacrawler-ai",
+    "description": "Enables natural language schema queries — explore tables, keys, procedures, and get SQL help fast",
+    "version": "v16.28.3-1",
+    "repository_url": "https://github.com/schemacrawler/SchemaCrawler-AI",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/204",
+    "processed_at": "2025-09-30 22:06:26 UTC"
+  },
+  "io.github.tuananh/hyper-mcp": {
+    "name": "io.github.tuananh/hyper-mcp",
+    "description": "📦️ A fast, secure MCP server that extends its capabilities through WebAssembly plugins",
+    "version": "1.0.0",
+    "repository_url": "https://github.com/tuananh/hyper-mcp",
+    "server_type": "community",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/205",
+    "processed_at": "2025-09-30 22:06:27 UTC"
+  },
+  "io.github.variflight/variflight-mcp": {
+    "name": "io.github.variflight/variflight-mcp",
+    "description": "VariFlight's official MCP server provides tools to query flight, weather, comfort, and fare data.",
+    "version": "1.0.2",
+    "repository_url": "https://github.com/variflight/variflight-mcp",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/206",
+    "processed_at": "2025-09-30 22:06:29 UTC"
+  },
+  "io.github.wonderwhy-er/desktop-commander": {
+    "name": "io.github.wonderwhy-er/desktop-commander",
+    "description": "MCP server for terminal commands, file operations, and process management",
+    "version": "0.2.16",
+    "repository_url": "https://github.com/wonderwhy-er/DesktopCommanderMCP",
+    "server_type": "community",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/207",
+    "processed_at": "2025-09-30 22:06:31 UTC"
+  },
+  "io.github.yifancong/rsdoctor": {
+    "name": "io.github.yifancong/rsdoctor",
+    "description": "An MCP server that provides build analysis and optimization recommendations for Rspack projects.",
+    "version": "0.1.0",
+    "repository_url": "https://github.com/web-infra-dev/rsdoctor",
+    "server_type": "community",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/208",
+    "processed_at": "2025-09-30 22:06:33 UTC"
+  },
+  "io.github.zenml-io/mcp-zenml": {
+    "name": "io.github.zenml-io/mcp-zenml",
+    "description": "MCP server for ZenML - browse stacks, pipelines, runs, artifacts & trigger pipeline runs via API",
+    "version": "1.0.4",
+    "repository_url": "https://github.com/zenml-io/mcp-zenml",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/209",
+    "processed_at": "2025-09-30 22:06:35 UTC"
+  },
+  "io.globalping/mcp": {
+    "name": "io.globalping/mcp",
+    "description": "Interact with a global network measurement platform.Run network commands from any point in the world",
+    "version": "1.0.0",
+    "repository_url": "https://github.com/jsdelivr/globalping-mcp-server",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/210",
+    "processed_at": "2025-09-30 22:06:36 UTC"
+  },
+  "io.scorecard/mcp": {
+    "name": "io.scorecard/mcp",
+    "description": "MCP server providing access to the Scorecard API to evaluate and optimize LLM systems.",
+    "version": "2.1.1",
+    "repository_url": "https://github.com/scorecard-ai/scorecard-node",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/211",
+    "processed_at": "2025-09-30 22:06:38 UTC"
+  },
+  "io.snyk/mcp": {
+    "name": "io.snyk/mcp",
+    "description": "Easily find and fix security issues in your applications leveraging Snyk platform capabilities.",
+    "version": "1.1299.1",
+    "repository_url": "https://github.com/snyk/snyk-ls",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/212",
+    "processed_at": "2025-09-30 22:06:40 UTC"
+  },
+  "net.gepuro.mcp-company-lens-v1/company-lens-mcp-registry": {
+    "name": "net.gepuro.mcp-company-lens-v1/company-lens-mcp-registry",
+    "description": "Search Japanese company database",
+    "version": "1.0.0",
+    "repository_url": "https://github.com/gepuro/company-lens-mcp-registry",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/213",
+    "processed_at": "2025-09-30 22:06:41 UTC"
+  },
+  "ai.smithery/blockscout-mcp-server": {
+    "name": "ai.smithery/blockscout-mcp-server",
+    "description": "Provide AI agents and automation tools with contextual access to blockchain data including balance…",
+    "version": "1.13.1",
+    "repository_url": "https://github.com/blockscout/mcp-server",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/215",
+    "processed_at": "2025-09-30 23:50:25 UTC"
+  },
+  "ai.waystation/mcp": {
+    "name": "ai.waystation/mcp",
+    "description": "Ultimate toolbox to connect your LLM to popular productivity tools such as Monday, AirTable, Slack",
+    "version": "0.3.1",
+    "repository_url": "https://github.com/waystation-ai/mcp",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/216",
+    "processed_at": "2025-09-30 23:50:26 UTC"
+  },
+  "ai.waystation/office": {
+    "name": "ai.waystation/office",
+    "description": "Create, edit, and collaborate on Office documents and spreadsheets.",
+    "version": "0.3.1",
+    "repository_url": "https://github.com/waystation-ai/mcp",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/217",
+    "processed_at": "2025-09-30 23:50:28 UTC"
+  },
+  "com.blockscout/mcp-server": {
+    "name": "com.blockscout/mcp-server",
+    "description": "MCP server for Blockscout",
+    "version": "0.11.0",
+    "repository_url": "https://github.com/blockscout/mcp-server",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/218",
+    "processed_at": "2025-09-30 23:50:30 UTC"
+  },
+  "com.docfork/docfork-mcp": {
+    "name": "com.docfork/docfork-mcp",
+    "description": "MCP server for Docfork",
+    "version": "0.7.2",
+    "repository_url": "https://github.com/docfork/docfork-mcp",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/219",
+    "processed_at": "2025-09-30 23:50:32 UTC"
+  },
+  "com.falkordb/QueryWeaver": {
+    "name": "com.falkordb/QueryWeaver",
+    "description": "An MCP server for Text2SQL: transforms natural language into SQL using graph schema understanding.",
+    "version": "0.0.11",
+    "repository_url": "https://github.com/FalkorDB/QueryWeaver",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/220",
+    "processed_at": "2025-09-30 23:50:33 UTC"
+  },
+  "io.github.brave/brave-search-mcp-server": {
+    "name": "io.github.brave/brave-search-mcp-server",
+    "description": "Brave Search MCP Server: web results, images, videos, rich results, AI summaries, and more.",
+    "version": "2.0.24",
+    "repository_url": "https://github.com/brave/brave-search-mcp-server",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/221",
+    "processed_at": "2025-09-30 23:50:35 UTC"
+  },
+  "io.github.macuse-app/macuse": {
+    "name": "io.github.macuse-app/macuse",
+    "description": "Bridges AI assistants with native macOS functionality through the Model Context Protocol (MCP).",
+    "version": "1.0.1",
+    "repository_url": "https://github.com/macuse-app/macuse",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/222",
+    "processed_at": "2025-09-30 23:50:37 UTC"
+  },
+  "io.ignission/mcp": {
+    "name": "io.ignission/mcp",
+    "description": "TikTok video data analytics and content strategy tools",
+    "version": "1.0.0",
+    "repository_url": "https://github.com/ignission-io/mcp",
+    "server_type": "official",
+    "issue_url": "https://github.com/obot-platform/mcp-catalog/issues/223",
+    "processed_at": "2025-09-30 23:50:39 UTC"
+  }
+}


### PR DESCRIPTION
Goal: Automatically discover and file issues for MCP servers from upstream registries so we can evaluate and add them to our catalog.

How this works (high level):
1. Fetches all MCP servers from the official registry (with pagination) -- Will expand this to multiple upstreams.
2. Loads existing catalog entries and previously processed servers to avoid duplicates
3. Filter to candidates that are:
- Active in the upstream registry
- Not already in the catalog
- Not already processed
4. AI Classification - Uses Gpt4.1 to categorize each server as:
- "Official" → Published by the product owner (e.g., Google for Gmail)
- "Community" → Third-party; must have 500+ stars and recent activity
5. Creates GitHub issues for qualifying servers with metadata, these issues are also tracked as sub-issues of https://github.com/obot-platform/mcp-catalog/issues/143
6. Caches AI decisions to avoid re-processing and saves states.