### PR TITLE
enhance: switch tavily MCP  to remote http

### DIFF
--- a/tavily_search.yaml
+++ b/tavily_search.yaml
@@ -33,26 +33,22 @@ description: '![Tavily Crawl Beta](https://raw.githubusercontent.com/tavily-ai/t
 
   **Required:**
 
-  - **Tavily API Key**: Get your free API key at [app.tavily.com](https://app.tavily.com/home)
+  - **Tavily API Key**: Get your free API key at [app.tavily.com](https://app.tavily.com/home), make sure to add the prefix "Bearer ", for example -- "Bearer <your_api_key>"
 
   '
 metadata:
   categories: Retrieval & Search, SaaS & API Integrations, Developer Tools
 icon: https://avatars.githubusercontent.com/u/170207473?v=4
 repoURL: https://github.com/tavily-ai/tavily-mcp
-env:
-- key: TAVILY_API_KEY
-  name: Tavily API Key
-  required: true
-  sensitive: true
-  description: Your Tavily API key. Get one at https://app.tavily.com/home
-runtime: containerized
-containerizedConfig:
-  image: ghcr.io/obot-platform/mcp-images/tavily:0.2.9
-  port: 8099
-  path: /
-  args:
-  - tavily-mcp
+runtime: remote
+remoteConfig:
+  fixedURL: https://mcp.tavily.com/mcp/
+  headers:
+  - name: Tavily API Key with prefix "Bearer "
+    description: Tavily API Key, make sure to add the prefix "Bearer ", for example -- "Bearer <your_api_key>"
+    key: Authorization
+    required: true
+    sensitive: true
 toolPreview:
 - name: tavily_search
   description: Search the web for real-time information about any topic. Use this tool when you need up-to-date information that might not be available in your training data, or when you need to verify current facts. The search results will include relevant snippets and URLs from web pages. This is particularly useful for questions about current events, technology updates, or any topic that requires recent information.


### PR DESCRIPTION
https://github.com/obot-platform/mcp-catalog/issues/242

Previously, their remote server required embedding the API key directly in the URL, which was insecure. They now support passing the API key via an HTTP header, so we’ve switched to using remote HTTP instead.
