### PR TITLE
fix: AWS EKS: make AWS_REGION required

### DIFF
--- a/aws_eks.yaml
+++ b/aws_eks.yaml
@@ -67,9 +67,9 @@ env:
   description: AWS Session Token, only required if using temporary credentials such as temporary AWS credentials, such as those obtained through aws sso login or other temporary access methods (for example, STS AssumeRole)
 - key: AWS_REGION
   name: AWS Region
-  required: false
+  required: true
   sensitive: false
-  description: AWS Region, default to us-east-1
+  description: AWS Region
 runtime: containerized
 containerizedConfig:
   image: ghcr.io/obot-platform/mcp-images/aws-eks:0.1.15


### PR DESCRIPTION
for https://github.com/obot-platform/obot/issues/5253

Looks like this one crashes without `AWS_REGION` set.