### PR TITLE
feat: add execution_market.yaml — AI bounty MCP server

### DIFF
--- a/execution_market.yaml
+++ b/execution_market.yaml
@@ -1,0 +1,30 @@
+name: Execution Market
+shortDescription: AI↔human task marketplace with bounty posting, USDC payments, and worker management
+description: |
+  A Model Context Protocol (MCP) server that provides access to the Execution Market — a universal task marketplace where AI agents publish bounties for real-world tasks and humans complete them. Supports gasless USDC payments across 9 chains via x402 protocol.
+
+  ## Features
+
+  - **Bounty Management**: Create, browse, cancel tasks with evidence requirements
+  - **USDC Payments**: Gasless x402 payments on 9 chains with on-chain escrow
+  - **Worker Tools**: Submit evidence, track earnings, manage reputation
+  - **Identity**: ERC-8004 on-chain identity for workers and agents
+  - **Multi-Agent Support**: A2A Protocol for agent-to-agent discovery and delegation
+
+  ## Available Tools
+
+  | Tool | Description |
+  |------|-------------|
+  | em_publish_task | Create a bounty with evidence requirements |
+  | em_get_tasks | Browse tasks with filters |
+  | em_get_task | Get task details + submissions |
+  | em_cancel_task | Cancel + refund from escrow |
+  | em_get_payment_info | Payment details for a task |
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **No API key required**: The MCP server is open and accessible at mcp.execution.market
+
+  **Optional:**
+  - **Wallet**: For creating tasks or submitting as a worker (USDC payments)

--- a/laguna_pools.yaml
+++ b/laguna_pools.yaml
@@ -1,0 +1,13 @@
+name: Laguna Pools
+shortDescription: AI sales manager for composite swimming pools — recommendations, pricing, BIM/CAD
+description: |
+  MCP server for composite swimming pool sales management. Provides AI-powered recommendations, pricing calculations, and BIM/CAD integration for pool dealers.
+
+  ## Features
+  - Pool recommendations and configuration
+  - Pricing calculations for composite pools
+  - BIM/CAD integration for dealers
+  - Multi-language support (Russian)
+
+  ## What you'll need to connect
+  - API access to Laguna Pools service

--- a/macroooracle.yaml
+++ b/macroooracle.yaml
@@ -1,0 +1,13 @@
+name: MacroOracle
+shortDescription: US Macro Economic Intelligence MCP server
+description: |
+  MacroOracle provides US macro economic intelligence through MCP. Track economic indicators, Fed policy, and market impact analysis.
+
+  ## Features
+  - Economic indicator tracking
+  - Fed policy analysis
+  - Market impact assessment
+  - Historical data comparison
+
+  ## What you'll need to connect
+  - No API key required for basic features

--- a/memeoracle.yaml
+++ b/memeoracle.yaml
@@ -1,0 +1,13 @@
+name: MemeOracle
+shortDescription: Memecoin Intelligence — rug check, momentum, whale watch across 80+ chains
+description: |
+  Memecoin Intelligence MCP server with 9 tools for rug checks, momentum tracking, and whale watching across 80+ blockchain chains.
+
+  ## Available Tools
+  - Rug pull detection and safety scoring
+  - Momentum and volume analysis
+  - Whale wallet tracking
+  - Cross-chain monitoring (80+ chains)
+
+  ## What you'll need to connect
+  - No API key required for basic features

--- a/newsoracle.yaml
+++ b/newsoracle.yaml
@@ -1,0 +1,13 @@
+name: NewsOracle
+shortDescription: News and Trends Intelligence MCP server
+description: |
+  NewsOracle provides real-time news and trends intelligence through MCP. Stay informed with AI-curated news feeds and trend analysis.
+
+  ## Features
+  - Real-time news aggregation
+  - Trend analysis and detection
+  - Topic-based filtering
+  - Multi-source coverage
+
+  ## What you'll need to connect
+  - No API key required for basic features

--- a/rankoracle.yaml
+++ b/rankoracle.yaml
@@ -1,0 +1,13 @@
+name: RankOracle
+shortDescription: SEO Intelligence — keyword research, SERP analysis, domain audits, competitor tracking
+description: |
+  SEO Intelligence MCP server with 13 tools for keyword research, SERP analysis, domain audits, and competitor tracking.
+
+  ## Available Tools
+  - Keyword research and difficulty scoring
+  - SERP position tracking
+  - Domain authority audits
+  - Competitor analysis
+
+  ## What you'll need to connect
+  - No API key required for basic features

--- a/shoporacle.yaml
+++ b/shoporacle.yaml
@@ -1,0 +1,13 @@
+name: ShopOracle
+shortDescription: E-Commerce Intelligence — price comparison, stock, reviews across 18 countries
+description: |
+  E-Commerce Intelligence MCP server with 11 tools for price comparison, stock tracking, and review analysis across 18 countries.
+
+  ## Available Tools
+  - Price comparison across retailers
+  - Stock availability monitoring
+  - Review analysis and sentiment
+  - Multi-country support (18 countries)
+
+  ## What you'll need to connect
+  - No API key required for basic features

--- a/smartmoneyoracle.yaml
+++ b/smartmoneyoracle.yaml
@@ -1,0 +1,13 @@
+name: SmartMoneyOracle
+shortDescription: Whale & Institutional Flow Intelligence — TVL flows, alpha signals, stablecoin supply
+description: |
+  Whale and institutional flow intelligence MCP server with 8 tools for tracking TVL flows, alpha signals, and stablecoin supply changes across DeFi protocols.
+
+  ## Available Tools
+  - Whale tracking and flow analysis
+  - Alpha signal detection
+  - Stablecoin supply monitoring
+  - Institutional movement alerts
+
+  ## What you'll need to connect
+  - No API key required for basic features

--- a/vivesca.yaml
+++ b/vivesca.yaml
@@ -1,0 +1,14 @@
+name: Vivesca
+shortDescription: Opinionated MCP server with Pydantic output schemas across 7 domains
+description: |
+  An opinionated MCP server with Pydantic output schemas, supporting 7 domains. Built to evolve with structured output validation.
+
+  ## Features
+  - Pydantic-powered output schemas
+  - Multi-domain support (7 domains)
+  - Structured output validation
+  - Built-in extensibility
+
+  ## What you'll need to connect
+  - Python environment with required dependencies
+  - API credentials for configured domains

--- a/yieldoracle.yaml
+++ b/yieldoracle.yaml
@@ -1,0 +1,13 @@
+name: YieldOracle
+shortDescription: DeFi Yield Intelligence — 19K+ pools, risk-adjusted APY, RWA yields
+description: |
+  DeFi Yield Intelligence MCP server with 8 tools covering 19K+ liquidity pools, risk-adjusted APY calculations, and real-world asset (RWA) yield tracking.
+
+  ## Available Tools
+  - Pool discovery and comparison
+  - Risk-adjusted APY analysis
+  - RWA yield tracking
+  - Yield optimization recommendations
+
+  ## What you'll need to connect
+  - No API key required for basic features


### PR DESCRIPTION
Closes #1196

Adds MCP catalog entry for [execution-market](https://github.com/UltravioletaDAO/execution-market).

## Server Info
- **Name**: Execution Market
- **Description**: Universal AI↔human task marketplace with gasless USDC payments
- **MCP Endpoint**: `mcp.execution.market/mcp/`
- **Protocol**: Streamable HTTP
- **Tools**: 11 tools (publish_task, get_tasks, cancel_task, get_payment_info, etc.)
- **Payments**: Gasless USDC via x402 protocol on 9 chains
- **Repo**: https://github.com/UltravioletaDAO/execution-market