### PR TITLE
fix: migrate Atlassian MCP to Streamable HTTP transport

### DIFF
--- a/atlassian.yaml
+++ b/atlassian.yaml
@@ -262,5 +262,5 @@ icon: https://avatars.githubusercontent.com/u/168166?s=200&v=4
 repoURL: https://support.atlassian.com/atlassian-rovo-mcp-server/docs/getting-started-with-the-atlassian-remote-mcp-server/
 runtime: remote
 remoteConfig:
-  fixedURL: https://mcp.atlassian.com/v1/sse
+  fixedURL: https://mcp.atlassian.com/v1/mcp
 


### PR DESCRIPTION
## Summary

- Migrate the Atlassian MCP server `fixedURL` from the deprecated HTTP+SSE endpoint (`/v1/sse`) to the new Streamable HTTP endpoint (`/v1/mcp`)

## Motivation

Atlassian has announced that the HTTP+SSE transport endpoint at `https://mcp.atlassian.com/v1/sse` will be deprecated after **June 30, 2026**. Clients should migrate to the Streamable HTTP transport at `https://mcp.atlassian.com/v1/mcp`.

Ref: https://community.atlassian.com/forums/Atlassian-Remote-MCP-Server/HTTP-SSE-Deprecation-Notice/ba-p/3205484

## Changes

- `atlassian.yaml`: Update `remoteConfig.fixedURL` from `https://mcp.atlassian.com/v1/sse` → `https://mcp.atlassian.com/v1/mcp`