### PR TITLE
Add Xquik remote MCP catalog entry

### DIFF
--- a/xquik.yaml
+++ b/xquik.yaml
@@ -1,0 +1,39 @@
+name: Xquik
+shortDescription: Search, extract, monitor, and automate X data through a remote MCP server
+description: |
+  A remote Model Context Protocol (MCP) server for Xquik, an X data platform with REST endpoints, extraction jobs, webhooks, monitors, compose workflows, and write actions.
+
+  ## Features
+  - **API Discovery**: Search the Xquik API specification before making live calls
+  - **X Data Access**: Search tweets, look up users, fetch timelines, inspect articles, and download media
+  - **Bulk Extraction**: Run 23 extraction tools for followers, following, replies, quotes, retweets, mentions, communities, lists, spaces, likes, and media
+  - **Automation**: Manage monitors, webhooks, drafts, draws, and compose workflows
+  - **Write Workflows**: Post tweets, manage likes, retweets, follows, DMs, profile media, and connected accounts through authenticated requests
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **Xquik API Key**: Create an API key from the Xquik dashboard and send it with each MCP request
+
+metadata:
+  categories: Developer Tools, SaaS & API Integrations, Data & Analytics
+icon: https://xquik.com/icon.svg
+repoURL: https://docs.xquik.com/mcp/overview
+runtime: remote
+remoteConfig:
+  fixedURL: https://xquik.com/mcp
+  headers:
+  - name: Xquik API Key
+    description: Xquik API key
+    key: X-API-Key
+    required: true
+    sensitive: true
+toolPreview:
+- name: explore
+  description: Search and browse Xquik API endpoints before making live API calls.
+  params:
+    code: Async arrow function that filters spec.endpoints and returns matching endpoint details
+- name: xquik
+  description: Execute authenticated Xquik API calls with xquik.request(path, options).
+  params:
+    code: Async arrow function that calls xquik.request with method, query, or body options


### PR DESCRIPTION
## Summary

- Add Xquik as a remote MCP server catalog entry.
- Include X-API-Key header config, public MCP docs, public icon, and tool previews for `explore` and `xquik`.

## Validation

- Parsed all 80 root YAML files with PyYAML.
- Ran the catalog env requirement helper for `xquik`.
- Ran the MCP tool linter in OpenAI-format mode for `xquik.yaml`.
- Checked changed-file links: icon and docs returned 200; the MCP endpoint returned 401 as expected without auth.

## Duplicate Checks

- No Xquik aliases found in the default branch.
- No open or closed PRs or issues found for Xquik aliases.
