### PR TITLE
fix: terraform: set correct args

### DIFF
--- a/terraform.yaml
+++ b/terraform.yaml
@@ -273,8 +273,7 @@ containerizedConfig:
   port: 8080
   path: "/mcp"
   args:
-  - /bin/terraform-mcp-server
-  - http
+  - streamable-http
   - --transport-port
   - 8080
   - --transport-host


### PR DESCRIPTION
for https://github.com/obot-platform/obot/issues/6364

Per the [docs](https://github.com/hashicorp/terraform-mcp-server#command-line-options), these are the correct args to set. The default entrypoint of `/bin/terraform-mcp-server` is already there in the container image, and we shouldn't be repeating it in the args.