### PR TITLE
fix: playwright: set correct arg

### DIFF
--- a/playwright.yaml
+++ b/playwright.yaml
@@ -117,4 +117,4 @@ containerizedConfig:
   port: 8099
   path: /
   args:
-  - mcp-server-playwright
+  - playwright-mcp


### PR DESCRIPTION
for https://github.com/obot-platform/obot/issues/6363

The name of the executable we were passing to nanobot was incorrect.

This might not be the only issue with playwright in main, but I know this fixes it locally at least. I'll continue troubleshooting if it still does not work.