### PR TITLE
Add Hive Intelligence MCP catalog entry

### DIFF
--- a/.github/workflows/tool-preview-refresh.yml
+++ b/.github/workflows/tool-preview-refresh.yml
@@ -49,6 +49,7 @@ on:
           - google-sheets.yaml
           - grafana.yaml
           - hubspot.yaml
+          - hive_intelligence.yaml
           - linear.yaml
           - markitdown.yaml
           - microsoft-docs.yaml

--- a/hive_intelligence.yaml
+++ b/hive_intelligence.yaml
@@ -1,0 +1,47 @@
+name: Hive Intelligence
+serverUserType: singleUser
+shortDescription: Access live crypto market data, wallet intelligence, DeFi analytics, token risk, and prediction markets
+description: |
+  A managed Model Context Protocol (MCP) server for crypto market infrastructure. Hive Intelligence gives AI agents one hosted endpoint for live prices, wallet positions, DeFi activity, DEX flows, NFT analytics, token and contract risk, Solana data, network status, and prediction markets.
+
+  ## Features
+  - **Runtime tool discovery**: Start with compact discovery tools, inspect schemas at runtime, and route requests to the exact provider-backed endpoint.
+  - **Market and token research**: Query live prices, market charts, OHLC, exchange data, token metadata, holders, liquidity, and DEX pairs.
+  - **Wallet and portfolio intelligence**: Inspect balances, token holdings, transfers, approvals, PnL context, NFTs, and DeFi positions across supported chains.
+  - **Security and risk checks**: Analyze token security, approvals, phishing, malicious addresses, dApp risk, rug-pull signals, and transaction simulation context.
+  - **DeFi, NFT, and prediction-market analytics**: Research protocol TVL and fees, NFT collections and sales, Solana assets, and Polymarket-style prediction-market data.
+  - **Stateful monitoring**: Create durable crypto intelligence monitors for wallets, tokens, protocols, markets, watchlists, and risk workflows.
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **Hive API Key**: Create a key from the Hive dashboard at [hiveintelligence.xyz](https://www.hiveintelligence.xyz/login?next=/dashboard/keys). The demo tier includes 10,000 monthly credits.
+
+metadata:
+  categories: Finance & Business, Data & Analytics, Security & Compliance
+icon: https://www.hiveintelligence.xyz/favicon.ico
+repoURL: https://github.com/hive-intel/hive-sdk
+runtime: remote
+remoteConfig:
+  fixedURL: https://mcp.hiveintelligence.xyz/mcp
+  headers:
+  - name: Hive API Key
+    description: Hive Intelligence API key
+    key: Authorization
+    required: true
+    sensitive: true
+    prefix: "Bearer "
+toolPreview:
+  - name: search_tools
+    description: Search Hive's crypto intelligence catalog to find the right task toolset, provider endpoint, schema, or entity identifier for a natural-language request.
+    params:
+      query: Natural-language description of the market, wallet, token, DeFi, NFT, risk, network, Solana, or prediction-market task.
+  - name: get_api_endpoint_schema
+    description: Retrieve the current argument schema and provider details for a specific Hive endpoint before invoking it.
+    params:
+      tool_name: Name of the Hive endpoint or tool returned by discovery.
+  - name: invoke_api_endpoint
+    description: Execute a selected Hive provider endpoint with validated arguments and return the live crypto intelligence result.
+    params:
+      tool: Name of the Hive endpoint to execute.
+      args: JSON object containing the endpoint arguments.


### PR DESCRIPTION
Adds Hive Intelligence as a remote MCP catalog entry for Obot users who need production crypto market and on-chain intelligence from a single hosted endpoint.

What changed:
- Added `hive_intelligence.yaml` with the official Streamable HTTP endpoint: `https://mcp.hiveintelligence.xyz/mcp`
- Configured the required `Authorization` header with the `Bearer ` prefix so users can provide their Hive API key at install time
- Included preview tools for Hive's discovery-first MCP workflow: `search_tools`, `get_api_endpoint_schema`, and `invoke_api_endpoint`
- Added the new YAML file to the tool-preview refresh workflow choices

Why this fits the catalog:
Hive Intelligence gives agents one governed MCP surface for live crypto prices, token and contract data, wallet/portfolio intelligence, DeFi analytics, DEX flows, NFT data, Solana data, network infrastructure, token risk/security checks, and prediction markets. The root MCP server keeps the initial tool surface compact while allowing runtime discovery of the provider-backed endpoints an agent needs for a specific market, wallet, protocol, or risk workflow.

Validation:
- Parsed `hive_intelligence.yaml` locally with PyYAML
- Parsed `.github/workflows/tool-preview-refresh.yml` locally with PyYAML
