### PR TITLE
chore: add catalog build validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,60 @@
+name: Build
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install YAML parser
+        run: python -m pip install PyYAML
+
+      - name: Validate catalog YAML
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          import yaml
+
+
+          def find_duplicate_keys(node, path):
+              errors = []
+              if isinstance(node, yaml.MappingNode):
+                  keys = set()
+                  for key_node, value_node in node.value:
+                      key = key_node.value
+                      if key in keys:
+                          errors.append(f"{path}:{key_node.start_mark.line + 1}: duplicate key {key!r}")
+                      keys.add(key)
+                      errors.extend(find_duplicate_keys(value_node, path))
+              elif isinstance(node, yaml.SequenceNode):
+                  for value_node in node.value:
+                      errors.extend(find_duplicate_keys(value_node, path))
+              return errors
+
+
+          errors = []
+          for path in sorted(Path(".").glob("*.yaml")):
+              try:
+                  node = yaml.compose(path.read_text())
+              except yaml.YAMLError as error:
+                  errors.append(f"{path}: invalid YAML: {error}")
+              else:
+                  errors.extend(find_duplicate_keys(node, path))
+
+          if errors:
+              raise SystemExit("\n".join(errors))
+
+          print("Catalog YAML is valid.")
+          PY


### PR DESCRIPTION
## Summary
- add a required `build` GitHub Actions job for pull requests to `main`
- validate catalog YAML syntax
- enforce unique catalog `entryKey` values