### PR TITLE
fix: use latest tags for auto-built images

### DIFF
--- a/cloud_run.yaml
+++ b/cloud_run.yaml
@@ -87,6 +87,6 @@ env:
 
 runtime: containerized
 containerizedConfig:
-  image: ghcr.io/obot-platform/mcp-images/googlecloudrun:main
+  image: ghcr.io/obot-platform/mcp-images/googlecloudrun:latest
   port: 3000
   path: "/mcp"

--- a/elasticsearch.yaml
+++ b/elasticsearch.yaml
@@ -64,7 +64,7 @@ env:
 
 runtime: containerized
 containerizedConfig:
-  image: ghcr.io/obot-platform/mcp-images/elasticsearch:main
+  image: ghcr.io/obot-platform/mcp-images/elasticsearch:latest
   port: 8080
   path: "/mcp"
   args:

--- a/github_enterprise.yaml
+++ b/github_enterprise.yaml
@@ -228,6 +228,6 @@ env:
 
 runtime: containerized
 containerizedConfig:
-  image: ghcr.io/obot-platform/mcp-images/github:main
+  image: ghcr.io/obot-platform/mcp-images/github:latest
   path: "/"
   port: 8099

--- a/hubspot.yaml
+++ b/hubspot.yaml
@@ -170,6 +170,6 @@ env:
     required: true
 runtime: containerized
 containerizedConfig:
-  image: ghcr.io/obot-platform/mcp-images/hubspot:main
+  image: ghcr.io/obot-platform/mcp-images/hubspot:latest
   port: 8099
   path: "/"

--- a/snowflake.yaml
+++ b/snowflake.yaml
@@ -239,6 +239,6 @@ env:
 
 runtime: containerized
 containerizedConfig:
-  image: ghcr.io/obot-platform/mcp-images/snowflake:main
+  image: ghcr.io/obot-platform/mcp-images/snowflake:latest
   port: 9000
   path: "/mcp"

--- a/tableau.yaml
+++ b/tableau.yaml
@@ -118,6 +118,6 @@ env:
 
 runtime: containerized
 containerizedConfig:
-  image: ghcr.io/obot-platform/mcp-images/tableau:main
+  image: ghcr.io/obot-platform/mcp-images/tableau:latest
   port: 8098
   path: "/tableau-mcp"

--- a/wordpress.yaml
+++ b/wordpress.yaml
@@ -241,6 +241,6 @@ env:
   sensitive: true
 runtime: containerized
 containerizedConfig:
-  image: ghcr.io/obot-platform/wordpress-mcp-server:main
+  image: ghcr.io/obot-platform/wordpress-mcp-server:latest
   port: 8099
   path: "/"


### PR DESCRIPTION
Updates the catalog to use `latest` rather than `main` for container images whose build automation refreshes `main`.

Affected entries: Cloud Run, Elasticsearch, GitHub Enterprise, Snowflake, and Tableau.

WordPress did not have a `latest` tag. I created a `release/v0.1.1` branch from pre-update commit, cherry-picked the commit to fix the trivy step of build-and-release, and then pushed a tag which triggered a build for `latest`.