### PR TITLE
fix: disable Tableau OAuth

### DIFF
--- a/tableau.yaml
+++ b/tableau.yaml
@@ -95,6 +95,9 @@ toolPreview:
       bundleType: "The type of bundle to generate (ban, springboard, basic, detail) - default: ban"
 
 env:
+  - key: DANGEROUSLY_DISABLE_OAUTH
+    value: "true"
+    description: Disable OAuth because Obot authenticates clients at its gateway.
   - name: Tableau Server URL
     key: SERVER
     description: Your Tableau Cloud or Server URL (e.g., https://your-site.online.tableau.com)


### PR DESCRIPTION
## Summary
- disable the Tableau container's OAuth handling because Obot authenticates clients at its gateway
- configure the setting as a static catalog environment value

## Validation
- validated all catalog YAML parsing and duplicate keys
- verified the static value parses as the string `true`
- ran `git diff --check`

Addresses https://github.com/obot-platform/obot/issues/7367