### PR TITLE
chore: deprecate low-value MCP entries

### DIFF
--- a/antv_charts.yaml
+++ b/antv_charts.yaml
@@ -3,6 +3,8 @@ entryKey: obot-antv-charts
 serverUserType: singleUser
 shortDescription: Generate 25+ professional chart types for data visualization and analysis
 description: |
+  **DEPRECATED**: this server is no longer supported by the Obot MCP Catalog. No direct replacement is currently available.
+
   ![MCP Server](https://badge.mcpx.dev?type=server) [![build](https://github.com/antvis/mcp-server-chart/actions/workflows/build.yml/badge.svg)](https://github.com/antvis/mcp-server-chart/actions/workflows/build.yml) [![npm Version](https://img.shields.io/npm/v/@antv/mcp-server-chart.svg)](https://www.npmjs.com/package/@antv/mcp-server-chart) [![npm License](https://img.shields.io/npm/l/@antv/mcp-server-chart.svg)](https://www.npmjs.com/package/@antv/mcp-server-chart)
 
   A Model Context Protocol (MCP) server for generating charts using AntV. Create various types of professional charts for data analysis and visualization with support for 25+ chart types including statistical, geographical, and specialized diagrams.
@@ -54,6 +56,7 @@ description: |
 
 metadata:
   categories: Data & Analytics
+  deprecated: "true"
 icon: https://avatars.githubusercontent.com/u/19199542?v=4
 repoURL: https://github.com/antvis/mcp-server-chart
 env:

--- a/brave_search.yaml
+++ b/brave_search.yaml
@@ -2,7 +2,9 @@ name: Brave Search
 entryKey: obot-brave-search
 serverUserType: singleUser
 shortDescription: Search the web, news, images, videos, and local businesses with Brave Search API
-description: 'A Model Context Protocol (MCP) server that provides comprehensive web search capabilities through the Brave Search API. It enables AI assistants to search the web, find news articles, discover videos and images, locate local businesses, and generate AI-powered summaries of search results.
+description: '**DEPRECATED**: this server is no longer supported by the Obot MCP Catalog. No direct replacement is currently available.
+
+  A Model Context Protocol (MCP) server that provides comprehensive web search capabilities through the Brave Search API. It enables AI assistants to search the web, find news articles, discover videos and images, locate local businesses, and generate AI-powered summaries of search results.
 
 
   ## Features
@@ -30,6 +32,7 @@ description: 'A Model Context Protocol (MCP) server that provides comprehensive 
   '
 metadata:
   categories: Retrieval & Search, SaaS & API Integrations
+  deprecated: "true"
 icon: https://brave.com/static-assets/images/brave-logo-sans-text.svg
 repoURL: https://github.com/brave/brave-search-mcp-server
 env:
@@ -115,4 +118,3 @@ toolPreview:
     key: Summary key from search results (required)
     entity_info: Include extra entity information (default false)
     inline_references: Add inline source references (default false)
-

--- a/browserbase.yaml
+++ b/browserbase.yaml
@@ -2,7 +2,9 @@ name: Browserbase
 entryKey: obot-browserbase
 serverUserType: singleUser
 shortDescription: Cloud browser automation with web scraping, screenshots, and AI interactions
-description: 'A Model Context Protocol (MCP) server that provides cloud browser automation capabilities using Browserbase and Stagehand. Enable LLMs to interact with web pages, take screenshots, extract information, and perform automated actions with atomic precision.
+description: '**DEPRECATED**: this server is no longer supported by the Obot MCP Catalog. No approved replacement is currently available. Browserbase''s hosted MCP is not approved because it requires API keys in URL query parameters.
+
+  A Model Context Protocol (MCP) server that provides cloud browser automation capabilities using Browserbase and Stagehand. Enable LLMs to interact with web pages, take screenshots, extract information, and perform automated actions with atomic precision.
 
 
   ## Features
@@ -36,6 +38,7 @@ description: 'A Model Context Protocol (MCP) server that provides cloud browser 
   '
 metadata:
   categories: Automation & Browsers
+  deprecated: "true"
 icon: https://avatars.githubusercontent.com/u/158221360?v=4
 repoURL: https://github.com/browserbase/mcp-server-browserbase
 env:

--- a/chroma.yaml
+++ b/chroma.yaml
@@ -2,7 +2,9 @@ name: Chroma Cloud
 entryKey: obot-chroma-cloud
 serverUserType: singleUser
 shortDescription: Manage collections, documents, and vector search in Chroma embedding database
-description: 'A Model Context Protocol (MCP) server implementation that provides database capabilities for Chroma Cloud, the open-source embedding database. This server enables AI models to create collections, store documents with embeddings, and retrieve data using vector search, full-text search, metadata filtering, and more.
+description: '**DEPRECATED**: this server is no longer supported by the Obot MCP Catalog. No direct replacement is currently available.
+
+  A Model Context Protocol (MCP) server implementation that provides database capabilities for Chroma Cloud, the open-source embedding database. This server enables AI models to create collections, store documents with embeddings, and retrieve data using vector search, full-text search, metadata filtering, and more.
 
 
   ## Features
@@ -39,6 +41,7 @@ description: 'A Model Context Protocol (MCP) server implementation that provides
   '
 metadata:
   categories: Database, Developer Tools, AI & Machine Learning
+  deprecated: "true"
 icon: https://avatars.githubusercontent.com/u/105881770?s=48&v=4
 repoURL: https://github.com/chroma-core/chroma-mcp
 env:
@@ -151,4 +154,3 @@ toolPreview:
   params:
     collection_name: Name of the collection to delete documents from
     ids: List of document IDs to delete
-

--- a/duckduckgo_search.yaml
+++ b/duckduckgo_search.yaml
@@ -2,7 +2,9 @@ name: DuckDuckGo Search
 entryKey: obot-duckduckgo-search
 serverUserType: singleUser
 shortDescription: Search the web with DuckDuckGo and retrieve webpage content with parsing
-description: 'A Model Context Protocol (MCP) server that provides web search capabilities through DuckDuckGo, with additional features for content fetching and parsing. Search the web and retrieve webpage content with LLM-friendly formatting.
+description: '**DEPRECATED**: this server is no longer supported by the Obot MCP Catalog. For hosted web search, use Tavily Search; it is not a no-key drop-in replacement.
+
+  A Model Context Protocol (MCP) server that provides web search capabilities through DuckDuckGo, with additional features for content fetching and parsing. Search the web and retrieve webpage content with LLM-friendly formatting.
 
 
   ## Features
@@ -26,6 +28,7 @@ description: 'A Model Context Protocol (MCP) server that provides web search cap
   '
 metadata:
   categories: Search
+  deprecated: "true"
 icon: https://img.icons8.com/?size=100&id=63778&format=png&color=000000
 repoURL: https://github.com/nickclyde/duckduckgo-mcp-server
 env: []

--- a/markitdown.yaml
+++ b/markitdown.yaml
@@ -2,7 +2,9 @@ name: MarkItDown
 entryKey: obot-markitdown
 serverUserType: singleUser
 shortDescription: Convert documents, images, audio, and web content to LLM-optimized Markdown
-description: 'A Model Context Protocol (MCP) server that provides powerful file-to-Markdown conversion capabilities. Convert various document formats and web content to clean, structured Markdown optimized for LLM consumption.
+description: '**DEPRECATED**: this server is no longer supported by the Obot MCP Catalog. No direct replacement is currently available.
+
+  A Model Context Protocol (MCP) server that provides powerful file-to-Markdown conversion capabilities. Convert various document formats and web content to clean, structured Markdown optimized for LLM consumption.
 
 
   ## Features
@@ -28,6 +30,7 @@ description: 'A Model Context Protocol (MCP) server that provides powerful file-
   '
 metadata:
   categories: Document Processing
+  deprecated: "true"
 icon: https://avatars.githubusercontent.com/u/6154722?s=48&v=4
 repoURL: https://github.com/microsoft/markitdown/tree/main/packages/markitdown-mcp
 toolPreview:
@@ -42,4 +45,3 @@ containerizedConfig:
   path: /
   args:
   - markitdown-mcp
-

--- a/playwright.yaml
+++ b/playwright.yaml
@@ -2,7 +2,9 @@ name: Playwright
 entryKey: obot-playwright
 serverUserType: singleUser
 shortDescription: Browser automation with accessibility-based interactions using Playwright
-description: 'A Model Context Protocol (MCP) server that provides browser automation capabilities using Playwright. This server enables AI agents to interact with web pages through structured accessibility snapshots, bypassing the need for screenshots or visually-tuned models for fast, deterministic automation.
+description: '**DEPRECATED**: this server is no longer supported by the Obot MCP Catalog. No direct replacement is currently available.
+
+  A Model Context Protocol (MCP) server that provides browser automation capabilities using Playwright. This server enables AI agents to interact with web pages through structured accessibility snapshots, bypassing the need for screenshots or visually-tuned models for fast, deterministic automation.
 
 
   ## Features
@@ -30,6 +32,7 @@ description: 'A Model Context Protocol (MCP) server that provides browser automa
   '
 metadata:
   categories: Automation & Browsers
+  deprecated: "true"
   unsupportedTools: browser_snapshot,browser_take_screenshot,browser_screen_capture,browser_pdf_save,browser_install
 icon: https://avatars.githubusercontent.com/u/6154722?v=4
 repoURL: https://github.com/microsoft/playwright-mcp


### PR DESCRIPTION
## Summary

- AntV Charts: deprecate with no direct replacement.
- Brave Search: deprecate with no direct replacement.
- Chroma Cloud: deprecate with no direct replacement.
- DuckDuckGo Search: deprecate and direct hosted-search users to Tavily Search.
- MarkItDown: deprecate with no direct replacement.
- Playwright: deprecate with no direct replacement.
- Browserbase: deprecate; its hosted MCP is not approved because it requires API keys in URL query parameters.

All catalog files and runtime definitions remain available.

Addresses https://github.com/obot-platform/obot/issues/7402