### PR TITLE
chore: use Obot catalog validator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,48 +13,17 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v6
+      - name: Checkout Obot validator
+        uses: actions/checkout@v6
         with:
-          python-version: "3.13"
+          repository: obot-platform/obot
+          ref: main
+          path: .obot
 
-      - name: Install YAML parser
-        run: python -m pip install PyYAML
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26.5"
+          cache: false
 
       - name: Validate catalog YAML
-        run: |
-          python - <<'PY'
-          from pathlib import Path
-
-          import yaml
-
-
-          def find_duplicate_keys(node, path):
-              errors = []
-              if isinstance(node, yaml.MappingNode):
-                  keys = set()
-                  for key_node, value_node in node.value:
-                      key = key_node.value
-                      if key in keys:
-                          errors.append(f"{path}:{key_node.start_mark.line + 1}: duplicate key {key!r}")
-                      keys.add(key)
-                      errors.extend(find_duplicate_keys(value_node, path))
-              elif isinstance(node, yaml.SequenceNode):
-                  for value_node in node.value:
-                      errors.extend(find_duplicate_keys(value_node, path))
-              return errors
-
-
-          errors = []
-          for path in sorted(Path(".").glob("*.yaml")):
-              try:
-                  node = yaml.compose(path.read_text())
-              except yaml.YAMLError as error:
-                  errors.append(f"{path}: invalid YAML: {error}")
-              else:
-                  errors.extend(find_duplicate_keys(node, path))
-
-          if errors:
-              raise SystemExit("\n".join(errors))
-
-          print("Catalog YAML is valid.")
-          PY
+        run: go -C .obot run . mcp validate-catalog-yaml --require-entry-key "$GITHUB_WORKSPACE"/*.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Catalog Validation
+
+After changing catalog YAML files, validate all entries before finishing:
+
+1. Check whether a compatible Obot CLI is installed by running `obot mcp validate-catalog-yaml --help`.
+2. If that command succeeds, run `obot mcp validate-catalog-yaml --require-entry-key ./*.yaml`.
+3. Otherwise, request that the user installs Obot CLI, but do not require it.


### PR DESCRIPTION
## Summary

- replace the inline Python YAML check with the Obot catalog validator
- require `entryKey` for every catalog entry in CI
- document the same validation workflow for coding agents, preferring an installed compatible Obot CLI
