### PR TITLE
chore: remove trailing slash from Obot remote MCP URLs

### DIFF
--- a/google-calendar.yaml
+++ b/google-calendar.yaml
@@ -33,7 +33,7 @@ icon: https://img.icons8.com/?size=100&id=WKF3bm1munsk&format=png&color=000000
 repoURL: https://github.com/obot-platform/google-mcp/tree/main/calendar
 runtime: remote
 remoteConfig:
-  fixedURL: https://google-calendar-mcp.obot.ai/mcp/
+  fixedURL: https://google-calendar-mcp.obot.ai/mcp
 toolPreview:
   - name: list_calendars
     description: Lists all calendars for the authenticated user.

--- a/google-docs.yaml
+++ b/google-docs.yaml
@@ -25,4 +25,4 @@ icon: https://img.icons8.com/color/96/google-docs--v1.png
 repoURL: https://github.com/obot-platform/google-mcp/tree/main/docs
 runtime: remote
 remoteConfig:
-  fixedURL: https://google-docs-mcp.obot.ai/mcp/
+  fixedURL: https://google-docs-mcp.obot.ai/mcp

--- a/google-drive.yaml
+++ b/google-drive.yaml
@@ -31,7 +31,7 @@ icon: https://img.icons8.com/?size=100&id=VLr4hUR8iMGF&format=png&color=000000
 repoURL: https://github.com/obot-platform/google-mcp/tree/main/drive
 runtime: remote
 remoteConfig:
-  fixedURL: https://google-drive-mcp.obot.ai/mcp/
+  fixedURL: https://google-drive-mcp.obot.ai/mcp
 toolPreview:
   - name: list_files
     description: List or search for files in the user's Google Drive. Returns up to 50 files by default, sorted by last modified date.

--- a/google-search-console.yaml
+++ b/google-search-console.yaml
@@ -27,4 +27,4 @@ icon: https://img.icons8.com/?size=100&id=V5cGWnc9R4xj&format=png&color=000000
 repoURL: https://github.com/obot-platform/google-mcp/tree/main/search-console
 runtime: remote
 remoteConfig:
-  fixedURL: https://google-search-console-mcp.obot.ai/mcp/
+  fixedURL: https://google-search-console-mcp.obot.ai/mcp

--- a/google-sheets.yaml
+++ b/google-sheets.yaml
@@ -30,7 +30,7 @@ icon: https://img.icons8.com/?size=100&id=qrAVeBIrsjod&format=png&color=000000
 repoURL: https://github.com/obot-platform/google-mcp/tree/main/sheets
 runtime: remote
 remoteConfig:
-  fixedURL: https://google-sheets-mcp.obot.ai/mcp/
+  fixedURL: https://google-sheets-mcp.obot.ai/mcp
 toolPreview:
   - name: list_spreadsheets
     description: List spreadsheets (both owned and shared) in the user's Google Drive.


### PR DESCRIPTION
## Summary
- remove trailing slashes from the five Obot-hosted Google MCP remote endpoints
- preserve external remote endpoint URLs unchanged

## Validation
- Catalog entries in 80 files are valid.