### PR TITLE
enhance: net-new catalog entries

### DIFF
--- a/.github/workflows/tool-preview-refresh.yml
+++ b/.github/workflows/tool-preview-refresh.yml
@@ -47,6 +47,7 @@ on:
           - google-drive.yaml
           - google-maps-grounding-lite.yaml
           - google-sheets.yaml
+          - grafana-cloud.yaml
           - grafana.yaml
           - hubspot.yaml
           - linear.yaml

--- a/.github/workflows/tool-preview-refresh.yml
+++ b/.github/workflows/tool-preview-refresh.yml
@@ -40,6 +40,7 @@ on:
           - firecrawl.yaml
           - github.yaml
           - github_enterprise.yaml
+          - github_enterprise_cloud.yaml
           - gitlab.yaml
           - gitmcp.yaml
           - gmail.yaml
@@ -47,7 +48,7 @@ on:
           - google-drive.yaml
           - google-maps-grounding-lite.yaml
           - google-sheets.yaml
-          - grafana-cloud.yaml
+          - grafana_cloud.yaml
           - grafana.yaml
           - hubspot.yaml
           - linear.yaml

--- a/.github/workflows/tool-preview-refresh.yml
+++ b/.github/workflows/tool-preview-refresh.yml
@@ -75,6 +75,7 @@ on:
           - square.yaml
           - stripe.yaml
           - supabase.yaml
+          - tableau_cloud.yaml
           - tableau.yaml
           - tavily_search.yaml
           - terraform.yaml

--- a/github_enterprise.yaml
+++ b/github_enterprise.yaml
@@ -7,7 +7,7 @@ description: |
 
   [Read the official GitHub Enterprise MCP server documentation](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/provide-context/use-mcp-in-your-ide/enterprise-configuration).
 
-  For GitHub Enterprise Cloud with data residency (`*.ghe.com`), use **GitHub Enterprise Cloud**. For standard GitHub Enterprise Cloud on `github.com`, use the regular **GitHub** catalog entry.
+  This server is appropriate for connecting to self-hosted instances of GitHub Enterprise Server. If you're using GitHub Enterprise Cloud with data residency (`*.ghe.com`), we recommend using the **GitHub Enterprise Cloud** MCP server. For standard GitHub Enterprise Cloud on `github.com`, use the regular **GitHub** catalog entry.
 
   This MCP server connects AI tools directly to GitHub Enterprise Server. It gives AI agents, assistants, and chatbots the ability to read repositories and code files, manage issues and PRs, analyze code, and automate workflows through natural language interactions.
 

--- a/github_enterprise.yaml
+++ b/github_enterprise.yaml
@@ -5,6 +5,8 @@ shortDescription: Connect AI tools to GitHub Enterprise Server
 description: |
   A containerized Model Context Protocol (MCP) server for GitHub Enterprise Server. GitHub does not provide a hosted remote MCP endpoint for GitHub Enterprise Server.
 
+  [Read the official GitHub Enterprise MCP server documentation](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/provide-context/use-mcp-in-your-ide/enterprise-configuration).
+
   For GitHub Enterprise Cloud with data residency (`*.ghe.com`), use **GitHub Enterprise Cloud**. For standard GitHub Enterprise Cloud on `github.com`, use the regular **GitHub** catalog entry.
 
   This MCP server connects AI tools directly to GitHub Enterprise Server. It gives AI agents, assistants, and chatbots the ability to read repositories and code files, manage issues and PRs, analyze code, and automate workflows through natural language interactions.
@@ -207,7 +209,7 @@ metadata:
   categories: Developer Tools
   unsupportedTools: create_or_update_file,push_files
 icon: https://avatars.githubusercontent.com/u/9919?v=4
-repoURL: https://github.com/github/github-mcp-server
+repoURL: https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/provide-context/use-mcp-in-your-ide/enterprise-configuration
 env:
   - key: GITHUB_PERSONAL_ACCESS_TOKEN
     name: GitHub Personal Access Token

--- a/github_enterprise.yaml
+++ b/github_enterprise.yaml
@@ -1,9 +1,13 @@
 name: GitHub Enterprise
 entryKey: obot-github-enterprise
 serverUserType: singleUser
-shortDescription: Connect AI tools to GitHub Enterprise Server and Enterprise Cloud with data residency
+shortDescription: Connect AI tools to GitHub Enterprise Server
 description: |
-  A Model Context Protocol (MCP) server that connects AI tools directly to GitHub's platform or [GitHub Enterprise](https://github.com/github/github-mcp-server?tab=readme-ov-file#github-enterprise-server-and-enterprise-cloud-with-data-residency-ghecom). This gives AI agents, assistants, and chatbots the ability to read repositories and code files, manage issues and PRs, analyze code, and automate workflows through natural language interactions. Supports GitHub Enterprise Server and Enterprise Cloud with data residency.
+  A containerized Model Context Protocol (MCP) server for GitHub Enterprise Server. GitHub does not provide a hosted remote MCP endpoint for GitHub Enterprise Server.
+
+  For GitHub Enterprise Cloud with data residency (`*.ghe.com`), use **GitHub Enterprise Cloud**. For standard GitHub Enterprise Cloud on `github.com`, use the regular **GitHub** catalog entry.
+
+  This MCP server connects AI tools directly to GitHub Enterprise Server. It gives AI agents, assistants, and chatbots the ability to read repositories and code files, manage issues and PRs, analyze code, and automate workflows through natural language interactions.
 
   ## Features
   - **Repository Management**: Browse and query code, search files, analyze commits, and understand project structure

--- a/github_enterprise_cloud.yaml
+++ b/github_enterprise_cloud.yaml
@@ -5,6 +5,8 @@ shortDescription: Connect to a GitHub Enterprise Cloud data-residency tenant wit
 description: |
   Connect AI tools directly to GitHub's hosted Model Context Protocol (MCP) server for a GitHub Enterprise Cloud data-residency tenant (`*.ghe.com`). GitHub operates the server, including updates and remote-only GitHub capabilities.
 
+  [Read the official GitHub Enterprise MCP server documentation](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/provide-context/use-mcp-in-your-ide/enterprise-configuration).
+
   ## Supported configuration
 
   This entry supports GitHub Enterprise Cloud with data residency only. Enter the tenant subdomain from a URL such as `https://octocorp.ghe.com`; for that example, enter `octocorp`. Obot connects to `https://copilot-api.octocorp.ghe.com/mcp`.
@@ -37,7 +39,7 @@ env:
 metadata:
   categories: Developer Tools
 icon: https://avatars.githubusercontent.com/u/9919?v=4
-repoURL: https://github.com/github/github-mcp-server
+repoURL: https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/provide-context/use-mcp-in-your-ide/enterprise-configuration
 runtime: remote
 remoteConfig:
   urlTemplate: https://copilot-api.${GITHUB_ENTERPRISE_SUBDOMAIN}.ghe.com/mcp

--- a/github_enterprise_cloud.yaml
+++ b/github_enterprise_cloud.yaml
@@ -1,0 +1,335 @@
+name: GitHub Enterprise Cloud
+entryKey: obot-github-enterprise-cloud
+serverUserType: singleUser
+shortDescription: Connect to a GitHub Enterprise Cloud data-residency tenant with GitHub-hosted MCP and OAuth
+description: |
+  Connect AI tools directly to GitHub's hosted Model Context Protocol (MCP) server for a GitHub Enterprise Cloud data-residency tenant (`*.ghe.com`). GitHub operates the server, including updates and remote-only GitHub capabilities.
+
+  ## Supported configuration
+
+  This entry supports GitHub Enterprise Cloud with data residency only. Enter the tenant subdomain from a URL such as `https://octocorp.ghe.com`; for that example, enter `octocorp`. Obot connects to `https://copilot-api.octocorp.ghe.com/mcp`.
+
+  Standard GitHub Enterprise Cloud organizations on `github.com`, including enterprises managed at `https://github.com/enterprises/<enterprise>`, should use the regular **GitHub** catalog entry at `https://api.githubcopilot.com/mcp/` instead.
+
+  GitHub Enterprise Server is not supported by this hosted entry. GitHub does not host a remote MCP server for GitHub Enterprise Server.
+
+  ## What you'll need to connect
+
+  An Obot administrator must register an OAuth App or GitHub App on this exact GHE.com tenant and configure its client ID and secret for this catalog entry. GitHub does not support Dynamic Client Registration, so each tenant requires a pre-registered OAuth client. Users then authenticate with OAuth when prompted.
+
+  The configured OAuth client is tenant-specific. Create a separate catalog entry for each unrelated GHE.com tenant rather than sharing one entry across tenants.
+
+  ## Features
+
+  - **Repository and code access**: Search repositories, read files, and inspect commits and branches
+  - **Issues and pull requests**: Triage work, manage issues, review pull requests, and add comments
+  - **Actions and security**: Inspect workflows and, where licensed and permitted, access security capabilities
+  - **Hosted-only capabilities**: Use GitHub's vendor-managed remote service and applicable Copilot features
+  - **Toolset control**: Optionally select the hosted GitHub toolsets appropriate for the tenant
+
+  The default GitHub toolsets are `context`, `repos`, `issues`, `pull_requests`, and `users`. Set GitHub Toolsets to `all` only when the broader tool surface is needed.
+env:
+  - key: GITHUB_ENTERPRISE_SUBDOMAIN
+    name: GitHub Enterprise Cloud Subdomain
+    required: true
+    sensitive: false
+    description: The GHE.com tenant subdomain only, for example octocorp for https://octocorp.ghe.com.
+metadata:
+  categories: Developer Tools
+icon: https://avatars.githubusercontent.com/u/9919?v=4
+repoURL: https://github.com/github/github-mcp-server
+runtime: remote
+remoteConfig:
+  urlTemplate: https://copilot-api.${GITHUB_ENTERPRISE_SUBDOMAIN}.ghe.com/mcp
+  staticOAuthRequired: true
+  headers:
+    - name: GitHub Toolsets
+      description: Optional comma-separated GitHub toolsets, such as repos,issues,pull_requests or all. Defaults to context,repos,issues,pull_requests,users.
+      key: X-MCP-Toolsets
+      required: false
+      sensitive: false
+toolPreview:
+  - name: get_me
+    description: Get the authenticated GitHub user's profile.
+  - name: actions_get
+    description: Get GitHub Actions resources.
+    params: {method: Parameter., owner: Parameter., repo: Parameter., resource_id: Parameter.}
+  - name: actions_list
+    description: List GitHub Actions resources.
+    params: {method: Parameter., owner: Parameter., page: Parameter., per_page: Parameter., repo: Parameter., resource_id: Parameter., workflow_jobs_filter: Parameter., workflow_runs_filter: Parameter.}
+  - name: actions_run_trigger
+    description: Trigger or manage GitHub Actions workflows.
+    params: {inputs: Parameter., method: Parameter., owner: Parameter., ref: Parameter., repo: Parameter., run_id: Parameter., workflow_id: Parameter.}
+  - name: add_comment_to_pending_review
+    description: Add a comment to a pending pull request review.
+    params: {body: Parameter., line: Parameter., owner: Parameter., path: Parameter., pullNumber: Parameter., repo: Parameter., side: Parameter., startLine: Parameter., startSide: Parameter., subjectType: Parameter.}
+  - name: add_issue_comment
+    description: Add a comment or reaction to an issue.
+    params: {body: Parameter., comment_id: Parameter., issue_number: Parameter., owner: Parameter., reaction: Parameter., repo: Parameter.}
+  - name: add_reply_to_pull_request_comment
+    description: Reply to a pull request comment.
+    params: {body: Parameter., commentId: Parameter., owner: Parameter., pullNumber: Parameter., reaction: Parameter., repo: Parameter.}
+  - name: check_dependency_vulnerabilities
+    description: Check repository dependencies for vulnerabilities.
+    params: {dependencies: Parameter., owner: Parameter., repo: Parameter.}
+  - name: create_branch
+    description: Create a repository branch.
+    params: {branch: Parameter., from_branch: Parameter., owner: Parameter., repo: Parameter.}
+  - name: create_gist
+    description: Create a GitHub gist.
+    params: {content: Parameter., description: Parameter., filename: Parameter., public: Parameter.}
+  - name: create_or_update_file
+    description: Create or update a repository file.
+    params: {branch: Parameter., content: Parameter., message: Parameter., owner: Parameter., path: Parameter., repo: Parameter., sha: Parameter.}
+  - name: create_pull_request
+    description: Create a pull request.
+    params: {base: Parameter., body: Parameter., draft: Parameter., head: Parameter., maintainer_can_modify: Parameter., owner: Parameter., repo: Parameter., reviewers: Parameter., title: Parameter.}
+  - name: create_repository
+    description: Create a repository.
+    params: {autoInit: Parameter., description: Parameter., name: Parameter., organization: Parameter., private: Parameter.}
+  - name: delete_file
+    description: Delete a repository file.
+    params: {branch: Parameter., message: Parameter., owner: Parameter., path: Parameter., repo: Parameter.}
+  - name: discussion_comment_write
+    description: Manage GitHub discussion comments.
+    params: {body: Parameter., commentNodeID: Parameter., discussionNumber: Parameter., method: Parameter., owner: Parameter., repo: Parameter.}
+  - name: dismiss_notification
+    description: Dismiss a GitHub notification.
+    params: {state: Parameter., threadID: Parameter.}
+  - name: fork_repository
+    description: Fork a repository.
+    params: {organization: Parameter., owner: Parameter., repo: Parameter.}
+  - name: get_code_quality_finding
+    description: Get a code quality finding.
+    params: {findingNumber: Parameter., owner: Parameter., repo: Parameter.}
+  - name: get_code_scanning_alert
+    description: Get a code scanning alert.
+    params: {alertNumber: Parameter., owner: Parameter., repo: Parameter.}
+  - name: get_commit
+    description: Get commit details.
+    params: {detail: Parameter., owner: Parameter., page: Parameter., perPage: Parameter., repo: Parameter., sha: Parameter.}
+  - name: get_copilot_space
+    description: Get a Copilot Space.
+    params: {name: Parameter., owner: Parameter.}
+  - name: get_dependabot_alert
+    description: Get a Dependabot alert.
+    params: {alertNumber: Parameter., owner: Parameter., repo: Parameter.}
+  - name: get_discussion
+    description: Get a GitHub discussion.
+    params: {discussionNumber: Parameter., owner: Parameter., repo: Parameter.}
+  - name: get_discussion_comments
+    description: Get discussion comments.
+    params: {after: Parameter., discussionNumber: Parameter., includeReplies: Parameter., owner: Parameter., perPage: Parameter., repo: Parameter.}
+  - name: search_repositories
+    description: Search GitHub repositories accessible to the authenticated user.
+    params:
+      minimal_output: Parameter.
+      order: Parameter.
+      page: Parameter.
+      perPage: Parameter.
+      query: Search query for GitHub repositories.
+      sort: Parameter.
+  - name: get_file_contents
+    description: Get the contents of a file or directory in a GitHub repository.
+    params:
+      fields: Parameter.
+      owner: Repository owner.
+      path: File or directory path.
+      ref: Git reference to read from (optional).
+      repo: Repository name.
+      sha: Parameter.
+  - name: get_gist
+    description: Get a GitHub gist.
+    params: {gist_id: Parameter.}
+  - name: get_global_security_advisory
+    description: Get a global security advisory.
+    params: {ghsaId: Parameter.}
+  - name: get_job_logs
+    description: Get GitHub Actions job logs.
+    params: {failed_only: Parameter., job_id: Parameter., owner: Parameter., repo: Parameter., return_content: Parameter., run_id: Parameter., tail_lines: Parameter.}
+  - name: get_label
+    description: Get a repository label.
+    params: {name: Parameter., owner: Parameter., repo: Parameter.}
+  - name: get_latest_release
+    description: Get the latest repository release.
+    params: {owner: Parameter., repo: Parameter.}
+  - name: get_notification_details
+    description: Get notification details.
+    params: {notificationID: Parameter.}
+  - name: get_release_by_tag
+    description: Get a release by tag.
+    params: {owner: Parameter., repo: Parameter., tag: Parameter.}
+  - name: get_repository_tree
+    description: Get a repository tree.
+    params: {owner: Parameter., path_filter: Parameter., recursive: Parameter., repo: Parameter., tree_sha: Parameter.}
+  - name: get_secret_scanning_alert
+    description: Get a secret scanning alert.
+    params: {alertNumber: Parameter., owner: Parameter., repo: Parameter.}
+  - name: get_tag
+    description: Get a repository tag.
+    params: {owner: Parameter., repo: Parameter., tag: Parameter.}
+  - name: get_team_members
+    description: Get organization team members.
+    params: {org: Parameter., team_slug: Parameter.}
+  - name: get_teams
+    description: Get teams for a user.
+    params: {user: Parameter.}
+  - name: issue_read
+    description: Get issue details, comments, labels, or issue hierarchy information.
+    params:
+      owner: Repository owner.
+      repo: Repository name.
+      issue_number: Issue number.
+      method: Read operation to perform, such as get or get_comments.
+      page: Parameter.
+      perPage: Parameter.
+  - name: issue_write
+    description: Manage GitHub issues.
+    params: {assignees: Parameter., body: Parameter., duplicate_of: Parameter., issue_fields: Parameter., issue_number: Parameter., labels: Parameter., method: Parameter., milestone: Parameter., owner: Parameter., repo: Parameter., state: Parameter., state_reason: Parameter., title: Parameter., type: Parameter.}
+  - name: label_write
+    description: Manage repository labels.
+    params: {color: Parameter., description: Parameter., method: Parameter., name: Parameter., new_name: Parameter., owner: Parameter., repo: Parameter.}
+  - name: list_branches
+    description: List repository branches.
+    params: {owner: Parameter., page: Parameter., perPage: Parameter., repo: Parameter.}
+  - name: list_code_scanning_alerts
+    description: List code scanning alerts.
+    params: {owner: Parameter., page: Parameter., perPage: Parameter., ref: Parameter., repo: Parameter., severity: Parameter., state: Parameter., tool_name: Parameter.}
+  - name: list_commits
+    description: List repository commits.
+    params: {author: Parameter., fields: Parameter., owner: Parameter., page: Parameter., path: Parameter., perPage: Parameter., repo: Parameter., sha: Parameter., since: Parameter., until: Parameter.}
+  - name: list_copilot_spaces
+    description: List Copilot Spaces.
+  - name: list_dependabot_alerts
+    description: List Dependabot alerts.
+    params: {after: Parameter., owner: Parameter., perPage: Parameter., repo: Parameter., severity: Parameter., state: Parameter.}
+  - name: list_discussion_categories
+    description: List discussion categories.
+    params: {owner: Parameter., repo: Parameter.}
+  - name: list_discussions
+    description: List GitHub discussions.
+    params: {after: Parameter., category: Parameter., direction: Parameter., orderBy: Parameter., owner: Parameter., perPage: Parameter., repo: Parameter.}
+  - name: list_gists
+    description: List GitHub gists.
+    params: {page: Parameter., perPage: Parameter., since: Parameter., username: Parameter.}
+  - name: list_global_security_advisories
+    description: List global security advisories.
+    params: {affects: Parameter., cveId: Parameter., cwes: Parameter., ecosystem: Parameter., ghsaId: Parameter., isWithdrawn: Parameter., modified: Parameter., published: Parameter., severity: Parameter., type: Parameter., updated: Parameter.}
+  - name: list_issue_fields
+    description: List issue fields.
+    params: {owner: Parameter., repo: Parameter.}
+  - name: list_issue_types
+    description: List issue types.
+    params: {owner: Parameter., repo: Parameter.}
+  - name: list_issues
+    description: List repository issues.
+    params: {after: Parameter., direction: Parameter., field_filters: Parameter., fields: Parameter., labels: Parameter., orderBy: Parameter., owner: Parameter., perPage: Parameter., repo: Parameter., since: Parameter., state: Parameter.}
+  - name: list_label
+    description: List repository labels.
+    params: {owner: Parameter., repo: Parameter.}
+  - name: list_notifications
+    description: List GitHub notifications.
+    params: {before: Parameter., filter: Parameter., owner: Parameter., page: Parameter., perPage: Parameter., repo: Parameter., since: Parameter.}
+  - name: list_org_repository_security_advisories
+    description: List organization repository security advisories.
+    params: {direction: Parameter., org: Parameter., sort: Parameter., state: Parameter.}
+  - name: list_pull_requests
+    description: List pull requests.
+    params: {base: Parameter., direction: Parameter., fields: Parameter., head: Parameter., owner: Parameter., page: Parameter., perPage: Parameter., repo: Parameter., sort: Parameter., state: Parameter.}
+  - name: list_releases
+    description: List repository releases.
+    params: {fields: Parameter., owner: Parameter., page: Parameter., perPage: Parameter., repo: Parameter.}
+  - name: list_repository_collaborators
+    description: List repository collaborators.
+    params: {affiliation: Parameter., owner: Parameter., page: Parameter., perPage: Parameter., repo: Parameter.}
+  - name: list_repository_security_advisories
+    description: List repository security advisories.
+    params: {direction: Parameter., owner: Parameter., repo: Parameter., sort: Parameter., state: Parameter.}
+  - name: list_secret_scanning_alerts
+    description: List secret scanning alerts.
+    params: {owner: Parameter., page: Parameter., perPage: Parameter., repo: Parameter., resolution: Parameter., secret_type: Parameter., state: Parameter.}
+  - name: list_starred_repositories
+    description: List starred repositories.
+    params: {direction: Parameter., page: Parameter., perPage: Parameter., sort: Parameter., username: Parameter.}
+  - name: list_tags
+    description: List repository tags.
+    params: {owner: Parameter., page: Parameter., perPage: Parameter., repo: Parameter.}
+  - name: manage_notification_subscription
+    description: Manage a notification subscription.
+    params: {action: Parameter., notificationID: Parameter.}
+  - name: manage_repository_notification_subscription
+    description: Manage a repository notification subscription.
+    params: {action: Parameter., owner: Parameter., repo: Parameter.}
+  - name: mark_all_notifications_read
+    description: Mark notifications as read.
+    params: {lastReadAt: Parameter., owner: Parameter., repo: Parameter.}
+  - name: merge_pull_request
+    description: Merge a pull request.
+    params: {commit_message: Parameter., commit_title: Parameter., merge_method: Parameter., owner: Parameter., pullNumber: Parameter., repo: Parameter.}
+  - name: projects_get
+    description: Get GitHub Projects resources.
+    params: {field_id: Parameter., field_names: Parameter., fields: Parameter., item_id: Parameter., method: Parameter., owner: Parameter., owner_type: Parameter., project_number: Parameter., status_update_id: Parameter.}
+  - name: projects_list
+    description: List GitHub Projects resources.
+    params: {after: Parameter., before: Parameter., field_names: Parameter., fields: Parameter., method: Parameter., owner: Parameter., owner_type: Parameter., per_page: Parameter., project_number: Parameter., query: Parameter.}
+  - name: projects_write
+    description: Manage GitHub Projects resources.
+    params: {body: Parameter., field_name: Parameter., issue_number: Parameter., item_id: Parameter., item_owner: Parameter., item_repo: Parameter., item_type: Parameter., items: Parameter., iteration_duration: Parameter., iterations: Parameter., method: Parameter., owner: Parameter., owner_type: Parameter., project_number: Parameter., pull_request_number: Parameter., start_date: Parameter., status: Parameter., target_date: Parameter., title: Parameter., updated_field: Parameter.}
+  - name: pull_request_read
+    description: Get pull request details, files, reviews, comments, or status information.
+    params:
+      after: Parameter.
+      method: Read operation to perform.
+      owner: Repository owner.
+      page: Parameter.
+      perPage: Parameter.
+      repo: Repository name.
+      pullNumber: Pull request number.
+  - name: pull_request_review_write
+    description: Manage pull request reviews.
+    params: {body: Parameter., commitID: Parameter., event: Parameter., method: Parameter., owner: Parameter., pullNumber: Parameter., repo: Parameter., threadId: Parameter.}
+  - name: push_files
+    description: Push files to a repository.
+    params: {branch: Parameter., files: Parameter., message: Parameter., owner: Parameter., repo: Parameter.}
+  - name: request_copilot_review
+    description: Request a Copilot pull request review.
+    params: {owner: Parameter., pullNumber: Parameter., repo: Parameter.}
+  - name: search_code
+    description: Search GitHub code.
+    params: {fields: Parameter., order: Parameter., page: Parameter., perPage: Parameter., query: Parameter., sort: Parameter.}
+  - name: search_commits
+    description: Search GitHub commits.
+    params: {order: Parameter., page: Parameter., perPage: Parameter., query: Parameter., sort: Parameter.}
+  - name: search_issues
+    description: Search GitHub issues.
+    params: {fields: Parameter., order: Parameter., owner: Parameter., page: Parameter., perPage: Parameter., query: Parameter., repo: Parameter., sort: Parameter.}
+  - name: search_orgs
+    description: Search GitHub organizations.
+    params: {order: Parameter., page: Parameter., perPage: Parameter., query: Parameter., sort: Parameter.}
+  - name: search_pull_requests
+    description: Search pull requests.
+    params: {fields: Parameter., order: Parameter., owner: Parameter., page: Parameter., perPage: Parameter., query: Parameter., repo: Parameter., sort: Parameter.}
+  - name: search_users
+    description: Search GitHub users.
+    params: {order: Parameter., page: Parameter., perPage: Parameter., query: Parameter., sort: Parameter.}
+  - name: semantic_issue_similarity_search
+    description: Search for semantically similar issues.
+    params: {issue_number: Parameter., owner: Parameter., page: Parameter., per_page: Parameter., repo: Parameter., threshold: Parameter.}
+  - name: star_repository
+    description: Star a repository.
+    params: {owner: Parameter., repo: Parameter.}
+  - name: sub_issue_write
+    description: Manage issue sub-issues.
+    params: {after_id: Parameter., before_id: Parameter., issue_number: Parameter., method: Parameter., owner: Parameter., replace_parent: Parameter., repo: Parameter., sub_issue_id: Parameter.}
+  - name: unstar_repository
+    description: Remove a star from a repository.
+    params: {owner: Parameter., repo: Parameter.}
+  - name: update_gist
+    description: Update a GitHub gist.
+    params: {content: Parameter., description: Parameter., filename: Parameter., gist_id: Parameter.}
+  - name: update_pull_request
+    description: Update a pull request.
+    params: {base: Parameter., body: Parameter., draft: Parameter., maintainer_can_modify: Parameter., owner: Parameter., pullNumber: Parameter., repo: Parameter., reviewers: Parameter., state: Parameter., title: Parameter.}
+  - name: update_pull_request_branch
+    description: Update a pull request branch.
+    params: {expectedHeadSha: Parameter., owner: Parameter., pullNumber: Parameter., repo: Parameter.}

--- a/grafana-cloud.yaml
+++ b/grafana-cloud.yaml
@@ -1,0 +1,344 @@
+name: Grafana Cloud
+entryKey: obot-grafana-cloud
+serverUserType: singleUser
+shortDescription: Query Grafana Cloud metrics, logs, dashboards, alerts, incidents, and on-call schedules with OAuth
+description: |
+  Grafana Cloud's official hosted Model Context Protocol (MCP) server connects AI agents directly to a Grafana Cloud stack. It uses OAuth 2.1, so each user authorizes access with their own Grafana identity and RBAC permissions instead of providing a service account token.
+
+  ## Features
+
+  - **Observability queries**: Query Prometheus metrics, Loki logs, Pyroscope profiles, Tempo data, and supported datasource types
+  - **Dashboards and alerts**: Search and manage dashboards, folders, alert rules, notification routing, and annotations
+  - **Incident response**: View and manage incidents and Grafana OnCall schedules, teams, users, and alert groups
+  - **Assistant workflows**: Start and inspect Grafana Assistant investigations, retrieve infrastructure summaries, and ask Grafana Assistant
+  - **User-scoped access**: Use the permissions already granted to the user in the selected Grafana Cloud stack
+
+  ## What you'll need to connect
+
+  - A hosted Grafana Cloud stack. This server does not support self-hosted Grafana.
+  - Grafana Assistant enabled for the stack, with any required terms accepted.
+  - The **Assistant Cloud MCP User** role or `grafana-assistant-app.cloud-mcp:access` permission. Editors and administrators have this permission by default.
+
+  Authenticate with Grafana when prompted. Read access is always available; grant write access during consent to create or modify Grafana resources. Grafana Cloud MCP usage contributes to Grafana Assistant active-user and token usage.
+
+  Optionally provide your stack URL to skip the stack-selection step during authorization. For example: `https://my-stack.grafana.net`.
+metadata:
+  categories: Observability, Monitoring, DevOps, Incident Management
+icon: https://avatars.githubusercontent.com/u/7195757?s=48&v=4
+repoURL: https://grafana.com/docs/grafana-cloud/ai-tools/mcp-servers/cloud-mcp/
+runtime: remote
+remoteConfig:
+  fixedURL: https://mcp.grafana.com/mcp
+  headers:
+  - name: Grafana Cloud Stack URL
+    description: Optional Grafana Cloud stack URL used to skip stack selection during OAuth authorization (for example, https://my-stack.grafana.net)
+    key: X-Grafana-URL
+    required: false
+    sensitive: false
+toolPreview:
+- name: add_activity_to_incident
+  description: Add activity to an incident.
+  params: {body: Input value., eventTime: Input value., incidentId: Input value.}
+- name: alerting_manage_routing
+  description: Manage alert notification routing.
+  params: {contact_point_title: Input value., datasource_uid: Input value., limit: Input value., name: Input value., operation: Input value., time_interval_name: Input value.}
+- name: alerting_manage_rules
+  description: Manage alert rules.
+  params: {annotations: Input value., condition: Input value., data: Input value., datasource_uid: Input value., disable_provenance: Input value., exec_err_state: Input value., folder_uid: Input value., for: Input value., is_paused: Input value., keep_firing_for: Input value., label_selectors: Input value., labels: Input value., limit_alerts: Input value., matchers: Input value., missing_series_evals_to_resolve: Input value., no_data_state: Input value., notification_settings: Input value., operation: Input value., org_id: Input value., record: Input value., rule_group: Input value., rule_limit: Input value., rule_type: Input value., rule_uid: Input value., search_folder: Input value., search_rule_name: Input value., states: Input value., title: Input value.}
+- name: analyze_loki_labels
+  description: Analyze Loki labels.
+  params: {datasourceUid: Input value., endRfc3339: Input value., expectedBaseLabels: Input value., labels: Input value., maxLabels: Input value., perfMetrics: Input value., selector: Input value., startRfc3339: Input value.}
+- name: ask_assistant
+  description: Ask Grafana Assistant.
+  params: {contextId: Input value., prompt: Input value.}
+- name: check_datasources_health
+  description: Check datasource health.
+  params: {offset: Input value., type: Input value., uids: Input value.}
+- name: create_annotation
+  description: Create an annotation.
+  params: {dashboardUid: Input value., data: Input value., format: Input value., graphiteData: Input value., panelId: Input value., tags: Input value., text: Input value., time: Input value., timeEnd: Input value., what: Input value., when: Input value.}
+- name: create_datasource
+  description: Create a datasource.
+  params: {access: Input value., basicAuth: Input value., database: Input value., fields: Input value., isDefault: Input value., name: Input value., schemaReviewed: Input value., type: Input value., url: Input value., withCredentials: Input value.}
+- name: create_folder
+  description: Create a folder.
+  params: {parentUid: Input value., title: Input value., uid: Input value.}
+- name: create_incident
+  description: Create an incident.
+  params: {attachCaption: Input value., attachUrl: Input value., isDrill: Input value., labels: Input value., roomPrefix: Input value., severity: Input value., status: Input value., title: Input value.}
+- name: create_investigation
+  description: Create an investigation.
+  params: {agentProfileId: Input value., instruction: Input value., teamNames: Input value., title: Input value.}
+- name: describe_athena_table
+  description: Describe an Athena table.
+  params: {catalog: Input value., database: Input value., datasourceUid: Input value., region: Input value., table: Input value.}
+- name: describe_clickhouse_table
+  description: Describe a ClickHouse table.
+  params: {database: Input value., datasourceUid: Input value., table: Input value.}
+- name: describe_infrastructure
+  description: Describe infrastructure.
+  params: {datasourceUID: Input value., queries: Input value.}
+- name: describe_snowflake_table
+  description: Describe a Snowflake table.
+  params: {database: Input value., datasourceUid: Input value., schema: Input value., table: Input value.}
+- name: generate_deeplink
+  description: Generate a Grafana deeplink.
+  params: {dashboardUid: Input value., datasourceUid: Input value., panelId: Input value., provisioningPreview: Input value., queries: Input value., queryParams: Input value., resourceType: Input value., shorten: Input value., timeRange: Input value.}
+- name: get_alert_group
+  description: Get an alert group.
+  params: {alertGroupId: Input value.}
+- name: get_annotation_tags
+  description: Get annotation tags.
+  params: {limit: Input value., tag: Input value.}
+- name: get_annotations
+  description: Get annotations.
+  params: {alertUid: Input value., dashboardUid: Input value., from: Input value., limit: Input value., matchAny: Input value., panelId: Input value., tags: Input value., to: Input value., type: Input value., userId: Input value.}
+- name: get_assertions
+  description: Get assertions.
+  params: {endTime: Input value., entityName: Input value., entityType: Input value., env: Input value., namespace: Input value., site: Input value., startTime: Input value.}
+- name: get_current_oncall_users
+  description: Get current on-call users.
+  params: {scheduleId: Input value.}
+- name: get_dashboard_by_uid
+  description: Get a dashboard.
+  params: {uid: Input value.}
+- name: get_dashboard_panel_queries
+  description: Get dashboard panel queries.
+  params: {panelId: Input value., uid: Input value., variables: Input value.}
+- name: get_dashboard_property
+  description: Get a dashboard property.
+  params: {jsonPath: Input value., uid: Input value.}
+- name: get_dashboard_summary
+  description: Get a dashboard summary.
+  params: {uid: Input value.}
+- name: get_datasource
+  description: Get a datasource.
+  params: {name: Input value., uid: Input value.}
+- name: get_incident
+  description: Get an incident.
+  params: {id: Input value.}
+- name: get_investigation
+  description: Get an investigation.
+  params: {investigationId: Input value.}
+- name: get_investigation_thread
+  description: Get an investigation thread.
+  params: {investigationId: Input value., limit: Input value., offset: Input value.}
+- name: get_oncall_shift
+  description: Get an on-call shift.
+  params: {shiftId: Input value.}
+- name: get_panel_image
+  description: Render a panel image.
+  params: {dashboardUid: Input value., height: Input value., panelId: Input value., provisioningPreview: Input value., scale: Input value., theme: Input value., timeRange: Input value., timeout: Input value., variables: Input value., width: Input value.}
+- name: get_plugin
+  description: Get a plugin.
+  params: {pluginId: Input value.}
+- name: get_query_examples
+  description: Get query examples.
+  params: {datasourceType: Input value.}
+- name: get_resource_description
+  description: Get a resource description.
+  params: {resourceType: Input value.}
+- name: get_resource_permissions
+  description: Get resource permissions.
+  params: {resource: Input value., resourceId: Input value.}
+- name: get_role_assignments
+  description: Get role assignments.
+  params: {roleUID: Input value.}
+- name: get_role_details
+  description: Get role details.
+  params: {roleUID: Input value.}
+- name: grafana_api_request
+  description: Make a Grafana API request.
+  params: {body: Input value., endpoint: Input value., headers: Input value., jq: Input value., method: Input value.}
+- name: install_plugin
+  description: Install a plugin.
+  params: {pluginId: Input value., version: Input value.}
+- name: list_alert_groups
+  description: List alert groups.
+  params: {id: Input value., integrationId: Input value., labels: Input value., name: Input value., page: Input value., routeId: Input value., startedAt: Input value., state: Input value., teamId: Input value.}
+- name: list_all_roles
+  description: List roles.
+  params: {delegatableOnly: Input value.}
+- name: list_athena_catalogs
+  description: List Athena catalogs.
+  params: {datasourceUid: Input value., region: Input value.}
+- name: list_athena_databases
+  description: List Athena databases.
+  params: {catalog: Input value., datasourceUid: Input value., region: Input value.}
+- name: list_athena_tables
+  description: List Athena tables.
+  params: {catalog: Input value., database: Input value., datasourceUid: Input value., region: Input value.}
+- name: list_clickhouse_tables
+  description: List ClickHouse tables.
+  params: {database: Input value., datasourceUid: Input value.}
+- name: list_cloudwatch_dimensions
+  description: List CloudWatch dimensions.
+  params: {accountId: Input value., datasourceUid: Input value., metricName: Input value., namespace: Input value., region: Input value.}
+- name: list_cloudwatch_metrics
+  description: List CloudWatch metrics.
+  params: {accountId: Input value., datasourceUid: Input value., namespace: Input value., region: Input value.}
+- name: list_cloudwatch_namespaces
+  description: List CloudWatch namespaces.
+  params: {accountId: Input value., datasourceUid: Input value., region: Input value.}
+- name: list_datasources
+  description: List datasources.
+  params: {limit: Input value., offset: Input value., type: Input value.}
+- name: list_graphite_metrics
+  description: List Graphite metrics.
+  params: {datasourceUid: Input value., query: Input value.}
+- name: list_graphite_tags
+  description: List Graphite tags.
+  params: {datasourceUid: Input value., prefix: Input value.}
+- name: list_incidents
+  description: List incidents.
+  params: {drill: Input value., limit: Input value., status: Input value.}
+- name: list_investigation_evidence
+  description: List investigation evidence.
+  params: {investigationId: Input value.}
+- name: list_investigation_profiles
+  description: List investigation profiles.
+  params: {}
+- name: list_investigations
+  description: List investigations.
+  params: {archivedOnly: Input value., chatId: Input value., from: Input value., includeArchived: Input value., includeLegacy: Input value., label: Input value., limit: Input value., offset: Input value., order: Input value., q: Input value., scope: Input value., sort: Input value., state: Input value., teamName: Input value., to: Input value., view: Input value.}
+- name: list_loki_label_names
+  description: List Loki label names.
+  params: {datasourceUid: Input value., endRfc3339: Input value., startRfc3339: Input value.}
+- name: list_loki_label_values
+  description: List Loki label values.
+  params: {datasourceUid: Input value., endRfc3339: Input value., labelName: Input value., startRfc3339: Input value.}
+- name: list_oncall_schedules
+  description: List on-call schedules.
+  params: {page: Input value., scheduleId: Input value., teamId: Input value.}
+- name: list_oncall_teams
+  description: List on-call teams.
+  params: {page: Input value.}
+- name: list_oncall_users
+  description: List on-call users.
+  params: {page: Input value., userId: Input value., username: Input value.}
+- name: list_prometheus_label_names
+  description: List Prometheus label names.
+  params: {datasourceUid: Input value., endRfc3339: Input value., limit: Input value., matches: Input value., projectName: Input value., startRfc3339: Input value.}
+- name: list_prometheus_label_values
+  description: List Prometheus label values.
+  params: {datasourceUid: Input value., endRfc3339: Input value., labelName: Input value., limit: Input value., matches: Input value., projectName: Input value., startRfc3339: Input value.}
+- name: list_prometheus_metric_metadata
+  description: List Prometheus metric metadata.
+  params: {datasourceUid: Input value., limit: Input value., limitPerMetric: Input value., metric: Input value., projectName: Input value.}
+- name: list_prometheus_metric_names
+  description: List Prometheus metric names.
+  params: {datasourceUid: Input value., endRfc3339: Input value., limit: Input value., page: Input value., projectName: Input value., regex: Input value., startRfc3339: Input value.}
+- name: list_pyroscope_label_names
+  description: List Pyroscope label names.
+  params: {data_source_uid: Input value., end_rfc_3339: Input value., matchers: Input value., start_rfc_3339: Input value.}
+- name: list_pyroscope_label_values
+  description: List Pyroscope label values.
+  params: {data_source_uid: Input value., end_rfc_3339: Input value., matchers: Input value., name: Input value., start_rfc_3339: Input value.}
+- name: list_pyroscope_profile_types
+  description: List Pyroscope profile types.
+  params: {data_source_uid: Input value., end_rfc_3339: Input value., start_rfc_3339: Input value.}
+- name: list_snowflake_tables
+  description: List Snowflake tables.
+  params: {database: Input value., datasourceUid: Input value., schema: Input value.}
+- name: list_team_roles
+  description: List team roles.
+  params: {teamIds: Input value.}
+- name: list_teams
+  description: List teams.
+  params: {query: Input value.}
+- name: list_user_roles
+  description: List user roles.
+  params: {userIds: Input value.}
+- name: list_users_by_org
+  description: List organization users.
+  params: {}
+- name: query_athena
+  description: Query Athena.
+  params: {catalog: Input value., database: Input value., datasourceUid: Input value., end: Input value., limit: Input value., query: Input value., region: Input value., resultReuseEnabled: Input value., resultReuseMaxAgeInMinutes: Input value., start: Input value., variables: Input value.}
+- name: query_clickhouse
+  description: Query ClickHouse.
+  params: {datasourceUid: Input value., end: Input value., limit: Input value., query: Input value., start: Input value., variables: Input value.}
+- name: query_cloudwatch
+  description: Query CloudWatch.
+  params: {accountId: Input value., datasourceUid: Input value., dimensions: Input value., end: Input value., metricName: Input value., namespace: Input value., period: Input value., region: Input value., start: Input value., statistic: Input value.}
+- name: query_elasticsearch
+  description: Query Elasticsearch.
+  params: {datasourceUid: Input value., endTime: Input value., index: Input value., limit: Input value., query: Input value., startTime: Input value.}
+- name: query_graphite
+  description: Query Graphite.
+  params: {datasourceUid: Input value., from: Input value., maxDataPoints: Input value., target: Input value., until: Input value.}
+- name: query_graphite_density
+  description: Query Graphite density.
+  params: {datasourceUid: Input value., from: Input value., target: Input value., until: Input value.}
+- name: query_influxdb
+  description: Query InfluxDB.
+  params: {datasourceUid: Input value., dialect: Input value., end: Input value., maxDataPoints: Input value., query: Input value., start: Input value.}
+- name: query_loki_logs
+  description: Query Loki logs.
+  params: {datasourceUid: Input value., direction: Input value., endRfc3339: Input value., limit: Input value., logql: Input value., queryType: Input value., startRfc3339: Input value., stepSeconds: Input value.}
+- name: query_loki_patterns
+  description: Query Loki patterns.
+  params: {datasourceUid: Input value., endRfc3339: Input value., logql: Input value., startRfc3339: Input value., step: Input value.}
+- name: query_loki_stats
+  description: Query Loki statistics.
+  params: {datasourceUid: Input value., endRfc3339: Input value., logql: Input value., startRfc3339: Input value.}
+- name: query_prometheus
+  description: Query Prometheus.
+  params: {datasourceUid: Input value., endTime: Input value., expr: Input value., projectName: Input value., queryType: Input value., startTime: Input value., stepSeconds: Input value.}
+- name: query_prometheus_histogram
+  description: Query Prometheus histogram data.
+  params: {datasourceUid: Input value., endTime: Input value., labels: Input value., metric: Input value., percentile: Input value., projectName: Input value., rateInterval: Input value., startTime: Input value., stepSeconds: Input value.}
+- name: query_pyroscope
+  description: Query Pyroscope.
+  params: {data_source_uid: Input value., end_rfc_3339: Input value., format: Input value., group_by: Input value., matchers: Input value., max_node_depth: Input value., profile_type: Input value., query_type: Input value., start_rfc_3339: Input value., step: Input value.}
+- name: query_snowflake
+  description: Query Snowflake.
+  params: {datasourceUid: Input value., end: Input value., limit: Input value., query: Input value., start: Input value., variables: Input value.}
+- name: run_panel_query
+  description: Run a dashboard panel query.
+  params: {dashboardUid: Input value., datasourceType: Input value., datasourceUid: Input value., end: Input value., panelIds: Input value., queryIndex: Input value., start: Input value., variables: Input value.}
+- name: search_dashboards
+  description: Search dashboards.
+  params: {limit: Input value., page: Input value., query: Input value.}
+- name: search_folders
+  description: Search folders.
+  params: {query: Input value.}
+- name: search_plugin_information
+  description: Search plugin information.
+  params: {query: Input value.}
+- name: suggest_loki_alloy_label_config
+  description: Suggest Loki Alloy label configuration.
+  params: {approvedLabels: Input value., componentName: Input value., forwardTo: Input value., normalizeLogLevel: Input value., requiredLabels: Input value.}
+- name: tempo_docs-config
+  description: Get Tempo configuration documentation.
+  params: {datasourceUid: Input value., name: Input value.}
+- name: tempo_docs-traceql
+  description: Get Tempo TraceQL documentation.
+  params: {datasourceUid: Input value., name: Input value.}
+- name: tempo_get-attribute-names
+  description: Get Tempo attribute names.
+  params: {datasourceUid: Input value., scope: Input value.}
+- name: tempo_get-attribute-values
+  description: Get Tempo attribute values.
+  params: {datasourceUid: Input value., filter-query: Input value., name: Input value.}
+- name: tempo_get-trace
+  description: Get a Tempo trace.
+  params: {datasourceUid: Input value., trace_id: Input value.}
+- name: tempo_traceql-metrics-instant
+  description: Query Tempo TraceQL instant metrics.
+  params: {datasourceUid: Input value., end: Input value., query: Input value., start: Input value.}
+- name: tempo_traceql-metrics-range
+  description: Query Tempo TraceQL range metrics.
+  params: {datasourceUid: Input value., end: Input value., query: Input value., start: Input value.}
+- name: tempo_traceql-search
+  description: Search Tempo traces with TraceQL.
+  params: {datasourceUid: Input value., end: Input value., query: Input value., start: Input value.}
+- name: update_annotation
+  description: Update an annotation.
+  params: {data: Input value., id: Input value., tags: Input value., text: Input value., time: Input value., timeEnd: Input value.}
+- name: update_dashboard
+  description: Update a dashboard.
+  params: {dashboard: Input value., folderUid: Input value., message: Input value., operations: Input value., overwrite: Input value., uid: Input value., userId: Input value.}
+- name: update_datasource
+  description: Update a datasource.
+  params: {access: Input value., basicAuth: Input value., database: Input value., fields: Input value., isDefault: Input value., jsonData: Input value., name: Input value., schemaReviewed: Input value., uid: Input value., url: Input value.}

--- a/grafana.yaml
+++ b/grafana.yaml
@@ -391,4 +391,3 @@ containerizedConfig:
   - --address
   - 0.0.0.0:8080
 
-

--- a/grafana.yaml
+++ b/grafana.yaml
@@ -5,6 +5,8 @@ shortDescription: Query metrics, logs, traces, manage dashboards, alerts, and on
 description: |
   A Model Context Protocol (MCP) server that provides comprehensive integration with Grafana, enabling seamless interaction with observability data, dashboards, alerts, and incident management. Connect to Grafana Cloud or self-hosted Grafana instances to query metrics, logs, traces, profiles, manage dashboards and alerts, and coordinate on-call schedules.
 
+  This server is appropriate for connecting to self-hosted instances of Grafana. If you're using Grafana Cloud, we recommend using the **Grafana Cloud** MCP server.
+
   ## Features
   - **Observability Data Queries**: Query Prometheus metrics, Loki logs, Tempo traces, and Pyroscope profiles
   - **Dashboard Management**: Search, view, create, update dashboards with full JSONPath support for efficient modifications
@@ -390,4 +392,3 @@ containerizedConfig:
   - streamable-http
   - --address
   - 0.0.0.0:8080
-

--- a/grafana_cloud.yaml
+++ b/grafana_cloud.yaml
@@ -5,6 +5,8 @@ shortDescription: Query Grafana Cloud metrics, logs, dashboards, alerts, inciden
 description: |
   Grafana Cloud's official hosted Model Context Protocol (MCP) server connects AI agents directly to a Grafana Cloud stack. It uses OAuth 2.1, so each user authorizes access with their own Grafana identity and RBAC permissions instead of providing a service account token.
 
+  [Read the official Grafana Cloud MCP server documentation](https://grafana.com/docs/grafana-cloud/ai-tools/mcp-servers/cloud-mcp/).
+
   ## Features
 
   - **Observability queries**: Query Prometheus metrics, Loki logs, Pyroscope profiles, Tempo data, and supported datasource types

--- a/tableau.yaml
+++ b/tableau.yaml
@@ -5,6 +5,8 @@ shortDescription: Query Tableau data sources, access Pulse metrics, and explore 
 description: |
   A Model Context Protocol (MCP) server that provides comprehensive access to Tableau Cloud and Tableau Server through multiple APIs. Connect to published data sources, query data with VizQL, explore Pulse metrics, and access workbooks and views with full metadata support.
 
+  This server is appropriate for connecting to self-hosted instances of Tableau Server. If you're using Tableau Cloud, we recommend using the **Tableau Cloud** MCP server.
+
   ## Features
   - **VizQL Data Service (VDS) API**: Access to Tableau published data sources with advanced querying capabilities
   - **Tableau Metadata API**: Collect data source metadata including columns with rich descriptions

--- a/tableau.yaml
+++ b/tableau.yaml
@@ -25,7 +25,6 @@ metadata:
   categories: Data Analytics, Business Intelligence, Visualization
 icon: https://avatars.githubusercontent.com/u/828667?s=48&v=4
 repoURL: https://github.com/tableau/tableau-mcp
-
 toolPreview:
   - name: list-datasources
     description: Retrieves a list of published data sources from a specified Tableau site using the Tableau REST API. Supports optional filtering via field:operator:value expressions for precise and flexible data source discovery.

--- a/tableau_cloud.yaml
+++ b/tableau_cloud.yaml
@@ -1,0 +1,146 @@
+name: Tableau Cloud
+entryKey: obot-tableau-cloud
+serverUserType: singleUser
+shortDescription: Query Tableau Cloud data, explore content, and manage Pulse metrics with OAuth
+description: |
+  The official Tableau-hosted Model Context Protocol (MCP) server for Tableau Cloud. It uses your Tableau Cloud identity, so each tool call respects your existing site role and content permissions.
+
+  ## Features
+  - **Data Q&A**: Discover published data sources, inspect metadata, and query data with VizQL
+  - **Content Exploration**: Search workbooks, views, projects, custom views, and Tableau Prep flows
+  - **Pulse Analytics**: Explore Pulse metrics and generate insight bundles and briefs
+  - **Administration**: Access guarded content, task, user, job, and Admin Insights tools when your site settings and permissions allow them
+
+  ## What you'll need to connect
+
+  A Tableau Cloud account with access to a Tableau site. Authentication is handled automatically through Tableau OAuth when you connect. No Personal Access Token, API key, or client credentials are required.
+
+  ## Limitations
+
+  This server supports Tableau Cloud only. Tableau Server and self-hosted Tableau deployments are not supported by Tableau's hosted endpoint.
+
+metadata:
+  categories: Data Analytics, Business Intelligence, Visualization
+
+icon: https://avatars.githubusercontent.com/u/828667?s=48&v=4
+repoURL: https://github.com/tableau/tableau-mcp
+runtime: remote
+remoteConfig:
+  fixedURL: https://mcp.tableau.com
+
+toolPreview:
+  - name: list-datasources
+    description: List published data sources available on the Tableau Cloud site.
+    params:
+      filter: Optional REST filter in field:operator:value format.
+      limit: Maximum number of results to return.
+      pageNumber: Page number to retrieve.
+  - name: get-datasource-metadata
+    description: Retrieve datasource descriptions, model relationships, fields, and parameters.
+    params:
+      datasourceLuid: LUID of the datasource to inspect.
+  - name: query-datasource
+    description: Query a published datasource through the VizQL Data Service.
+    params:
+      datasourceLuid: LUID of the datasource to query.
+      query: VizQL query with fields, filters, aggregations, sorting, and parameters.
+      limit: Maximum number of rows to return.
+  - name: list-workbooks
+    description: List workbooks available on the Tableau Cloud site.
+    params:
+      filter: Optional REST filter in field:operator:value format.
+      limit: Maximum number of results to return.
+      pageNumber: Page number to retrieve.
+  - name: get-workbook
+    description: Retrieve a workbook and its views.
+    params:
+      workbookId: ID of the workbook to retrieve.
+  - name: list-views
+    description: List views with their workbook and owner metadata.
+    params:
+      filter: Optional REST filter in field:operator:value format.
+      limit: Maximum number of results to return.
+      pageNumber: Page number to retrieve.
+  - name: get-view
+    description: Retrieve metadata for a workbook view.
+    params:
+      viewId: ID of the view to retrieve.
+  - name: get-view-data
+    description: Retrieve CSV data for a workbook view.
+    params:
+      viewId: ID of the view to retrieve.
+      viewFilters: Optional filters to apply to the view.
+  - name: get-view-image
+    description: Retrieve a rendered image for a workbook view.
+    params:
+      viewId: ID of the view to render.
+      width: Image width in pixels.
+      height: Image height in pixels.
+      format: Image format.
+      viewFilters: Optional filters to apply to the view.
+  - name: list-custom-views
+    description: List saved custom views for a workbook.
+    params:
+      workbookId: ID of the workbook.
+      filter: Optional REST filter in field:operator:value format.
+      limit: Maximum number of results to return.
+  - name: get-custom-view-data
+    description: Retrieve CSV data for a saved custom view.
+    params:
+      customViewId: ID of the custom view.
+      viewFilters: Optional filters to apply to the view.
+  - name: get-custom-view-image
+    description: Retrieve a rendered image for a saved custom view.
+    params:
+      customViewId: ID of the custom view.
+      width: Image width in pixels.
+      height: Image height in pixels.
+      format: Image format.
+      viewFilters: Optional filters to apply to the view.
+  - name: list-projects
+    description: List projects available on the Tableau Cloud site.
+    params:
+      filter: Optional REST filter in field:operator:value format.
+      limit: Maximum number of results to return.
+      pageNumber: Page number to retrieve.
+  - name: list-all-pulse-metric-definitions
+    description: List published Pulse metric definitions.
+    params:
+      view: Definition detail level.
+      limit: Maximum number of results to return.
+      pageSize: Number of items per page.
+  - name: list-pulse-metric-definitions-from-definition-ids
+    description: Retrieve Pulse metric definitions by ID.
+    params:
+      metricDefinitionIds: Pulse metric definition IDs.
+      view: Definition detail level.
+  - name: list-pulse-metrics-from-metric-definition-id
+    description: List Pulse metrics for a metric definition.
+    params:
+      pulseMetricDefinitionID: ID of the Pulse metric definition.
+  - name: list-pulse-metrics-from-metric-ids
+    description: Retrieve Pulse metrics by ID.
+    params:
+      metricIds: Pulse metric IDs.
+  - name: list-pulse-metric-subscriptions
+    description: List the current user's Pulse metric subscriptions.
+  - name: generate-pulse-metric-value-insight-bundle
+    description: Generate an insight bundle for a Pulse metric.
+    params:
+      bundleRequest: Request containing the metric and insight context.
+      bundleType: Insight bundle type.
+  - name: generate-pulse-insight-brief
+    description: Generate an AI-powered Pulse Insight Brief. Requires Tableau+.
+    params:
+      briefRequest: Request containing conversation and metric context.
+  - name: search-content
+    description: Search Tableau content, including workbooks, views, data sources, databases, and tables.
+    params:
+      terms: Terms to search for.
+      limit: Maximum number of results to return.
+      orderBy: Sorting configuration.
+      filter: Content type, owner, or modification-time filters.
+  - name: reset-consent
+    description: Reset Tableau MCP consent for the current user.
+  - name: revoke-access-token
+    description: Revoke the current Tableau MCP access token.

--- a/tableau_cloud.yaml
+++ b/tableau_cloud.yaml
@@ -5,6 +5,8 @@ shortDescription: Query Tableau Cloud data, explore content, and manage Pulse me
 description: |
   The official Tableau-hosted Model Context Protocol (MCP) server for Tableau Cloud. It uses your Tableau Cloud identity, so each tool call respects your existing site role and content permissions.
 
+  [Read the official hosted Tableau MCP documentation](https://tableau.github.io/tableau-mcp/docs/hosted-tableau-mcp).
+
   ## Features
   - **Data Q&A**: Discover published data sources, inspect metadata, and query data with VizQL
   - **Content Exploration**: Search workbooks, views, projects, custom views, and Tableau Prep flows
@@ -23,7 +25,7 @@ metadata:
   categories: Data Analytics, Business Intelligence, Visualization
 
 icon: https://avatars.githubusercontent.com/u/828667?s=48&v=4
-repoURL: https://github.com/tableau/tableau-mcp
+repoURL: https://tableau.github.io/tableau-mcp/docs/hosted-tableau-mcp
 runtime: remote
 remoteConfig:
   fixedURL: https://mcp.tableau.com


### PR DESCRIPTION
Part of https://github.com/obot-platform/obot/issues/7376

This adds new remote entries alongside non-deprecated versions since they are not exact replacements:

- Grafana: compatible with Grafana Cloud and not self-hosted
- Tableau: same
- Github Enterprise Cloud: same