### PR TITLE
fix(ci): temporarily disable mcpwn workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.5"
+          go-version: "1.27"
           cache: false
 
       - name: Validate catalog YAML

--- a/.github/workflows/mcpwn-fanout.yml
+++ b/.github/workflows/mcpwn-fanout.yml
@@ -1,13 +1,6 @@
 name: Mcpwn Fan-out (dispatch one run per YAML)
 run-name: ${{ inputs.workflow_name || 'Mcpwn Scan' }} - Fan-out
-on:
-  workflow_dispatch:
-    inputs:
-      workflow_name:
-        description: "Custom workflow name (optional)"
-        required: false
-        type: string
-        default: "Mcpwn Scan"
+on: []
 
 permissions:
   contents: read

--- a/.github/workflows/mcpwn-worker.yml
+++ b/.github/workflows/mcpwn-worker.yml
@@ -1,34 +1,7 @@
 name: Mcpwn Worker (scan one YAML target)
 run-name: ${{ inputs.workflow_name || 'Mcpwn Scan' }} - ${{ inputs.file }}
 
-on:
-  workflow_dispatch:
-    inputs:
-      file:
-        description: "Repo YAML file path"
-        required: true
-        type: string
-      image:
-        description: "Container image"
-        required: true
-        type: string
-      port:
-        description: "Container port to publish on 8080"
-        required: true
-        type: string
-      args_b64:
-        description: "Base64 JSON array of args"
-        required: true
-        type: string
-      env_b64:
-        description: "Base64 JSON object of env"
-        required: true
-        type: string
-      workflow_name:
-        description: "Custom workflow name"
-        required: false
-        type: string
-        default: "Mcpwn Scan"
+on: []
 
 permissions:
   contents: read

--- a/.github/workflows/mcpwn.yml
+++ b/.github/workflows/mcpwn.yml
@@ -6,10 +6,7 @@ permissions:
   actions: read
   pull-requests: write
 
-on:
-  workflow_dispatch:
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+on: []
 
 jobs:
   generate-matrix:


### PR DESCRIPTION
`mcpwn` is having false positives and not being useful now. Disabling for later re-evaluation