### PR TITLE
enhance: add more remote MCPs and improve descriptions

### DIFF
--- a/.agents/skills/claude-catalog-entry/SKILL.md
+++ b/.agents/skills/claude-catalog-entry/SKILL.md
@@ -31,7 +31,8 @@ Use the repository CLI for snapshots, selection, and every ledger mutation. Neve
 4. Verify authentication using the read-only public discovery flow below, then map it to supported Obot remote configuration.
 5. If it is a duplicate, record `existing`. If it cannot be supported or ported, record `skipped`. Leave ambiguous cases unreviewed.
 6. Otherwise create the smallest useful catalog entry under `remotes/`. Link the authoritative provider documentation in the entry's `description`, even when the same URL is used for `repoURL`. Do not add `toolPreview` during intake.
-7. Validate catalog YAML before recording an imported disposition:
+7. Verify the entry's icon using the image checks below.
+8. Validate catalog YAML before recording an imported disposition:
 
    ```sh
    obot mcp validate-catalog-yaml --require-entry-key .
@@ -60,6 +61,17 @@ Choose the first verified Obot mapping:
 - If OAuth requires a provider-created client ID/secret or allowlisted redirect URI, use static OAuth with `remoteConfig.staticOAuthRequired: true` and document the provider setup and required scopes.
 - If provider docs specify a static token or API key, use `remoteConfig.headers`. Mark the value `required: true` and `sensitive: true`; use the documented header name and add a prefix such as `Bearer ` only when required.
 - If documentation and live discovery conflict, or the auth scheme cannot be represented safely, leave the connector unreviewed. Never infer auth from a Claude-only connect button.
+
+## Verify the icon
+
+Prefer an official, stable image asset. Do not use a homepage URL or assume that `/favicon.ico` exists.
+
+Apply the same public-destination and manual-redirect policy used for authentication requests, then make a GET request to the exact URL that will be stored in `icon`:
+
+- Require a successful 2xx response without authentication.
+- Require an `image/*` response content type and a non-empty body.
+- If the candidate redirects, validate every redirect target and store the final direct image URL rather than the redirecting URL.
+- Leave the connector unreviewed if no stable image URL can be verified.
 
 ## Record the verified disposition
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# Remote catalog entries
+# Catalog entries
 
-Remote catalog entries must:
+Catalog entries must:
 
 - Use `repoURL` to link to official documentation.
 - Include a link to official documentation or setup instructions in the description before the first feature or setup section.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,10 @@ Remote catalog entries must:
 
 - Use `repoURL` to link to official documentation.
 - Include a link to official documentation or setup instructions in the description before the first feature or setup section.
+- Lead the description with concrete, product-specific functionality or outcomes.
+- Avoid opening with protocol, hosting, or "official server" boilerplate.
+- Use `MCP`, not the expanded term "Model Context Protocol".
+- Mention hosting, authentication, or official status only when it adds useful context.
 - Use `urlTemplate`, not `URLTemplate`, when configuring a URL template.
 
 # Catalog Validation

--- a/obot-images/antv_charts.yaml
+++ b/obot-images/antv_charts.yaml
@@ -7,7 +7,7 @@ description: |
 
   ![MCP Server](https://badge.mcpx.dev?type=server) [![build](https://github.com/antvis/mcp-server-chart/actions/workflows/build.yml/badge.svg)](https://github.com/antvis/mcp-server-chart/actions/workflows/build.yml) [![npm Version](https://img.shields.io/npm/v/@antv/mcp-server-chart.svg)](https://www.npmjs.com/package/@antv/mcp-server-chart) [![npm License](https://img.shields.io/npm/l/@antv/mcp-server-chart.svg)](https://www.npmjs.com/package/@antv/mcp-server-chart)
 
-  A Model Context Protocol (MCP) server for generating charts using AntV. Create various types of professional charts for data analysis and visualization with support for 25+ chart types including statistical, geographical, and specialized diagrams.
+  Generate more than 25 professional AntV chart types for data analysis and visualization, including statistical, geographical, and specialized diagrams.
 
   ## Features
   # Now 25+ charts supported:

--- a/obot-images/aws.yaml
+++ b/obot-images/aws.yaml
@@ -2,7 +2,7 @@ name: AWS API
 entryKey: obot-aws-api
 serverUserType: singleUser
 shortDescription: Execute AWS CLI commands across all AWS services with intelligent suggestions
-description: 'A Model Context Protocol (MCP) server for AWS CLI operations. Execute AWS CLI commands and get intelligent command suggestions across all AWS services safely and efficiently.
+description: 'Execute AWS CLI commands and get intelligent command suggestions across AWS services safely and efficiently.
 
 
   ## Features
@@ -119,4 +119,3 @@ toolPreview:
   description: Get AI-powered suggestions for AWS CLI commands based on natural language queries
   params:
     query: A natural language description of what you want to accomplish in AWS
-

--- a/obot-images/aws_documentation.yaml
+++ b/obot-images/aws_documentation.yaml
@@ -5,7 +5,7 @@ shortDescription: Access, search, and get recommendations from AWS documentation
 description: '![AWS Documentation MCP Demo](https://github.com/awslabs/mcp/blob/main/src/aws-documentation-mcp-server/basic-usage.gif?raw=true)
 
 
-  A Model Context Protocol (MCP) server for AWS Documentation. Access, search, and get recommendations from AWS documentation with tools to fetch content, search globally, and discover related resources.
+  Access, search, and get recommendations from AWS documentation with tools to fetch content, search globally, and discover related resources.
 
 
   ## Features

--- a/obot-images/aws_eks.yaml
+++ b/obot-images/aws_eks.yaml
@@ -2,7 +2,7 @@ name: AWS EKS
 entryKey: obot-aws-eks
 serverUserType: singleUser
 shortDescription: Manage Amazon EKS clusters, Kubernetes resources, and containerized applications
-description: 'A Model Context Protocol (MCP) server for Amazon EKS that provides AI code assistants with resource management tools and real-time cluster state visibility. Streamline application development through tailored guidance from initial setup through production optimization and troubleshooting.
+description: 'Manage Amazon EKS resources and inspect real-time cluster state, with guidance from initial setup through production optimization and troubleshooting.
 
 
   ## Features

--- a/obot-images/aws_kendra.yaml
+++ b/obot-images/aws_kendra.yaml
@@ -2,7 +2,7 @@ name: AWS Kendra
 entryKey: obot-aws-kendra
 serverUserType: singleUser
 shortDescription: Query Amazon Kendra indices for enhanced RAG context in AI applications
-description: 'A Model Context Protocol (MCP) server for Amazon Kendra developed by AWS Labs. Use Kendra Indices as additional context for RAG to enhance your existing MCP-enabled ChatBot and coding assistants.
+description: 'Query Amazon Kendra indices as additional RAG context for chatbots and coding assistants.
 
 
   ## Features

--- a/obot-images/aws_redshift.yaml
+++ b/obot-images/aws_redshift.yaml
@@ -2,7 +2,7 @@ name: AWS Redshift
 entryKey: obot-aws-redshift
 serverUserType: singleUser
 shortDescription: Discover, explore, and query Amazon Redshift clusters and serverless workgroups
-description: 'A Model Context Protocol (MCP) server for Amazon Redshift. Discover, explore, and query Amazon Redshift clusters and serverless workgroups safely and efficiently through comprehensive discovery and query execution tools.
+description: 'Discover, explore, and query Amazon Redshift clusters and serverless workgroups safely and efficiently.
 
 
   ## Features

--- a/obot-images/azure.yaml
+++ b/obot-images/azure.yaml
@@ -2,7 +2,7 @@ name: Azure
 entryKey: obot-azure
 serverUserType: singleUser
 shortDescription: Manage Azure services including AI, databases, compute, storage, and monitoring
-description: 'A Model Context Protocol (MCP) server that implements the MCP specification to create a seamless connection between AI agents and Azure services. Supercharge your agents with Azure context across compute, storage, databases, AI services, and more.
+description: 'Manage Azure compute, storage, databases, AI services, and other cloud resources.
 
 
   ## Features

--- a/obot-images/brave_search.yaml
+++ b/obot-images/brave_search.yaml
@@ -4,7 +4,7 @@ serverUserType: singleUser
 shortDescription: Search the web, news, images, videos, and local businesses with Brave Search API
 description: '**DEPRECATED**: this server is no longer supported by the Obot MCP Catalog. No direct replacement is currently available.
 
-  A Model Context Protocol (MCP) server that provides comprehensive web search capabilities through the Brave Search API. It enables AI assistants to search the web, find news articles, discover videos and images, locate local businesses, and generate AI-powered summaries of search results.
+  Search the web, news, videos, images, and local businesses through the Brave Search API, and generate AI-powered result summaries.
 
 
   ## Features

--- a/obot-images/browserbase.yaml
+++ b/obot-images/browserbase.yaml
@@ -4,7 +4,7 @@ serverUserType: singleUser
 shortDescription: Cloud browser automation with web scraping, screenshots, and AI interactions
 description: '**DEPRECATED**: this server is no longer supported by the Obot MCP Catalog. No approved replacement is currently available. Browserbase''s hosted MCP is not approved because it requires API keys in URL query parameters.
 
-  A Model Context Protocol (MCP) server that provides cloud browser automation capabilities using Browserbase and Stagehand. Enable LLMs to interact with web pages, take screenshots, extract information, and perform automated actions with atomic precision.
+  Automate cloud browsers with Browserbase and Stagehand to interact with pages, take screenshots, extract information, and perform precise actions.
 
 
   ## Features

--- a/obot-images/chroma.yaml
+++ b/obot-images/chroma.yaml
@@ -4,7 +4,7 @@ serverUserType: singleUser
 shortDescription: Manage collections, documents, and vector search in Chroma embedding database
 description: '**DEPRECATED**: this server is no longer supported by the Obot MCP Catalog. No direct replacement is currently available.
 
-  A Model Context Protocol (MCP) server implementation that provides database capabilities for Chroma Cloud, the open-source embedding database. This server enables AI models to create collections, store documents with embeddings, and retrieve data using vector search, full-text search, metadata filtering, and more.
+  Create Chroma Cloud collections, store documents with embeddings, and retrieve data using vector search, full-text search, metadata filtering, and more.
 
 
   ## Features

--- a/obot-images/duckduckgo_search.yaml
+++ b/obot-images/duckduckgo_search.yaml
@@ -2,7 +2,7 @@ name: DuckDuckGo Search
 entryKey: obot-duckduckgo-search
 serverUserType: singleUser
 shortDescription: Search the web with DuckDuckGo and retrieve webpage content with parsing
-description: 'A Model Context Protocol (MCP) server that provides web search capabilities through DuckDuckGo, with additional features for content fetching and parsing. Search the web and retrieve webpage content with LLM-friendly formatting.
+description: 'Search the web through DuckDuckGo and retrieve parsed webpage content with LLM-friendly formatting.
 
 
   ## Features

--- a/obot-images/github_enterprise.yaml
+++ b/obot-images/github_enterprise.yaml
@@ -3,7 +3,7 @@ entryKey: obot-github-enterprise
 serverUserType: singleUser
 shortDescription: Connect AI tools to GitHub Enterprise Server
 description: |
-  A containerized Model Context Protocol (MCP) server for GitHub Enterprise Server. GitHub does not provide a hosted remote MCP endpoint for GitHub Enterprise Server.
+  Connect AI tools to GitHub Enterprise Server with a containerized MCP server. GitHub does not provide a hosted remote MCP endpoint for GitHub Enterprise Server.
 
   [Read the official GitHub Enterprise MCP server documentation](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/provide-context/use-mcp-in-your-ide/enterprise-configuration).
 

--- a/obot-images/gitlab.yaml
+++ b/obot-images/gitlab.yaml
@@ -2,7 +2,7 @@ name: GitLab
 entryKey: obot-gitlab
 serverUserType: singleUser
 shortDescription: Manage GitLab projects, repositories, issues, merge requests, and CI/CD pipelines
-description: 'A Model Context Protocol (MCP) server that provides comprehensive GitLab integration capabilities. Enable LLMs to interact with GitLab projects, manage repositories, handle issues and merge requests, and perform automated GitLab operations with precision.
+description: 'Manage GitLab projects, repositories, issues, merge requests, CI/CD pipelines, and other development workflows.
 
 
   ## Features

--- a/obot-images/grafana.yaml
+++ b/obot-images/grafana.yaml
@@ -3,7 +3,7 @@ entryKey: obot-grafana
 serverUserType: singleUser
 shortDescription: Query metrics, logs, traces, manage dashboards, alerts, and on-call schedules
 description: |
-  A Model Context Protocol (MCP) server that provides comprehensive integration with Grafana, enabling seamless interaction with observability data, dashboards, alerts, and incident management. Connect to Grafana Cloud or self-hosted Grafana instances to query metrics, logs, traces, profiles, manage dashboards and alerts, and coordinate on-call schedules.
+  Query metrics, logs, traces, and profiles in Grafana Cloud or self-hosted Grafana, manage dashboards and alerts, and coordinate on-call schedules.
 
   This server is appropriate for connecting to self-hosted instances of Grafana. If you're using Grafana Cloud, we recommend using the **Grafana Cloud** MCP server.
 

--- a/obot-images/markitdown.yaml
+++ b/obot-images/markitdown.yaml
@@ -4,7 +4,7 @@ serverUserType: singleUser
 shortDescription: Convert documents, images, audio, and web content to LLM-optimized Markdown
 description: '**DEPRECATED**: this server is no longer supported by the Obot MCP Catalog. No direct replacement is currently available.
 
-  A Model Context Protocol (MCP) server that provides powerful file-to-Markdown conversion capabilities. Convert various document formats and web content to clean, structured Markdown optimized for LLM consumption.
+  Convert documents, images, audio, and web content to clean, structured Markdown optimized for LLM consumption.
 
 
   ## Features

--- a/obot-images/mongodb_atlas_management.yaml
+++ b/obot-images/mongodb_atlas_management.yaml
@@ -5,7 +5,7 @@ shortDescription: Create and manage MongoDB Atlas projects, clusters, and databa
 description: |
   **DEPRECATED**: Use the **MongoDB Atlas** connector instead. It connects to MongoDB's hosted Atlas MCP service and supports Atlas management, database operations, and stream processing through one connector.
 
-  A Model Context Protocol (MCP) server for interacting with the MongoDB Atlas Cloud Service. This connector allows you to perform management actions with clusters, projects, databases, collections, and database users.
+  Manage MongoDB Atlas projects, clusters, databases, collections, and database users.
 
   ## Features
   - **Atlas Management**: Create and manage MongoDB Atlas projects, clusters, and database users

--- a/obot-images/mongodb_database.yaml
+++ b/obot-images/mongodb_database.yaml
@@ -3,7 +3,7 @@ entryKey: obot-mongodb-database
 serverUserType: singleUser
 shortDescription: Manage MongoDB databases, collections, documents, and aggregation pipelines
 description: |
-  A Model Context Protocol (MCP) server for interacting with MongoDB databases. Provides comprehensive tools for database operations, collection management, and data manipulation with any MongoDB instance (local, cloud, or self-hosted).
+  Manage databases, collections, documents, and aggregation pipelines in local, cloud, or self-hosted MongoDB instances.
 
   **Using MongoDB Atlas?** Use the **MongoDB Atlas** connector instead. Use this connector for Community Edition, Enterprise Advanced, self-hosted deployments, or databases reachable only on a private network.
 

--- a/obot-images/mysql.yaml
+++ b/obot-images/mysql.yaml
@@ -7,7 +7,7 @@ description: '![Tests](https://github.com/designcomputer/mysql_mcp_server/action
   ![PyPI - Downloads](https://img.shields.io/pypi/dm/mysql-mcp-server)
 
 
-  A Model Context Protocol (MCP) server that enables secure interaction with MySQL databases. This server facilitates communication between AI applications and MySQL databases, making database exploration and analysis safer and more structured through a controlled interface.
+  Execute SQL queries and explore MySQL databases through a structured, controlled interface.
 
 
   ## Features

--- a/obot-images/playwright.yaml
+++ b/obot-images/playwright.yaml
@@ -4,7 +4,7 @@ serverUserType: singleUser
 shortDescription: Browser automation with accessibility-based interactions using Playwright
 description: '**DEPRECATED**: this server is no longer supported by the Obot MCP Catalog. No direct replacement is currently available.
 
-  A Model Context Protocol (MCP) server that provides browser automation capabilities using Playwright. This server enables AI agents to interact with web pages through structured accessibility snapshots, bypassing the need for screenshots or visually-tuned models for fast, deterministic automation.
+  Automate web pages with Playwright through structured accessibility snapshots for fast, deterministic interactions without screenshots.
 
 
   ## Features

--- a/obot-images/postgresql.yaml
+++ b/obot-images/postgresql.yaml
@@ -9,7 +9,7 @@ description: '[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg
   [![Contributors](https://img.shields.io/github/contributors/crystaldba/postgres-mcp)](https://github.com/crystaldba/postgres-mcp/graphs/contributors)
 
 
-  A Model Context Protocol (MCP) server designed for deep SQL performance analysis and optimization. It delivers advanced index tuning, workload-aware query insights, safe execution controls, and schema-aware SQL generation—backed by comprehensive database health diagnostics and EXPLAIN plan simulation.
+  Analyze and optimize PostgreSQL performance with index tuning, workload-aware query insights, safe execution controls, schema-aware SQL generation, health diagnostics, and EXPLAIN plan simulation.
 
 
   ## Features

--- a/obot-images/redis.yaml
+++ b/obot-images/redis.yaml
@@ -5,7 +5,7 @@ shortDescription: Manage Redis data types, vector search, streams, and pub/sub m
 description: |
   [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
   [![Python Version](https://img.shields.io/badge/python-3.13%2B-blue)](https://www.python.org/downloads/)
-  A Model Context Protocol (MCP) server that provides a natural language interface designed for agentic applications to efficiently manage and search data in Redis. It integrates seamlessly with MCP clients, enabling AI-driven workflows to interact with structured and unstructured data using conversational commands.
+  Manage and search structured and unstructured Redis data with natural-language commands for AI-driven workflows.
   ## Features
   - **Natural Language Queries**: Enable AI agents to query and update Redis using conversational commands
   - **Complete Redis Data Types**: Support for strings, hashes, lists, sets, sorted sets, streams, and JSON documents

--- a/obot-images/slack.yaml
+++ b/obot-images/slack.yaml
@@ -11,7 +11,7 @@ description: |
   ![Node.js](https://img.shields.io/badge/Node.js-18+-orange?style=for-the-badge&logo=node.js)
   ![License](https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge)
 
-  A Model Context Protocol (MCP) server for Slack integration, providing comprehensive workspace management capabilities through a modern API interface.
+  Send messages, manage channels, search history, and work with threads in Slack workspaces.
 
   ## Features
   - **Channel Management**: List, search, and interact with Slack channels

--- a/obot-images/tableau.yaml
+++ b/obot-images/tableau.yaml
@@ -3,7 +3,7 @@ entryKey: obot-tableau
 serverUserType: singleUser
 shortDescription: Query Tableau data sources, access Pulse metrics, and explore workbooks
 description: |
-  A Model Context Protocol (MCP) server that provides comprehensive access to Tableau Cloud and Tableau Server through multiple APIs. Connect to published data sources, query data with VizQL, explore Pulse metrics, and access workbooks and views with full metadata support.
+  Query published Tableau data sources with VizQL, explore Pulse metrics, and access workbooks and views with full metadata in Tableau Cloud or Tableau Server.
 
   This server is appropriate for connecting to self-hosted instances of Tableau Server. If you're using Tableau Cloud, we recommend using the **Tableau Cloud** MCP server.
 

--- a/obot-images/terraform.yaml
+++ b/obot-images/terraform.yaml
@@ -3,7 +3,7 @@ entryKey: obot-terraform
 serverUserType: singleUser
 shortDescription: Manage Terraform Cloud workspaces, runs, variables, and explore the registry
 description: |
-  A Model Context Protocol (MCP) server that provides seamless integration with the Terraform ecosystem, enabling advanced automation and interaction capabilities for Infrastructure as Code (IaC) development. Connect to Terraform Cloud or Terraform Enterprise to manage workspaces, runs, variables, and explore the Terraform Registry.
+  Manage Terraform Cloud or Terraform Enterprise workspaces, runs, and variables, and explore the Terraform Registry for Infrastructure as Code development.
 
   ## Features
   - **Workspace Management**: Create, update, list, and manage Terraform Cloud/Enterprise workspaces

--- a/obot-images/wordpress.yaml
+++ b/obot-images/wordpress.yaml
@@ -3,7 +3,7 @@ entryKey: obot-wordpress
 serverUserType: singleUser
 shortDescription: Manage WordPress posts, categories, tags, and media on self-hosted sites
 description: |
-  A Model Context Protocol (MCP) server that integrates with a self-hosted WordPress site (wordpress.com not supported).
+  Manage posts, categories, tags, and media on a self-hosted WordPress site (wordpress.com is not supported).
   
   ## Features
   - **Posts**: Manage blog posts

--- a/obot-remotes/calendar.yaml
+++ b/obot-remotes/calendar.yaml
@@ -7,7 +7,7 @@ description: |
   ![Go](https://img.shields.io/badge/Go-1.25+-green?style=for-the-badge&logo=go)
   ![License](https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge)
 
-  A Model Context Protocol (MCP) server for Microsoft 365 Calendar integration, providing comprehensive calendar and event management capabilities through Microsoft Graph API.
+  Manage Microsoft 365 calendars, events, meetings, and attendees through the Microsoft Graph API.
 
   ## Features
   - **Calendar Management**: Access personal and group calendars with full metadata and permissions

--- a/obot-remotes/contact.yaml
+++ b/obot-remotes/contact.yaml
@@ -7,7 +7,7 @@ description: |
   ![Go](https://img.shields.io/badge/Go-1.23+-green?style=for-the-badge&logo=go)
   ![License](https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge)
 
-  A Model Context Protocol (MCP) server for Microsoft 365 Contact integration, providing comprehensive contact management capabilities through Microsoft Graph API.
+  Create, search, update, and delete Microsoft 365 contacts through the Microsoft Graph API.
 
   ## Features
   - **Complete Contact Management**: Create, read, update, and delete Outlook contacts with full CRUD operations

--- a/obot-remotes/excel.yaml
+++ b/obot-remotes/excel.yaml
@@ -7,7 +7,7 @@ description: |
   ![Go](https://img.shields.io/badge/Go-1.23+-green?style=for-the-badge&logo=go)
   ![License](https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge)
 
-  A Model Context Protocol (MCP) server for Microsoft Excel integration, providing comprehensive spreadsheet management capabilities through Microsoft Graph API.
+  Manage Microsoft Excel workbooks, worksheets, tables, and data through the Microsoft Graph API.
 
   ## Features
   - **Workbook Management**: List and access all Excel workbooks in OneDrive with complete metadata

--- a/obot-remotes/gmail.yaml
+++ b/obot-remotes/gmail.yaml
@@ -12,7 +12,7 @@ description: |
 
   Obot plans to move this catalog entry to Google's official MCP server for Gmail once it leaves Developer Preview. To try Google's Developer Preview now, see [Configure the Gmail MCP server](https://developers.google.com/workspace/gmail/api/guides/configure-mcp-server).
 
-  A Model Context Protocol (MCP) server for Gmail integration, providing comprehensive email management capabilities through a modern API interface.
+  Send, read, draft, search, and organize Gmail messages and labels.
 
   ## Features
   - **OAuth2 Authentication**: Secure Google OAuth integration with automatic token refresh

--- a/obot-remotes/google-calendar.yaml
+++ b/obot-remotes/google-calendar.yaml
@@ -12,7 +12,7 @@ description: |
 
   Obot plans to move this catalog entry to Google's official MCP server for Google Calendar once it leaves Developer Preview. To try Google's Developer Preview now, see [Configure the Calendar MCP server](https://developers.google.com/workspace/calendar/api/guides/configure-mcp-server).
 
-  A Model Context Protocol (MCP) server for Google Calendar integration, providing comprehensive calendar and event management capabilities through a modern API interface.
+  Manage Google Calendar events, recurring schedules, and attendees.
 
   ## Features
   - **OAuth2 Authentication**: Secure Google OAuth integration with automatic token refresh

--- a/obot-remotes/google-docs.yaml
+++ b/obot-remotes/google-docs.yaml
@@ -12,7 +12,7 @@ description: |
 
   Obot plans to move this catalog entry to Google's official MCP server for Google Docs once it leaves Developer Preview. To try Google's Developer Preview now, see [Configure the Docs MCP server](https://developers.google.com/workspace/docs/api/guides/configure-mcp-server).
 
-  A Model Context Protocol (MCP) server for Google Docs integration, providing comprehensive docujment document management capabilities.
+  Create and manage documents in Google Docs.
 
   ## Features
   - **OAuth2 Authentication**: Secure Google OAuth integration with automatic token refresh

--- a/obot-remotes/google-drive.yaml
+++ b/obot-remotes/google-drive.yaml
@@ -12,7 +12,7 @@ description: |
 
   Obot plans to move this catalog entry to Google's official MCP server for Google Drive once it leaves Developer Preview. To try Google's Developer Preview now, see [Configure the Drive MCP server](https://developers.google.com/workspace/drive/api/guides/configure-mcp-server).
 
-  A Model Context Protocol (MCP) server for Google Drive integration, providing comprehensive file and folder management capabilities through a modern API interface.
+  Manage Google Drive files, folders, permissions, and sharing.
 
   ## Features
   - **OAuth2 Authentication**: Secure Google OAuth integration with automatic token refresh

--- a/obot-remotes/google-search-console.yaml
+++ b/obot-remotes/google-search-console.yaml
@@ -10,7 +10,7 @@ description: |
 
   This remote server is a [custom Obot implementation](https://github.com/obot-platform/google-mcp/tree/main/search-console), hosted and managed by Obot so you can connect through a streamlined authentication flow without navigating the usual Google Cloud project and OAuth configuration.
 
-  A Model Context Protocol (MCP) server for Google Search Console integration, providing access to search console data.
+  Inspect sitemaps, search analytics, and other Google Search Console data.
 
   ## Features
   - **OAuth2 Authentication**: Secure Google OAuth integration with automatic token refresh

--- a/obot-remotes/google-sheets.yaml
+++ b/obot-remotes/google-sheets.yaml
@@ -12,7 +12,7 @@ description: |
 
   Obot plans to move this catalog entry to Google's official MCP server for Google Sheets once it leaves Developer Preview. To try Google's Developer Preview now, see [Configure the Sheets MCP server](https://developers.google.com/workspace/sheets/api/guides/configure-mcp-server).
 
-  A Model Context Protocol (MCP) server for Google Sheets integration, providing comprehensive spreadsheet management capabilities through a modern API interface.
+  Create and manage Google Sheets spreadsheets, worksheets, cells, and formulas.
 
   ## Features
   - **OAuth2 Authentication**: Secure Google OAuth integration with automatic token refresh

--- a/obot-remotes/onedrive.yaml
+++ b/obot-remotes/onedrive.yaml
@@ -7,7 +7,7 @@ description: |
   ![Go](https://img.shields.io/badge/Go-1.23+-green?style=for-the-badge&logo=go)
   ![License](https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge)
 
-  A Model Context Protocol (MCP) server for Microsoft OneDrive integration, providing comprehensive cloud file management capabilities through Microsoft Graph API.
+  Manage OneDrive files, folders, sharing, and cross-drive operations through the Microsoft Graph API.
 
   ## Features
   - **Drive Management**: Access personal and shared organization drives with detailed information

--- a/obot-remotes/outlook.yaml
+++ b/obot-remotes/outlook.yaml
@@ -8,7 +8,7 @@ description: |
   ![FastMCP](https://img.shields.io/badge/FastMCP-2.11.1+-orange?style=for-the-badge)
   ![License](https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge)
 
-  A Model Context Protocol (MCP) server for Microsoft Outlook integration, providing comprehensive email management capabilities through Microsoft Graph API.
+  Manage Outlook email, folders, drafts, and attachments through the Microsoft Graph API.
 
   ## Features
   - **Complete Email Management**: Read, send, draft, delete, and organize Outlook emails and messages

--- a/obot-remotes/word.yaml
+++ b/obot-remotes/word.yaml
@@ -7,7 +7,7 @@ description: |
   ![Go](https://img.shields.io/badge/Go-1.23+-green?style=for-the-badge&logo=go)
   ![License](https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge)
 
-  A Model Context Protocol (MCP) server for Microsoft Word integration, providing comprehensive document management capabilities through Microsoft Graph API.
+  Create and manage Microsoft Word documents, including Markdown content conversion, through the Microsoft Graph API.
 
   ## Features
   - **Document Discovery**: List and search all Word documents across OneDrive with detailed metadata

--- a/remotes/ahrefs.yaml
+++ b/remotes/ahrefs.yaml
@@ -3,7 +3,7 @@ entryKey: obot-ahrefs
 serverUserType: singleUser
 shortDescription: Research keywords, backlinks, rankings, competitors, and AI visibility
 description: |
-  [Ahrefs' official remote Model Context Protocol (MCP) server](https://docs.ahrefs.com/docs/mcp/reference/introduction) connects AI agents to Ahrefs SEO, competitive-intelligence, site-audit, and brand-visibility data.
+  Research keywords, backlinks, rankings, competitors, and AI visibility with [Ahrefs' official MCP server](https://docs.ahrefs.com/docs/mcp/reference/introduction).
 
   ## Features
   - Research keywords, search results, domains, and competitors

--- a/remotes/ahrefs.yaml
+++ b/remotes/ahrefs.yaml
@@ -1,0 +1,25 @@
+name: Ahrefs
+entryKey: obot-ahrefs
+serverUserType: singleUser
+shortDescription: Research keywords, backlinks, rankings, competitors, and AI visibility
+description: |
+  [Ahrefs' official remote Model Context Protocol (MCP) server](https://docs.ahrefs.com/docs/mcp/reference/introduction) connects AI agents to Ahrefs SEO, competitive-intelligence, site-audit, and brand-visibility data.
+
+  ## Features
+  - Research keywords, search results, domains, and competitors
+  - Analyze backlinks, referring domains, anchors, and link metrics
+  - Inspect site audits, rank tracking, and project data
+  - Measure brand mentions and visibility across AI search platforms
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **Ahrefs Account**: Each user authenticates through OAuth and receives access according to their Ahrefs plan and permissions
+
+metadata:
+  categories: Marketing, Data & Analytics, SaaS & API Integrations
+icon: https://ahrefs.com/favicon.ico
+repoURL: https://docs.ahrefs.com/docs/mcp/reference/introduction
+runtime: remote
+remoteConfig:
+  fixedURL: https://api.ahrefs.com/mcp/mcp

--- a/remotes/airtable.yaml
+++ b/remotes/airtable.yaml
@@ -1,0 +1,26 @@
+name: Airtable
+entryKey: obot-airtable
+serverUserType: singleUser
+shortDescription: Search, analyze, create, and update structured Airtable data
+description: |
+  [Airtable's official remote Model Context Protocol (MCP) server](https://support.airtable.com/using-the-airtable-mcp-server) connects AI agents to Airtable bases while respecting each user's existing permissions.
+
+  ## Features
+  - Search bases and inspect tables, fields, and records
+  - Analyze structured operational data
+  - Create and update records, tables, and fields
+  - Control which bases and applications the integration can access
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **Airtable Account**: Each user authenticates through OAuth and selects the bases available to the integration
+  - **Integration Permission**: Airtable administrators may need to allow third-party integrations for the organization
+
+metadata:
+  categories: Databases, Productivity, SaaS & API Integrations
+icon: https://airtable.com/favicon.ico
+repoURL: https://support.airtable.com/using-the-airtable-mcp-server
+runtime: remote
+remoteConfig:
+  fixedURL: https://mcp.airtable.com/mcp

--- a/remotes/airtable.yaml
+++ b/remotes/airtable.yaml
@@ -3,7 +3,7 @@ entryKey: obot-airtable
 serverUserType: singleUser
 shortDescription: Search, analyze, create, and update structured Airtable data
 description: |
-  [Airtable's official remote Model Context Protocol (MCP) server](https://support.airtable.com/using-the-airtable-mcp-server) connects AI agents to Airtable bases while respecting each user's existing permissions.
+  Search, analyze, create, and update structured data with [Airtable's official MCP server](https://support.airtable.com/using-the-airtable-mcp-server), which respects each user's existing base permissions.
 
   ## Features
   - Search bases and inspect tables, fields, and records

--- a/remotes/apollo.yaml
+++ b/remotes/apollo.yaml
@@ -3,7 +3,7 @@ entryKey: obot-apollo
 serverUserType: singleUser
 shortDescription: Find, enrich, and manage sales prospects and sequences
 description: |
-  [Apollo's official Model Context Protocol (MCP) integration](https://knowledge.apollo.io/hc/en-us/articles/43827318678541-Integrate-Apollo-with-Claude) connects AI agents to Apollo's people, company, contact, and sequence data.
+  Find and enrich people and companies, manage contacts, and work with sales sequences through [Apollo's official MCP integration](https://knowledge.apollo.io/hc/en-us/articles/43827318678541-Integrate-Apollo-with-Claude).
 
   ## Features
   - Search for people, companies, contacts, and job postings

--- a/remotes/apollo.yaml
+++ b/remotes/apollo.yaml
@@ -1,0 +1,25 @@
+name: Apollo.io
+entryKey: obot-apollo
+serverUserType: singleUser
+shortDescription: Find, enrich, and manage sales prospects and sequences
+description: |
+  [Apollo's official Model Context Protocol (MCP) integration](https://knowledge.apollo.io/hc/en-us/articles/43827318678541-Integrate-Apollo-with-Claude) connects AI agents to Apollo's people, company, contact, and sequence data.
+
+  ## Features
+  - Search for people, companies, contacts, and job postings
+  - Enrich people and organizations with verified sales data
+  - Create and update contacts
+  - Add contacts to or remove them from sales sequences
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **Apollo Account**: Each user authenticates through OAuth and receives access according to their Apollo plan and permissions
+
+metadata:
+  categories: Sales, Marketing, SaaS & API Integrations
+icon: https://www.apollo.io/favicon.ico
+repoURL: https://knowledge.apollo.io/hc/en-us/articles/43827318678541-Integrate-Apollo-with-Claude
+runtime: remote
+remoteConfig:
+  fixedURL: https://mcp.apollo.io/mcp

--- a/remotes/asana.yaml
+++ b/remotes/asana.yaml
@@ -10,7 +10,7 @@ upgradeNote: |
   - **Tool changes:** Tool names and parameters change. Dedicated goal mutation, time-period lookup, workspace listing, and several granular task helper tools are no longer available; some task operations are consolidated into bulk create and update tools.
   - **New capabilities:** V2 adds bulk task operations, status overviews, comments, and AI Teammate discovery.
 description: |
-  Connect to Asana's official Model Context Protocol (MCP) server to search and manage tasks, projects, portfolios, users, teams, attachments, comments, status updates, and AI Teammates.
+  Search and manage tasks, projects, portfolios, users, teams, attachments, comments, status updates, and AI Teammates through [Asana's official MCP server](https://developers.asana.com/docs/using-asanas-mcp-server).
 
   > **⚠️ Upgrade notice**
   >

--- a/remotes/atlassian.yaml
+++ b/remotes/atlassian.yaml
@@ -4,7 +4,7 @@ serverUserType: singleUser
 shortDescription: Manage Jira issues, Confluence pages, and Compass services with AI assistance
 description: |
 
-  A Model Context Protocol (MCP) server that bridges between your Atlassian Cloud site and compatible external tools. Once configured, it enables those tools to interact with Jira, Compass, and Confluence data in real-time.
+  Work with Jira, Compass, and Confluence data in real time through [Atlassian's remote MCP server](https://support.atlassian.com/atlassian-rovo-mcp-server/docs/getting-started-with-the-atlassian-remote-mcp-server/), which connects compatible tools to your Atlassian Cloud site.
 
   ## Features
   - **Smart Jira Management**: Create, update, search, and transition issues with AI assistance, manage comments, and track project metadata

--- a/remotes/box.yaml
+++ b/remotes/box.yaml
@@ -1,0 +1,27 @@
+name: Box
+entryKey: obot-box
+serverUserType: singleUser
+shortDescription: Search, analyze, create, and update content stored in Box
+description: |
+  [Box's official remote Model Context Protocol (MCP) server](https://developer.box.com/guides/box-mcp/) connects AI agents to content stored in Box while preserving existing Box permissions and security controls.
+
+  ## Features
+  - Search files, folders, metadata, and Box Hubs
+  - Read files and answer questions across one or more documents
+  - Extract structured or free-form information with Box AI
+  - Upload files, create folders, and update content when authorized
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **Box Admin Setup**: An administrator must enable MCP in the Box Admin Console
+  - **Box Integration Credentials**: Create OAuth client credentials, register the redirect URI shown by Obot, and enable the scopes required by the tools you plan to use, such as Content Actions
+
+metadata:
+  categories: Storage, Document Processing, Productivity
+icon: https://www.box.com/favicon.ico
+repoURL: https://developer.box.com/guides/box-mcp/
+runtime: remote
+remoteConfig:
+  fixedURL: https://mcp.box.com
+  staticOAuthRequired: true

--- a/remotes/box.yaml
+++ b/remotes/box.yaml
@@ -3,7 +3,7 @@ entryKey: obot-box
 serverUserType: singleUser
 shortDescription: Search, analyze, create, and update content stored in Box
 description: |
-  [Box's official remote Model Context Protocol (MCP) server](https://developer.box.com/guides/box-mcp/) connects AI agents to content stored in Box while preserving existing Box permissions and security controls.
+  Search, analyze, create, and update Box content through [Box's official MCP server](https://developer.box.com/guides/box-mcp/), while preserving existing permissions and security controls.
 
   ## Features
   - Search files, folders, metadata, and Box Hubs

--- a/remotes/calendly.yaml
+++ b/remotes/calendly.yaml
@@ -3,7 +3,7 @@ entryKey: obot-calendly
 serverUserType: singleUser
 shortDescription: Manage Calendly event types, availability, links, and bookings
 description: |
-  [Calendly's official remote Model Context Protocol (MCP) server](https://developer.calendly.com/calendly-mcp-server) connects AI agents to Calendly scheduling workflows.
+  Manage event types, availability, scheduling links, and bookings through [Calendly's official MCP server](https://developer.calendly.com/calendly-mcp-server).
 
   ## Features
   - Create and update event types

--- a/remotes/calendly.yaml
+++ b/remotes/calendly.yaml
@@ -1,0 +1,25 @@
+name: Calendly
+entryKey: obot-calendly
+serverUserType: singleUser
+shortDescription: Manage Calendly event types, availability, links, and bookings
+description: |
+  [Calendly's official remote Model Context Protocol (MCP) server](https://developer.calendly.com/calendly-mcp-server) connects AI agents to Calendly scheduling workflows.
+
+  ## Features
+  - Create and update event types
+  - Inspect and manage availability schedules
+  - Create scheduling links and book or cancel meetings
+  - Work with invitees, routing forms, and organization memberships
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **Calendly Account**: Each user authenticates through OAuth and receives access based on their Calendly permissions
+
+metadata:
+  categories: Scheduling, Productivity, SaaS & API Integrations
+icon: https://calendly.com/favicon.ico
+repoURL: https://developer.calendly.com/calendly-mcp-server
+runtime: remote
+remoteConfig:
+  fixedURL: https://mcp.calendly.com/

--- a/remotes/canva.yaml
+++ b/remotes/canva.yaml
@@ -3,7 +3,7 @@ entryKey: obot-canva
 serverUserType: singleUser
 shortDescription: Search, create, edit, and export Canva designs
 description: |
-  [Canva's official remote Model Context Protocol (MCP) server](https://www.canva.dev/docs/mcp/) enables AI agents to work with Canva designs and content.
+  Search, create, and update Canva designs and content through [Canva's official MCP server](https://www.canva.dev/docs/mcp/).
 
   ## Features
   - Search and inspect designs, pages, and folders

--- a/remotes/circle.yaml
+++ b/remotes/circle.yaml
@@ -3,7 +3,7 @@ entryKey: obot-circle
 serverUserType: singleUser
 shortDescription: Manage and analyze your Circle community through its official MCP server
 description: |
-  The official Circle Model Context Protocol (MCP) server connects your AI assistant to a Circle community through the Admin API v2.
+  Manage a Circle community through the Admin API v2 with [Circle's official MCP server](https://api.circle.so/mcp).
 
   ## Features
   - Browse and search members, spaces, posts, events, courses, tags, analytics, and form submissions

--- a/remotes/clay.yaml
+++ b/remotes/clay.yaml
@@ -1,0 +1,25 @@
+name: Clay
+entryKey: obot-clay
+serverUserType: singleUser
+shortDescription: Find prospects, enrich contacts, and research target companies
+description: |
+  [Clay's official remote Model Context Protocol (MCP) server](https://www.notion.so/clayrun/Clay-Claude-MCP-Server-Documentation-2ef7e66eb01480c9820de48041591aeb) connects AI agents to Clay's prospecting, enrichment, and account-research capabilities.
+
+  ## Features
+  - Find and enrich contacts at target companies
+  - Research and enrich companies
+  - Add contact and company data points
+  - Inspect available credits and previous searches
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **Clay Account**: Each user authenticates through OAuth and receives access based on their Clay account and credit balance
+
+metadata:
+  categories: Sales, Marketing, Data & Analytics
+icon: https://clay.com/favicon.ico
+repoURL: https://www.notion.so/clayrun/Clay-Claude-MCP-Server-Documentation-2ef7e66eb01480c9820de48041591aeb
+runtime: remote
+remoteConfig:
+  fixedURL: https://api.clay.com/v3/mcp

--- a/remotes/clay.yaml
+++ b/remotes/clay.yaml
@@ -3,7 +3,7 @@ entryKey: obot-clay
 serverUserType: singleUser
 shortDescription: Find prospects, enrich contacts, and research target companies
 description: |
-  [Clay's official remote Model Context Protocol (MCP) server](https://www.notion.so/clayrun/Clay-Claude-MCP-Server-Documentation-2ef7e66eb01480c9820de48041591aeb) connects AI agents to Clay's prospecting, enrichment, and account-research capabilities.
+  Find prospects, enrich contacts, and research target companies through [Clay's official MCP server](https://www.notion.so/clayrun/Clay-Claude-MCP-Server-Documentation-2ef7e66eb01480c9820de48041591aeb).
 
   ## Features
   - Find and enrich contacts at target companies

--- a/remotes/clay.yaml
+++ b/remotes/clay.yaml
@@ -18,7 +18,7 @@ description: |
 
 metadata:
   categories: Sales, Marketing, Data & Analytics
-icon: https://clay.com/favicon.ico
+icon: "https://t2.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=http://clay.com&size=256"
 repoURL: https://www.notion.so/clayrun/Clay-Claude-MCP-Server-Documentation-2ef7e66eb01480c9820de48041591aeb
 runtime: remote
 remoteConfig:

--- a/remotes/clickup.yaml
+++ b/remotes/clickup.yaml
@@ -3,7 +3,7 @@ entryKey: obot-clickup
 serverUserType: singleUser
 shortDescription: Manage ClickUp tasks, documents, chat, lists, and time tracking
 description: |
-  [ClickUp's official remote Model Context Protocol (MCP) server](https://help.clickup.com/hc/en-us/articles/33335772678423-What-is-ClickUp-MCP) connects AI agents to ClickUp workspaces using OAuth.
+  Manage ClickUp tasks, documents, chat, lists, and time tracking through [ClickUp's official MCP server](https://help.clickup.com/hc/en-us/articles/33335772678423-What-is-ClickUp-MCP), with each user connecting through OAuth.
 
   ## Features
   - Search, create, and update tasks individually or in bulk

--- a/remotes/clickup.yaml
+++ b/remotes/clickup.yaml
@@ -1,0 +1,25 @@
+name: ClickUp
+entryKey: obot-clickup
+serverUserType: singleUser
+shortDescription: Manage ClickUp tasks, documents, chat, lists, and time tracking
+description: |
+  [ClickUp's official remote Model Context Protocol (MCP) server](https://help.clickup.com/hc/en-us/articles/33335772678423-What-is-ClickUp-MCP) connects AI agents to ClickUp workspaces using OAuth.
+
+  ## Features
+  - Search, create, and update tasks individually or in bulk
+  - Work with Spaces, folders, lists, tags, assignees, and comments
+  - Create and update ClickUp Docs and pages
+  - Read and send Chat messages and manage time tracking
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **ClickUp Account**: Each user authenticates through OAuth and receives access based on their ClickUp workspace permissions
+
+metadata:
+  categories: Project Management, Productivity, SaaS & API Integrations
+icon: https://clickup.com/favicon.ico
+repoURL: https://help.clickup.com/hc/en-us/articles/33335772678423-What-is-ClickUp-MCP
+runtime: remote
+remoteConfig:
+  fixedURL: https://mcp.clickup.com/mcp

--- a/remotes/composio.yaml
+++ b/remotes/composio.yaml
@@ -3,7 +3,7 @@ entryKey: obot-composio
 serverUserType: singleUser
 shortDescription: Connect your assistant to more than 1,000 apps through one MCP server
 description: |
-  Composio Connect is a hosted Model Context Protocol (MCP) server that gives your assistant access to more than 1,000 applications through one connection. Its small set of meta-tools discovers app-specific tools, connects accounts on demand, and executes actions without loading every integration into the model context.
+  Access more than 1,000 applications through one [Composio Connect](https://docs.composio.dev/docs/composio-connect) MCP connection. Its small set of meta-tools discovers app-specific tools, connects accounts on demand, and executes actions without loading every integration into the model context.
 
   ## Features
   - Discover relevant tools across Gmail, Notion, Slack, GitHub, Linear, HubSpot, and many other apps

--- a/remotes/consensus.yaml
+++ b/remotes/consensus.yaml
@@ -1,0 +1,25 @@
+name: Consensus
+entryKey: obot-consensus
+serverUserType: singleUser
+shortDescription: Search and synthesize evidence from scientific research
+description: |
+  [Consensus' official remote Model Context Protocol (MCP) server](https://docs.consensus.app/docs/mcp) connects AI agents to a large corpus of peer-reviewed scientific literature.
+
+  ## Features
+  - Search scientific papers using natural-language research questions
+  - Build literature reviews and structured evidence summaries
+  - Identify research gaps and relevant studies
+  - Draft cited research outputs and bibliographies
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **Consensus Account**: Each user authenticates through OAuth and receives access according to their Consensus plan
+
+metadata:
+  categories: Research, Data & Analytics, Education
+icon: https://consensus.app/favicon.ico
+repoURL: https://docs.consensus.app/docs/mcp
+runtime: remote
+remoteConfig:
+  fixedURL: https://mcp.consensus.app/mcp

--- a/remotes/consensus.yaml
+++ b/remotes/consensus.yaml
@@ -3,7 +3,7 @@ entryKey: obot-consensus
 serverUserType: singleUser
 shortDescription: Search and synthesize evidence from scientific research
 description: |
-  [Consensus' official remote Model Context Protocol (MCP) server](https://docs.consensus.app/docs/mcp) connects AI agents to a large corpus of peer-reviewed scientific literature.
+  Search and synthesize evidence from a large corpus of peer-reviewed scientific literature with [Consensus' official MCP server](https://docs.consensus.app/docs/mcp).
 
   ## Features
   - Search scientific papers using natural-language research questions

--- a/remotes/context7.yaml
+++ b/remotes/context7.yaml
@@ -9,7 +9,7 @@ upgradeNote: |
   - **Authentication:** OAuth, anonymous access, and optional API-key access are now supported.
   - **Tool changes:** Tool parameters and documentation-retrieval behavior may change with the hosted service.
 description: |
-  The official hosted Context7 Model Context Protocol (MCP) server provides current, version-specific documentation and code examples for libraries and frameworks.
+  Retrieve current, version-specific library documentation and code examples through [Context7's hosted MCP server](https://context7.com/docs).
 
   > **⚠️ Upgrade notice**
   >

--- a/remotes/databricks_genie.yaml
+++ b/remotes/databricks_genie.yaml
@@ -3,7 +3,7 @@ entryKey: obot-databricks-genie-spaces
 serverUserType: singleUser
 shortDescription: Ask natural language questions about your data with AI-powered analytics
 description: |
-  A Model Context Protocol (MCP) server that provides easy connection to Databricks Genie Spaces using managed MCP servers. Ask natural language questions about your data and get insights through AI-powered analytics with built-in Unity Catalog security.
+  Ask natural-language questions and analyze data in Genie Spaces through [Databricks managed MCP servers](https://docs.databricks.com/aws/en/generative-ai/mcp/), with built-in Unity Catalog security.
 
   ## Features
   - **Natural Language Analytics**: Ask questions about your data in plain English

--- a/remotes/databricks_uc_functions.yaml
+++ b/remotes/databricks_uc_functions.yaml
@@ -3,7 +3,7 @@ entryKey: obot-databricks-unity-catalog-functions
 serverUserType: singleUser
 shortDescription: Execute and manage Databricks Unity Catalog serverless functions
 description: |
-  A Model Context Protocol (MCP) server that provides easy connection to Databricks Unity Catalog Functions using managed MCP servers. Execute and manage your registered serverless functions with built-in Unity Catalog security and governance.
+  Execute and manage registered Databricks Unity Catalog Functions through [Databricks managed MCP servers](https://docs.databricks.com/aws/en/generative-ai/mcp/), with built-in security and governance.
 
   ## Features
   - **Function Execution**: Execute Unity Catalog functions with proper parameters

--- a/remotes/databricks_vector_search.yaml
+++ b/remotes/databricks_vector_search.yaml
@@ -3,7 +3,7 @@ entryKey: obot-databricks-vector-search
 serverUserType: singleUser
 shortDescription: Semantic search and similarity queries with Databricks Vector Search indexes
 description: |
-  A Model Context Protocol (MCP) server that provides easy connection to Databricks Vector Search using managed MCP servers. Access your vector search indexes for semantic search and similarity queries with built-in Unity Catalog security.
+  Run semantic search and similarity queries against Databricks Vector Search indexes through [Databricks managed MCP servers](https://docs.databricks.com/aws/en/generative-ai/mcp/), with built-in Unity Catalog security.
 
   ## Features
   - **Semantic Search**: Query and search through your indexed data using Databricks Vector Search

--- a/remotes/datadog.yaml
+++ b/remotes/datadog.yaml
@@ -9,7 +9,7 @@ upgradeNote: |
   - **Region:** This entry connects to Datadog US1.
   - **Tool changes:** Tool names, parameters, permissions, and available toolsets change.
 description: |
-  Datadog's official, vendor-hosted Model Context Protocol (MCP) server connects AI agents to Datadog observability data and platform features. Use it to investigate logs, metrics, traces, monitors, dashboards, incidents, hosts, RUM, and more.
+  Investigate logs, metrics, traces, monitors, dashboards, incidents, hosts, RUM, and more through [Datadog's vendor-hosted MCP server](https://docs.datadoghq.com/mcp_server/).
 
   > **⚠️ Upgrade notice**
   >

--- a/remotes/deepwiki.yaml
+++ b/remotes/deepwiki.yaml
@@ -4,7 +4,7 @@ serverUserType: singleUser
 shortDescription: Access AI-generated documentation for any public GitHub repository
 description: |
 
-  A Model Context Protocol (MCP) server that provides AI-generated documentation for any public GitHub repository. Search, read, and ask questions about codebases through comprehensive, automatically-generated documentation.
+  Search, read, and ask questions about any public GitHub repository through [DeepWiki's automatically generated documentation](https://github.com/CognitionAI/deepwiki).
 
   ## Features
 

--- a/remotes/digitalocean.yaml
+++ b/remotes/digitalocean.yaml
@@ -9,7 +9,7 @@ upgradeNote: |
   - **Configuration change:** The previous comma-separated enabled-services setting is no longer used; create separate connections for multiple services.
   - **Tool changes:** Available tools and parameters now follow each DigitalOcean-hosted service.
 description: |
-  A Model Context Protocol (MCP) server that provides an interface for managing DigitalOcean resources and performing actions using the DigitalOcean API. Connect directly to DigitalOcean's vendor-hosted MCP services.
+  Manage DigitalOcean resources and perform API actions through [DigitalOcean's vendor-hosted MCP services](https://docs.digitalocean.com/products/app-platform/reference/mcp/).
 
   > **⚠️ Upgrade notice**
   >

--- a/remotes/docusign.yaml
+++ b/remotes/docusign.yaml
@@ -3,7 +3,7 @@ entryKey: obot-docusign
 serverUserType: singleUser
 shortDescription: Search agreements and manage Docusign envelopes and workflows
 description: |
-  [Docusign's official remote Model Context Protocol (MCP) server](https://developers.docusign.com/platform/mcp-server/) connects AI agents to agreements, envelopes, templates, users, and Maestro workflows.
+  Search agreements and manage envelopes, templates, users, and Maestro workflows through [Docusign's official MCP server](https://developers.docusign.com/platform/mcp-server/).
 
   ## Features
   - Search agreements and retrieve agreement details

--- a/remotes/docusign.yaml
+++ b/remotes/docusign.yaml
@@ -1,0 +1,27 @@
+name: Docusign
+entryKey: obot-docusign
+serverUserType: singleUser
+shortDescription: Search agreements and manage Docusign envelopes and workflows
+description: |
+  [Docusign's official remote Model Context Protocol (MCP) server](https://developers.docusign.com/platform/mcp-server/) connects AI agents to agreements, envelopes, templates, users, and Maestro workflows.
+
+  ## Features
+  - Search agreements and retrieve agreement details
+  - Create, inspect, and update envelopes and recipients
+  - List, start, pause, resume, and cancel workflows
+  - Work with Docusign templates, accounts, and users
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **Docusign Account**: Access to the Docusign products and agreement data used by the selected tools
+  - **Docusign Integration**: Create OAuth integration credentials, register the redirect URI shown by Obot, and enable the `signature`, `aow_manage`, and `adm_store_unified_repo_read` scopes as needed
+
+metadata:
+  categories: Business, Legal, SaaS & API Integrations
+icon: https://www.docusign.com/favicon.ico
+repoURL: https://developers.docusign.com/platform/mcp-server/
+runtime: remote
+remoteConfig:
+  fixedURL: https://mcp.docusign.com/mcp
+  staticOAuthRequired: true

--- a/remotes/dropbox.yaml
+++ b/remotes/dropbox.yaml
@@ -3,7 +3,7 @@ entryKey: obot-dropbox
 serverUserType: singleUser
 shortDescription: Search, organize, create, and share Dropbox files and folders
 description: |
-  [Dropbox's official remote Model Context Protocol (MCP) connector](https://help.dropbox.com/integrations/connect-dropbox-to-claude) connects AI agents to Dropbox content while respecting existing permissions.
+  Search, organize, create, and share Dropbox files and folders through [Dropbox's official MCP connector](https://help.dropbox.com/integrations/connect-dropbox-to-claude), which respects existing permissions.
 
   ## Features
   - Search, browse, preview, and download files

--- a/remotes/dropbox.yaml
+++ b/remotes/dropbox.yaml
@@ -1,0 +1,25 @@
+name: Dropbox
+entryKey: obot-dropbox
+serverUserType: singleUser
+shortDescription: Search, organize, create, and share Dropbox files and folders
+description: |
+  [Dropbox's official remote Model Context Protocol (MCP) connector](https://help.dropbox.com/integrations/connect-dropbox-to-claude) connects AI agents to Dropbox content while respecting existing permissions.
+
+  ## Features
+  - Search, browse, preview, and download files
+  - Create, copy, move, and delete files and folders
+  - Create and inspect shared links
+  - Create and manage file requests
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **Dropbox Account**: Each user authenticates through OAuth and can access files allowed by their Dropbox permissions
+
+metadata:
+  categories: File Management, Productivity, SaaS & API Integrations
+icon: https://www.dropbox.com/favicon.ico
+repoURL: https://help.dropbox.com/integrations/connect-dropbox-to-claude
+runtime: remote
+remoteConfig:
+  fixedURL: https://mcp.dropbox.com/claude_app_mcp

--- a/remotes/dropbox.yaml
+++ b/remotes/dropbox.yaml
@@ -18,7 +18,7 @@ description: |
 
 metadata:
   categories: File Management, Productivity, SaaS & API Integrations
-icon: https://www.dropbox.com/favicon.ico
+icon: "https://t2.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=http://dropbox.com&size=256"
 repoURL: https://help.dropbox.com/integrations/connect-dropbox-to-claude
 runtime: remote
 remoteConfig:

--- a/remotes/dynatrace.yaml
+++ b/remotes/dynatrace.yaml
@@ -9,7 +9,7 @@ upgradeNote: |
   - **Compatibility:** Dynatrace Managed and classic environments are no longer supported.
   - **Tool changes:** Tool names and parameters change.
 description: |
-  The official Dynatrace Model Context Protocol (MCP) server provides secure, governed access to Dynatrace observability data and Dynatrace Intelligence. It is hosted and maintained by Dynatrace in your SaaS environment.
+  Investigate observability data and use Dynatrace Intelligence through [Dynatrace's secure, governed MCP server](https://docs.dynatrace.com/docs/dynatrace-intelligence/dynatrace-mcp), hosted and maintained in your SaaS environment.
 
   > **⚠️ Upgrade notice**
   >

--- a/remotes/elasticsearch.yaml
+++ b/remotes/elasticsearch.yaml
@@ -9,7 +9,7 @@ upgradeNote: |
   - **New requirement:** Agent Builder requires Elastic Cloud Serverless or Elastic Stack 9.3 or later.
   - **Tool changes:** All tool names and parameters change. Direct raw Query DSL and shard inspection are no longer available.
 description: |
-  Elastic Agent Builder's official Model Context Protocol (MCP) server exposes built-in and custom tools from Elastic Cloud Serverless projects and self-managed Elastic Stack deployments.
+  Use built-in and custom Elastic Agent Builder tools from Elastic Cloud Serverless and self-managed Elastic Stack deployments through [Elastic's official MCP server](https://www.elastic.co/docs/explore-analyze/ai-features/agent-builder/mcp-server).
 
   > **⚠️ Upgrade notice**
   >

--- a/remotes/exa_search.yaml
+++ b/remotes/exa_search.yaml
@@ -9,7 +9,7 @@ upgradeNote: |
   - **New capabilities:** Advanced search, webpage fetching, and Exa Agent are enabled.
   - **Tool changes:** Legacy code-context and crawling tools are replaced by the hosted server's current tools and parameters.
 description: |
-  The official Exa-hosted Model Context Protocol (MCP) server for AI-powered web search and clean webpage retrieval.
+  Search the web and retrieve clean webpage content through [Exa's hosted MCP server](https://exa.ai/docs/reference/exa-mcp).
 
   > **⚠️ Upgrade notice**
   >

--- a/remotes/excalidraw.yaml
+++ b/remotes/excalidraw.yaml
@@ -3,7 +3,7 @@ entryKey: obot-excalidraw
 serverUserType: singleUser
 shortDescription: Create and edit interactive hand-drawn diagrams with Excalidraw
 description: |
-  [Excalidraw's official remote Model Context Protocol (MCP) server](https://github.com/excalidraw/excalidraw-mcp) connects AI agents to an interactive Excalidraw canvas.
+  Create and edit interactive hand-drawn diagrams with [Excalidraw's official MCP server](https://github.com/excalidraw/excalidraw-mcp).
 
   ## Features
   - Create hand-drawn diagrams from natural-language descriptions

--- a/remotes/excalidraw.yaml
+++ b/remotes/excalidraw.yaml
@@ -1,0 +1,24 @@
+name: Excalidraw
+entryKey: obot-excalidraw
+serverUserType: singleUser
+shortDescription: Create and edit interactive hand-drawn diagrams with Excalidraw
+description: |
+  [Excalidraw's official remote Model Context Protocol (MCP) server](https://github.com/excalidraw/excalidraw-mcp) connects AI agents to an interactive Excalidraw canvas.
+
+  ## Features
+  - Create hand-drawn diagrams from natural-language descriptions
+  - View and refine diagrams on an interactive canvas
+  - Export diagrams to Excalidraw for full-screen editing
+  - Save and restore diagram checkpoints during longer sessions
+
+  ## What you'll need to connect
+
+  No account, API key, or other credentials are required.
+
+metadata:
+  categories: Design, Productivity, Visualization
+icon: https://excalidraw.com/favicon.ico
+repoURL: https://github.com/excalidraw/excalidraw-mcp
+runtime: remote
+remoteConfig:
+  fixedURL: https://mcp.excalidraw.com/mcp

--- a/remotes/fathom.yaml
+++ b/remotes/fathom.yaml
@@ -18,7 +18,7 @@ description: |
 
 metadata:
   categories: Communication, Productivity, SaaS & API Integrations
-icon: https://fathom.ai/favicon.ico
+icon: "https://t2.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=http://fathom.ai&size=256"
 repoURL: https://help.fathom.video/en/articles/11497793
 runtime: remote
 remoteConfig:

--- a/remotes/fathom.yaml
+++ b/remotes/fathom.yaml
@@ -3,7 +3,7 @@ entryKey: obot-fathom
 serverUserType: singleUser
 shortDescription: Search meetings and retrieve summaries, transcripts, and action items
 description: |
-  [Fathom's official remote Model Context Protocol (MCP) server](https://help.fathom.video/en/articles/11497793) connects AI agents to meeting intelligence captured by Fathom.
+  Search meetings and retrieve summaries, transcripts, and action items through [Fathom's official MCP server](https://help.fathom.video/en/articles/11497793).
 
   ## Features
   - List and search recorded meetings

--- a/remotes/fathom.yaml
+++ b/remotes/fathom.yaml
@@ -1,0 +1,25 @@
+name: Fathom
+entryKey: obot-fathom
+serverUserType: singleUser
+shortDescription: Search meetings and retrieve summaries, transcripts, and action items
+description: |
+  [Fathom's official remote Model Context Protocol (MCP) server](https://help.fathom.video/en/articles/11497793) connects AI agents to meeting intelligence captured by Fathom.
+
+  ## Features
+  - List and search recorded meetings
+  - Retrieve meeting summaries and transcripts
+  - Find people mentioned in meeting content
+  - Build deliverables grounded in meeting discussions and action items
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **Fathom Account**: Each user authenticates through OAuth and can access meetings allowed by their Fathom permissions
+
+metadata:
+  categories: Communication, Productivity, SaaS & API Integrations
+icon: https://fathom.ai/favicon.ico
+repoURL: https://help.fathom.video/en/articles/11497793
+runtime: remote
+remoteConfig:
+  fixedURL: https://api.fathom.ai/mcp

--- a/remotes/figma.yaml
+++ b/remotes/figma.yaml
@@ -1,0 +1,25 @@
+name: Figma
+entryKey: obot-figma
+serverUserType: singleUser
+shortDescription: Generate diagrams and build code from Figma design context
+description: |
+  [Figma's official remote Model Context Protocol (MCP) server](https://developers.figma.com/docs/figma-mcp-server/) connects AI agents to Figma Design, FigJam, and Figma Make.
+
+  ## Features
+  - Retrieve design context, variables, components, layouts, and screenshots
+  - Generate implementation code from Figma frames and nodes
+  - Reuse mapped components through Code Connect
+  - Read FigJam and Figma Make resources and generate diagrams
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **Figma Account**: Authentication is handled through OAuth; available tools and usage limits depend on your Figma plan and seat
+
+metadata:
+  categories: Design, Developer Tools, Productivity
+icon: https://www.figma.com/favicon.ico
+repoURL: https://developers.figma.com/docs/figma-mcp-server/
+runtime: remote
+remoteConfig:
+  fixedURL: https://mcp.figma.com/mcp

--- a/remotes/figma.yaml
+++ b/remotes/figma.yaml
@@ -3,7 +3,7 @@ entryKey: obot-figma
 serverUserType: singleUser
 shortDescription: Generate diagrams and build code from Figma design context
 description: |
-  [Figma's official remote Model Context Protocol (MCP) server](https://developers.figma.com/docs/figma-mcp-server/) connects AI agents to Figma Design, FigJam, and Figma Make.
+  Turn Figma Design, FigJam, and Figma Make context into diagrams and implementation code with [Figma's official MCP server](https://developers.figma.com/docs/figma-mcp-server/).
 
   ## Features
   - Retrieve design context, variables, components, layouts, and screenshots

--- a/remotes/figma.yaml
+++ b/remotes/figma.yaml
@@ -18,7 +18,7 @@ description: |
 
 metadata:
   categories: Design, Developer Tools, Productivity
-icon: https://www.figma.com/favicon.ico
+icon: "https://t2.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=http://figma.com&size=256"
 repoURL: https://developers.figma.com/docs/figma-mcp-server/
 runtime: remote
 remoteConfig:

--- a/remotes/filescom.yaml
+++ b/remotes/filescom.yaml
@@ -9,7 +9,7 @@ upgradeNote: |
   - **OAuth setup:** A site administrator must enable MCP Dynamic Client Registration.
   - **Compatibility:** Custom domains are not accepted, tool parameters may change, and local file upload and download tools remain unavailable.
 description: |
-  The official Files.com hosted Model Context Protocol (MCP) server lets AI agents securely manage resources and perform file operations without running a local server.
+  Securely manage Files.com resources and perform file operations through [Files.com's hosted MCP server](https://www.files.com/docs/integrations/model-context-protocol-mcp-server), without running a local server.
 
   > **⚠️ Upgrade notice**
   >

--- a/remotes/firecrawl.yaml
+++ b/remotes/firecrawl.yaml
@@ -9,7 +9,7 @@ upgradeNote: |
   - **Authentication:** OAuth and limited keyless access are now available in addition to API-key access.
   - **Tool changes:** Tool names, parameters, and the available scraping, research, interaction, and monitoring capabilities change.
 description: |
-  The official hosted Firecrawl Model Context Protocol (MCP) server gives AI assistants current web data without running a local MCP container. Firecrawl operates and updates the server directly.
+  Search, scrape, and retrieve current web data through [Firecrawl's hosted MCP server](https://docs.firecrawl.dev/mcp-server), without running a local container. Firecrawl operates and updates the server directly.
 
   > **⚠️ Upgrade notice**
   >

--- a/remotes/fireflies.yaml
+++ b/remotes/fireflies.yaml
@@ -3,7 +3,7 @@ entryKey: obot-fireflies
 serverUserType: singleUser
 shortDescription: Retrieve and analyze Fireflies meeting transcripts and summaries
 description: |
-  [Fireflies' official remote Model Context Protocol (MCP) server](https://guide.fireflies.ai/articles/8272956938-learn-about-the-fireflies-mcp-server-model-context-protocol) connects AI agents to meeting transcripts and summaries captured by Fireflies.ai.
+  Retrieve and analyze meeting transcripts and summaries captured by Fireflies.ai through [Fireflies' official MCP server](https://guide.fireflies.ai/articles/8272956938-learn-about-the-fireflies-mcp-server-model-context-protocol).
 
   ## Features
   - List available meeting transcripts

--- a/remotes/fireflies.yaml
+++ b/remotes/fireflies.yaml
@@ -1,0 +1,25 @@
+name: Fireflies
+entryKey: obot-fireflies
+serverUserType: singleUser
+shortDescription: Retrieve and analyze Fireflies meeting transcripts and summaries
+description: |
+  [Fireflies' official remote Model Context Protocol (MCP) server](https://guide.fireflies.ai/articles/8272956938-learn-about-the-fireflies-mcp-server-model-context-protocol) connects AI agents to meeting transcripts and summaries captured by Fireflies.ai.
+
+  ## Features
+  - List available meeting transcripts
+  - Retrieve individual transcripts and meeting details
+  - Review decisions, concerns, and action items from meetings
+  - Extract themes and insights across meeting history
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **Fireflies.ai Account**: Each user authenticates through OAuth and can access meetings allowed by their Fireflies permissions
+
+metadata:
+  categories: Communication, Productivity, SaaS & API Integrations
+icon: https://fireflies.ai/favicon.ico
+repoURL: https://guide.fireflies.ai/articles/8272956938-learn-about-the-fireflies-mcp-server-model-context-protocol
+runtime: remote
+remoteConfig:
+  fixedURL: https://api.fireflies.ai/mcp

--- a/remotes/gamma.yaml
+++ b/remotes/gamma.yaml
@@ -1,0 +1,25 @@
+name: Gamma
+entryKey: obot-gamma
+serverUserType: singleUser
+shortDescription: Create presentations, documents, webpages, and social posts with AI
+description: |
+  [Gamma's official remote Model Context Protocol (MCP) server](https://developers.gamma.app/mcp) lets AI agents generate polished presentations, documents, webpages, and social posts.
+
+  ## Features
+  - Generate content from prompts, outlines, or notes
+  - Control format, tone, language, text density, images, and layout
+  - Browse Gamma themes, including workspace themes
+  - Organize generated content into Gamma folders
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **Gamma Account**: Each user authenticates through OAuth; generated content consumes Gamma credits
+
+metadata:
+  categories: Productivity, Design, SaaS & API Integrations
+icon: https://gamma.app/favicon.ico
+repoURL: https://developers.gamma.app/mcp
+runtime: remote
+remoteConfig:
+  fixedURL: https://mcp.gamma.app/mcp

--- a/remotes/gamma.yaml
+++ b/remotes/gamma.yaml
@@ -3,7 +3,7 @@ entryKey: obot-gamma
 serverUserType: singleUser
 shortDescription: Create presentations, documents, webpages, and social posts with AI
 description: |
-  [Gamma's official remote Model Context Protocol (MCP) server](https://developers.gamma.app/mcp) lets AI agents generate polished presentations, documents, webpages, and social posts.
+  Generate polished presentations, documents, webpages, and social posts with [Gamma's official MCP server](https://developers.gamma.app/mcp).
 
   ## Features
   - Generate content from prompts, outlines, or notes

--- a/remotes/github.yaml
+++ b/remotes/github.yaml
@@ -3,7 +3,7 @@ entryKey: obot-github
 serverUserType: singleUser
 shortDescription: Manage GitHub repositories, issues, PRs, workflows, and CI/CD operations
 description: |
-  A Model Context Protocol (MCP) server that provides easy connection to GitHub using the hosted version – no local setup or runtime required. Access comprehensive GitHub functionality through a remote server with additional tools not available in the local version.
+  Manage GitHub repositories, issues, pull requests, workflows, and more through [GitHub's hosted MCP server](https://github.com/github/github-mcp-server), with no local runtime required and additional remote-only tools.
 
   ## Features
   - **Repository Management**: Browse and query code, search files, analyze commits, and understand project structure

--- a/remotes/github_enterprise_cloud.yaml
+++ b/remotes/github_enterprise_cloud.yaml
@@ -3,7 +3,7 @@ entryKey: obot-github-enterprise-cloud
 serverUserType: singleUser
 shortDescription: Connect to a GitHub Enterprise Cloud data-residency tenant with GitHub-hosted MCP and OAuth
 description: |
-  Connect AI tools directly to GitHub's hosted Model Context Protocol (MCP) server for a GitHub Enterprise Cloud data-residency tenant (`*.ghe.com`). GitHub operates the server, including updates and remote-only GitHub capabilities.
+  Manage repositories and workflows in a GitHub Enterprise Cloud data-residency tenant (`*.ghe.com`) through [GitHub's hosted MCP server](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/provide-context/use-mcp-in-your-ide/enterprise-configuration). GitHub operates the server, including updates and remote-only capabilities.
 
   [Read the official GitHub Enterprise MCP server documentation](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/provide-context/use-mcp-in-your-ide/enterprise-configuration).
 

--- a/remotes/gitmcp.yaml
+++ b/remotes/gitmcp.yaml
@@ -3,7 +3,7 @@ entryKey: obot-gitmcp
 serverUserType: singleUser
 shortDescription: Access any GitHub project's documentation and code in real-time with AI assistance
 description: |
-  A Model Context Protocol (MCP) server that transforms any GitHub project into a documentation hub. It enables AI tools like Cursor to access up-to-date documentation and code, eliminating code hallucinations by providing real-time access to the latest project information.
+  Turn any public GitHub project into an up-to-date documentation hub with [GitMCP](https://gitmcp.io), giving AI tools current documentation and code context.
 
   ## Features
   - **Latest Documentation Access**: Grant AI assistants seamless access to any GitHub project's documentation and code with smart search capabilities

--- a/remotes/grafana_cloud.yaml
+++ b/remotes/grafana_cloud.yaml
@@ -3,7 +3,7 @@ entryKey: obot-grafana-cloud
 serverUserType: singleUser
 shortDescription: Query Grafana Cloud metrics, logs, dashboards, alerts, incidents, and on-call schedules with OAuth
 description: |
-  Grafana Cloud's official hosted Model Context Protocol (MCP) server connects AI agents directly to a Grafana Cloud stack. It uses OAuth 2.1, so each user authorizes access with their own Grafana identity and RBAC permissions instead of providing a service account token.
+  Investigate and manage a Grafana Cloud stack through [Grafana Cloud's hosted MCP server](https://grafana.com/docs/grafana-cloud/ai-tools/mcp-servers/cloud-mcp/). OAuth 2.1 gives each user access through their own Grafana identity and RBAC permissions instead of a service account token.
 
   [Read the official Grafana Cloud MCP server documentation](https://grafana.com/docs/grafana-cloud/ai-tools/mcp-servers/cloud-mcp/).
 

--- a/remotes/granola.yaml
+++ b/remotes/granola.yaml
@@ -19,7 +19,7 @@ description: |
 
 metadata:
   categories: Productivity, Communication, SaaS & API Integrations
-icon: https://www.granola.ai/favicon.ico
+icon: "https://t2.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=http://granola.ai&size=256"
 repoURL: https://help.granola.ai/article/granola-mcp
 runtime: remote
 remoteConfig:

--- a/remotes/granola.yaml
+++ b/remotes/granola.yaml
@@ -1,0 +1,26 @@
+name: Granola
+entryKey: obot-granola
+serverUserType: singleUser
+shortDescription: Search meeting notes, transcripts, decisions, and action items
+description: |
+  [Granola's official remote Model Context Protocol (MCP) server](https://help.granola.ai/article/granola-mcp) lets AI agents search and reason over your Granola meeting history.
+
+  ## Features
+  - Search meeting notes by topic, attendee, or date
+  - Retrieve meeting details, private notes, and enhanced notes
+  - Extract decisions, action items, and recurring themes
+  - Read raw meeting transcripts on supported Granola plans
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **Granola Account**: Each user authenticates through browser OAuth and can access meeting notes they own
+  - **Workspace Approval**: Enterprise administrators must enable MCP access for the workspace
+
+metadata:
+  categories: Productivity, Communication, SaaS & API Integrations
+icon: https://www.granola.ai/favicon.ico
+repoURL: https://help.granola.ai/article/granola-mcp
+runtime: remote
+remoteConfig:
+  fixedURL: https://mcp.granola.ai/mcp

--- a/remotes/granola.yaml
+++ b/remotes/granola.yaml
@@ -3,7 +3,7 @@ entryKey: obot-granola
 serverUserType: singleUser
 shortDescription: Search meeting notes, transcripts, decisions, and action items
 description: |
-  [Granola's official remote Model Context Protocol (MCP) server](https://help.granola.ai/article/granola-mcp) lets AI agents search and reason over your Granola meeting history.
+  Search meeting notes, transcripts, decisions, and action items with [Granola's official MCP server](https://help.granola.ai/article/granola-mcp).
 
   ## Features
   - Search meeting notes by topic, attendee, or date

--- a/remotes/hugging_face.yaml
+++ b/remotes/hugging_face.yaml
@@ -1,0 +1,25 @@
+name: Hugging Face
+entryKey: obot-hugging-face
+serverUserType: singleUser
+shortDescription: Search Hugging Face models, datasets, papers, docs, and Spaces
+description: |
+  [Hugging Face's official Model Context Protocol (MCP) server](https://huggingface.co/settings/mcp) connects AI agents to Hugging Face Hub resources and Gradio applications.
+
+  ## Features
+  - Search and inspect models and datasets
+  - Search research papers and Hugging Face documentation
+  - Discover and use compatible Gradio Spaces
+  - Inspect the authenticated Hugging Face account
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **Hugging Face Account**: Each user authenticates through OAuth and receives access based on their Hub permissions
+
+metadata:
+  categories: AI & Machine Learning, Developer Tools, Research
+icon: https://huggingface.co/favicon.ico
+repoURL: https://huggingface.co/settings/mcp
+runtime: remote
+remoteConfig:
+  fixedURL: "https://huggingface.co/mcp?login&gradio=none"

--- a/remotes/hugging_face.yaml
+++ b/remotes/hugging_face.yaml
@@ -3,7 +3,7 @@ entryKey: obot-hugging-face
 serverUserType: singleUser
 shortDescription: Search Hugging Face models, datasets, papers, docs, and Spaces
 description: |
-  [Hugging Face's official Model Context Protocol (MCP) server](https://huggingface.co/settings/mcp) connects AI agents to Hugging Face Hub resources and Gradio applications.
+  Search Hugging Face models, datasets, papers, documentation, and Gradio applications through [Hugging Face's official MCP server](https://huggingface.co/settings/mcp).
 
   ## Features
   - Search and inspect models and datasets

--- a/remotes/hyperframes.yaml
+++ b/remotes/hyperframes.yaml
@@ -3,7 +3,7 @@ entryKey: obot-hyperframes
 serverUserType: singleUser
 shortDescription: Build animated slides, explainer videos, and motion graphics with HTML
 description: |
-  [HeyGen's official HyperFrames Model Context Protocol (MCP) server](https://hyperframes.heygen.com/guides/mcp) connects AI agents to an HTML-based video composition and rendering workflow.
+  Build animated slides, explainer videos, and motion graphics with HTML through [HeyGen's official HyperFrames MCP server](https://hyperframes.heygen.com/guides/mcp).
 
   ## Features
   - Compose animated slides and motion graphics from HTML

--- a/remotes/hyperframes.yaml
+++ b/remotes/hyperframes.yaml
@@ -1,0 +1,25 @@
+name: HyperFrames by HeyGen
+entryKey: obot-hyperframes
+serverUserType: singleUser
+shortDescription: Build animated slides, explainer videos, and motion graphics with HTML
+description: |
+  [HeyGen's official HyperFrames Model Context Protocol (MCP) server](https://hyperframes.heygen.com/guides/mcp) connects AI agents to an HTML-based video composition and rendering workflow.
+
+  ## Features
+  - Compose animated slides and motion graphics from HTML
+  - Build explainer videos from natural-language instructions
+  - Preview and refine generated compositions
+  - Render completed compositions as videos
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **HeyGen Account**: Each user authenticates through OAuth and receives access based on their HeyGen permissions
+
+metadata:
+  categories: Design, Video, AI & Machine Learning
+icon: https://www.heygen.com/favicon.ico
+repoURL: https://hyperframes.heygen.com/guides/mcp
+runtime: remote
+remoteConfig:
+  fixedURL: https://mcp.heygen.com/mcp/hyperframes/

--- a/remotes/intercom.yaml
+++ b/remotes/intercom.yaml
@@ -18,7 +18,7 @@ description: |
 
 metadata:
   categories: Business, SaaS & API Integrations, Productivity
-icon: https://www.intercom.com/favicon.ico
+icon: "https://t2.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=http://intercom.com&size=256"
 repoURL: https://developers.intercom.com/docs/guides/mcp
 runtime: remote
 remoteConfig:

--- a/remotes/intercom.yaml
+++ b/remotes/intercom.yaml
@@ -1,0 +1,32 @@
+name: Intercom
+entryKey: obot-intercom
+serverUserType: singleUser
+shortDescription: Search Intercom conversations, contacts, tickets, and customer data
+description: |
+  [Intercom's official remote Model Context Protocol (MCP) server](https://developers.intercom.com/docs/guides/mcp) gives AI agents access to customer conversations, contacts, companies, tickets, and Help Center content.
+
+  ## Features
+  - Search and inspect customer conversations and support tickets
+  - Find contacts, companies, and associated customer details
+  - Analyze customer feedback and conversation patterns
+  - Read and manage Help Center articles when permitted by the token
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **Intercom Access Token**: Create an Intercom access token with the permissions required for the tools you plan to use, including contact, conversation, and article permissions
+
+metadata:
+  categories: Business, SaaS & API Integrations, Productivity
+icon: https://www.intercom.com/favicon.ico
+repoURL: https://developers.intercom.com/docs/guides/mcp
+runtime: remote
+remoteConfig:
+  fixedURL: https://mcp.intercom.com/mcp
+  headers:
+  - name: Intercom Access Token
+    description: Intercom access token with permissions for the requested customer data
+    key: Authorization
+    required: true
+    sensitive: true
+    prefix: "Bearer "

--- a/remotes/intercom.yaml
+++ b/remotes/intercom.yaml
@@ -3,7 +3,7 @@ entryKey: obot-intercom
 serverUserType: singleUser
 shortDescription: Search Intercom conversations, contacts, tickets, and customer data
 description: |
-  [Intercom's official remote Model Context Protocol (MCP) server](https://developers.intercom.com/docs/guides/mcp) gives AI agents access to customer conversations, contacts, companies, tickets, and Help Center content.
+  Search customer conversations, contacts, companies, tickets, and Help Center content through [Intercom's official MCP server](https://developers.intercom.com/docs/guides/mcp).
 
   ## Features
   - Search and inspect customer conversations and support tickets

--- a/remotes/jotform.yaml
+++ b/remotes/jotform.yaml
@@ -1,0 +1,25 @@
+name: Jotform
+entryKey: obot-jotform
+serverUserType: singleUser
+shortDescription: Create and edit forms and analyze Jotform submissions
+description: |
+  [Jotform's official remote Model Context Protocol (MCP) server](https://www.jotform.com/developers/mcp/) connects AI agents to forms and submission data.
+
+  ## Features
+  - Create and edit forms using natural language
+  - Search and list existing forms
+  - Retrieve, filter, and analyze submissions
+  - Display and assign forms and create submissions
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **Jotform Account**: Each user authenticates through OAuth and can access forms allowed by their Jotform permissions
+
+metadata:
+  categories: Productivity, Data & Analytics, SaaS & API Integrations
+icon: https://www.jotform.com/favicon.ico
+repoURL: https://www.jotform.com/developers/mcp/
+runtime: remote
+remoteConfig:
+  fixedURL: https://mcp.jotform.com/mcp-app

--- a/remotes/jotform.yaml
+++ b/remotes/jotform.yaml
@@ -3,7 +3,7 @@ entryKey: obot-jotform
 serverUserType: singleUser
 shortDescription: Create and edit forms and analyze Jotform submissions
 description: |
-  [Jotform's official remote Model Context Protocol (MCP) server](https://www.jotform.com/developers/mcp/) connects AI agents to forms and submission data.
+  Create and edit forms and analyze submissions through [Jotform's official MCP server](https://www.jotform.com/developers/mcp/).
 
   ## Features
   - Create and edit forms using natural language

--- a/remotes/linear.yaml
+++ b/remotes/linear.yaml
@@ -3,7 +3,7 @@ entryKey: obot-linear
 serverUserType: singleUser
 shortDescription: Manage Linear issues, projects, comments, and team workflows with AI agents
 description: |
-  A Model Context Protocol (MCP) server for Linear that enables AI agents to access and manage issues, projects, comments, and team workflows.
+  Access and manage issues, projects, comments, and team workflows through [Linear's MCP server](https://linear.app/changelog/2025-05-01-mcp).
 
   ## Features
   - **Issue Management**: Find, create, and update Linear issues with comprehensive filtering and search

--- a/remotes/lovable.yaml
+++ b/remotes/lovable.yaml
@@ -1,0 +1,25 @@
+name: Lovable
+entryKey: obot-lovable
+serverUserType: singleUser
+shortDescription: Create, inspect, iterate on, and deploy Lovable applications
+description: |
+  [Lovable's official remote Model Context Protocol (MCP) server](https://docs.lovable.dev/integrations/lovable-mcp-server) connects AI agents to Lovable workspaces, projects, files, databases, and deployments.
+
+  ## Features
+  - Create, inspect, remix, and deploy Lovable projects
+  - Send project prompts and review generated changes
+  - Read project files, knowledge, analytics, and database status
+  - Manage project visibility, connectors, and MCP servers
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **Lovable Account**: Each user authenticates through OAuth and can access workspaces and projects allowed by their Lovable permissions
+
+metadata:
+  categories: Developer Tools, Productivity, SaaS & API Integrations
+icon: https://lovable.dev/favicon.ico
+repoURL: https://docs.lovable.dev/integrations/lovable-mcp-server
+runtime: remote
+remoteConfig:
+  fixedURL: https://mcp.lovable.dev

--- a/remotes/lovable.yaml
+++ b/remotes/lovable.yaml
@@ -3,7 +3,7 @@ entryKey: obot-lovable
 serverUserType: singleUser
 shortDescription: Create, inspect, iterate on, and deploy Lovable applications
 description: |
-  [Lovable's official remote Model Context Protocol (MCP) server](https://docs.lovable.dev/integrations/lovable-mcp-server) connects AI agents to Lovable workspaces, projects, files, databases, and deployments.
+  Create, inspect, iterate on, and deploy Lovable applications through [Lovable's official MCP server](https://docs.lovable.dev/integrations/lovable-mcp-server).
 
   ## Features
   - Create, inspect, remix, and deploy Lovable projects

--- a/remotes/lucid.yaml
+++ b/remotes/lucid.yaml
@@ -3,7 +3,7 @@ entryKey: obot-lucid
 serverUserType: singleUser
 shortDescription: Search, summarize, share, and create Lucid diagrams and documents
 description: |
-  [Lucid's official remote Model Context Protocol (MCP) server](https://help.lucid.co/hc/en-us/articles/42578801807508-Integrate-Lucid-with-AI-tools-using-the-Lucid-MCP-server) connects AI agents to Lucidchart and Lucidspark content.
+  Search, summarize, share, and create Lucidchart and Lucidspark content through [Lucid's official MCP server](https://help.lucid.co/hc/en-us/articles/42578801807508-Integrate-Lucid-with-AI-tools-using-the-Lucid-MCP-server).
 
   ## Features
   - Search, retrieve, and summarize Lucid documents

--- a/remotes/lucid.yaml
+++ b/remotes/lucid.yaml
@@ -1,0 +1,26 @@
+name: Lucid
+entryKey: obot-lucid
+serverUserType: singleUser
+shortDescription: Search, summarize, share, and create Lucid diagrams and documents
+description: |
+  [Lucid's official remote Model Context Protocol (MCP) server](https://help.lucid.co/hc/en-us/articles/42578801807508-Integrate-Lucid-with-AI-tools-using-the-Lucid-MCP-server) connects AI agents to Lucidchart and Lucidspark content.
+
+  ## Features
+  - Search, retrieve, and summarize Lucid documents
+  - Create flowcharts, mind maps, org charts, and sequence diagrams
+  - Export diagrams and create document share links
+  - Share documents with collaborators
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **Lucid Account**: Each user authenticates through OAuth and can access documents permitted by their Lucid account
+  - **Admin Approval**: Team and Enterprise administrators must enable MCP access in Lucid AI controls
+
+metadata:
+  categories: Design, Productivity, SaaS & API Integrations
+icon: https://lucid.co/favicon.ico
+repoURL: https://help.lucid.co/hc/en-us/articles/42578801807508-Integrate-Lucid-with-AI-tools-using-the-Lucid-MCP-server
+runtime: remote
+remoteConfig:
+  fixedURL: https://mcp.lucid.app/mcp

--- a/remotes/make.yaml
+++ b/remotes/make.yaml
@@ -1,0 +1,25 @@
+name: Make
+entryKey: obot-make
+serverUserType: singleUser
+shortDescription: Run and manage Make scenarios, connections, teams, and data stores
+description: |
+  [Make's official remote Model Context Protocol (MCP) server](https://developers.make.com/mcp-server/) connects AI agents to Make scenarios and account resources.
+
+  ## Features
+  - Create, update, activate, and run scenarios
+  - Manage connections, webhooks, data stores, and records
+  - Work with teams, organizations, users, and executions
+  - Manage folders, keys, data structures, and app modules
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **Make Account**: Each user authenticates through OAuth and can access resources allowed by their Make permissions
+
+metadata:
+  categories: Automation, Productivity, SaaS & API Integrations
+icon: https://www.make.com/favicon.ico
+repoURL: https://developers.make.com/mcp-server/
+runtime: remote
+remoteConfig:
+  fixedURL: https://mcp.make.com

--- a/remotes/make.yaml
+++ b/remotes/make.yaml
@@ -3,7 +3,7 @@ entryKey: obot-make
 serverUserType: singleUser
 shortDescription: Run and manage Make scenarios, connections, teams, and data stores
 description: |
-  [Make's official remote Model Context Protocol (MCP) server](https://developers.make.com/mcp-server/) connects AI agents to Make scenarios and account resources.
+  Run and manage scenarios, connections, teams, and data stores through [Make's official MCP server](https://developers.make.com/mcp-server/).
 
   ## Features
   - Create, update, activate, and run scenarios

--- a/remotes/miro.yaml
+++ b/remotes/miro.yaml
@@ -1,0 +1,26 @@
+name: Miro
+entryKey: obot-miro
+serverUserType: singleUser
+shortDescription: Search, summarize, and create content on Miro boards
+description: |
+  [Miro's official remote Model Context Protocol (MCP) server](https://developers.miro.com/docs/miro-mcp) lets AI agents work directly with Miro boards.
+
+  ## Features
+  - Search and summarize boards, decisions, and open questions
+  - Create boards, diagrams, layouts, documents, tables, and images
+  - Read, reply to, and resolve board comments
+  - Turn research, specifications, and plans into visual board content
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **Miro Account**: Each user authenticates through OAuth and selects the Miro team containing the boards they want to use
+  - **Enterprise Approval**: Enterprise administrators may need to enable MCP for the organization and selected teams
+
+metadata:
+  categories: Design, Productivity, Developer Tools
+icon: https://miro.com/favicon.ico
+repoURL: https://developers.miro.com/docs/miro-mcp
+runtime: remote
+remoteConfig:
+  fixedURL: https://mcp.miro.com/

--- a/remotes/miro.yaml
+++ b/remotes/miro.yaml
@@ -3,7 +3,7 @@ entryKey: obot-miro
 serverUserType: singleUser
 shortDescription: Search, summarize, and create content on Miro boards
 description: |
-  [Miro's official remote Model Context Protocol (MCP) server](https://developers.miro.com/docs/miro-mcp) lets AI agents work directly with Miro boards.
+  Search, summarize, and create content on Miro boards through [Miro's official MCP server](https://developers.miro.com/docs/miro-mcp).
 
   ## Features
   - Search and summarize boards, decisions, and open questions

--- a/remotes/mondaycom.yaml
+++ b/remotes/mondaycom.yaml
@@ -9,7 +9,7 @@ upgradeNote: |
   - **Tool changes:** monday.com updates its hosted server automatically, so available tools and parameters may change over time.
   - **Same account access:** Tool calls continue to run as the connected user and cannot exceed that user's monday.com permissions.
 description: |
-  Connect to monday.com's hosted Model Context Protocol (MCP) server to work with boards, items, updates, workspaces, documents, dashboards, and other monday.com data.
+  Work with boards, items, updates, workspaces, documents, dashboards, and other monday.com data through [monday.com's hosted MCP server](https://developer.monday.com/api-reference/docs/integrate-with-monday-mcp).
 
   > **⚠️ Upgrade notice**
   >

--- a/remotes/morningstar.yaml
+++ b/remotes/morningstar.yaml
@@ -4,7 +4,7 @@ serverUserType: singleUser
 shortDescription: Access Morningstar financial data, analyst research, and investment screening
 description: |
 
-  A Model Context Protocol (MCP) server that provides comprehensive access to Morningstar's institutional-grade financial data and research. Retrieve real-time and historical market data, access professional analyst research with economic moat ratings, screen investments across stocks/ETFs/funds, analyze fund holdings, and explore 400+ financial datapoints for any publicly traded security.
+  Retrieve market data, analyst research, economic moat ratings, investment screens, fund holdings, and hundreds of financial data points through [Morningstar's MCP server](https://developer.morningstar.com/direct-web-services/documentation/morningstar-ai-integrations/morningstar-mcp-server/overview).
 
   ## Features
 

--- a/remotes/netlify.yaml
+++ b/remotes/netlify.yaml
@@ -3,7 +3,7 @@ entryKey: obot-netlify
 serverUserType: singleUser
 shortDescription: Create, deploy, manage, and secure websites on Netlify
 description: |
-  [Netlify's official remote Model Context Protocol (MCP) server](https://docs.netlify.com/build/build-with-ai/netlify-mcp-server/) connects AI agents to Netlify sites, projects, teams, deployments, and platform services.
+  Create, deploy, manage, and secure websites through [Netlify's official MCP server](https://docs.netlify.com/build/build-with-ai/netlify-mcp-server/).
 
   ## Features
   - Create and deploy Netlify sites

--- a/remotes/netlify.yaml
+++ b/remotes/netlify.yaml
@@ -1,0 +1,25 @@
+name: Netlify
+entryKey: obot-netlify
+serverUserType: singleUser
+shortDescription: Create, deploy, manage, and secure websites on Netlify
+description: |
+  [Netlify's official remote Model Context Protocol (MCP) server](https://docs.netlify.com/build/build-with-ai/netlify-mcp-server/) connects AI agents to Netlify sites, projects, teams, deployments, and platform services.
+
+  ## Features
+  - Create and deploy Netlify sites
+  - Manage projects, teams, and environment variables
+  - Configure site services and access controls
+  - Work with forms, extensions, and deployment services
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **Netlify Account**: Each user authenticates through OAuth and receives access according to their Netlify team and project permissions
+
+metadata:
+  categories: Developer Tools, Cloud Infrastructure, DevOps
+icon: https://www.netlify.com/favicon.ico
+repoURL: https://docs.netlify.com/build/build-with-ai/netlify-mcp-server/
+runtime: remote
+remoteConfig:
+  fixedURL: https://netlify-mcp.netlify.app/mcp

--- a/remotes/pagerduty.yaml
+++ b/remotes/pagerduty.yaml
@@ -9,7 +9,7 @@ upgradeNote: |
   - **Configuration change:** The previous API-host setting is replaced by a hosted-server region selection.
   - **Tool changes:** Tool names, parameters, and the available incident-response and administration operations change.
 description: |
-  PagerDuty's official hosted Model Context Protocol (MCP) server connects AI agents directly to PagerDuty. Investigate incidents, manage on-call coverage, administer services and teams, and run incident-response workflows without installing a local server.
+  Investigate incidents, manage on-call coverage, administer services and teams, and run incident-response workflows through [PagerDuty's hosted MCP server](https://support.pagerduty.com/main/docs/pagerduty-mcp-server), without installing a local server.
 
   > **⚠️ Upgrade notice**
   >

--- a/remotes/paypal.yaml
+++ b/remotes/paypal.yaml
@@ -3,7 +3,7 @@ entryKey: obot-paypal
 serverUserType: singleUser
 shortDescription: Create invoices, process payments, manage subscriptions, and handle disputes with PayPal
 description: |
-  A Model Context Protocol (MCP) server for PayPal that enables AI agents to create invoices and manage business transactions through natural language interactions.
+  Create invoices and manage PayPal business transactions through [PayPal's MCP server](https://www.paypal.ai/docs/tools/mcp-quickstart).
 
   ## Features
   - **Invoice Management**: Create, send, and manage PayPal invoices with QR code generation

--- a/remotes/posthog.yaml
+++ b/remotes/posthog.yaml
@@ -3,7 +3,7 @@ entryKey: obot-posthog
 serverUserType: singleUser
 shortDescription: Query product analytics and manage PostHog insights and experiments
 description: |
-  [PostHog's official remote Model Context Protocol (MCP) server](https://posthog.com/docs/model-context-protocol) connects AI agents to PostHog analytics, dashboards, flags, experiments, surveys, errors, and logs.
+  Query product analytics and manage dashboards, flags, experiments, surveys, errors, and logs through [PostHog's official MCP server](https://posthog.com/docs/model-context-protocol).
 
   ## Features
   - Query product data using natural language, HogQL, or SQL

--- a/remotes/posthog.yaml
+++ b/remotes/posthog.yaml
@@ -1,0 +1,25 @@
+name: PostHog
+entryKey: obot-posthog
+serverUserType: singleUser
+shortDescription: Query product analytics and manage PostHog insights and experiments
+description: |
+  [PostHog's official remote Model Context Protocol (MCP) server](https://posthog.com/docs/model-context-protocol) connects AI agents to PostHog analytics, dashboards, flags, experiments, surveys, errors, and logs.
+
+  ## Features
+  - Query product data using natural language, HogQL, or SQL
+  - Create and manage insights and dashboards
+  - Manage feature flags, experiments, and surveys
+  - Explore errors, logs, event definitions, schemas, and LLM costs
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **PostHog Account**: Each user authenticates through OAuth and can access organizations and projects allowed by their permissions
+
+metadata:
+  categories: Developer Tools, Data & Analytics, Monitoring & Observability
+icon: https://posthog.com/favicon.ico
+repoURL: https://posthog.com/docs/model-context-protocol
+runtime: remote
+remoteConfig:
+  fixedURL: https://mcp.posthog.com/mcp

--- a/remotes/posthog.yaml
+++ b/remotes/posthog.yaml
@@ -18,7 +18,7 @@ description: |
 
 metadata:
   categories: Developer Tools, Data & Analytics, Monitoring & Observability
-icon: https://posthog.com/favicon.ico
+icon: "https://t2.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=http://posthog.com&size=256"
 repoURL: https://posthog.com/docs/model-context-protocol
 runtime: remote
 remoteConfig:

--- a/remotes/postman.yaml
+++ b/remotes/postman.yaml
@@ -9,7 +9,7 @@ upgradeNote: |
   - **Authentication:** The US service now supports OAuth without an API key; the EU service still requires a Postman API key.
   - **New option:** The `code` tool configuration adds API-discovery and code-generation tools alongside `minimal` and `mcp`.
 description: |
-  Postman's official hosted Model Context Protocol (MCP) server connects AI agents directly to Postman resources.
+  Work with Postman workspaces, collections, APIs, and other resources through [Postman's hosted MCP server](https://www.postman.com/product/mcp-server/).
 
   > **⚠️ Upgrade notice**
   >

--- a/remotes/ramp.yaml
+++ b/remotes/ramp.yaml
@@ -3,7 +3,7 @@ entryKey: obot-ramp
 serverUserType: singleUser
 shortDescription: Search and analyze Ramp transactions, bills, cards, and vendors
 description: |
-  [Ramp's official remote Model Context Protocol (MCP) server](https://docs.ramp.com/developer-api/v1/guides/ramp-mcp-remote) connects AI agents to Ramp financial and spend-management data.
+  Search and analyze Ramp transactions, bills, cards, vendors, and other spend data through [Ramp's official MCP server](https://docs.ramp.com/developer-api/v1/guides/ramp-mcp-remote).
 
   ## Features
   - Query transactions, reimbursements, and bills

--- a/remotes/ramp.yaml
+++ b/remotes/ramp.yaml
@@ -1,0 +1,25 @@
+name: Ramp
+entryKey: obot-ramp
+serverUserType: singleUser
+shortDescription: Search and analyze Ramp transactions, bills, cards, and vendors
+description: |
+  [Ramp's official remote Model Context Protocol (MCP) server](https://docs.ramp.com/developer-api/v1/guides/ramp-mcp-remote) connects AI agents to Ramp financial and spend-management data.
+
+  ## Features
+  - Query transactions, reimbursements, and bills
+  - Analyze purchase orders, cards, limits, and spend programs
+  - Inspect vendors, departments, users, entities, and locations
+  - Load Ramp exports for custom analysis
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **Ramp Account**: Each user authenticates through OAuth and receives access based on their Ramp role and permissions
+
+metadata:
+  categories: Finance, Business, Data & Analytics
+icon: https://ramp.com/favicon.ico
+repoURL: https://docs.ramp.com/developer-api/v1/guides/ramp-mcp-remote
+runtime: remote
+remoteConfig:
+  fixedURL: https://ramp-mcp-remote.ramp.com/mcp

--- a/remotes/sentry.yaml
+++ b/remotes/sentry.yaml
@@ -1,0 +1,25 @@
+name: Sentry
+entryKey: obot-sentry
+serverUserType: singleUser
+shortDescription: Search, investigate, and manage Sentry errors, issues, and projects
+description: |
+  [Sentry's official remote Model Context Protocol (MCP) server](https://docs.sentry.io/product/sentry-mcp/) connects AI agents to Sentry errors, issues, projects, releases, and performance data.
+
+  ## Features
+  - Search errors, transactions, issues, releases, tags, and documentation
+  - Retrieve issue details and event attachments
+  - Create and update projects, teams, and DSNs
+  - Run Seer analysis for root causes and suggested fixes
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **Sentry Account**: Each user authenticates through OAuth and can access organizations and projects allowed by their Sentry permissions
+
+metadata:
+  categories: Developer Tools, Monitoring & Observability, DevOps
+icon: https://sentry.io/favicon.ico
+repoURL: https://docs.sentry.io/product/sentry-mcp/
+runtime: remote
+remoteConfig:
+  fixedURL: https://mcp.sentry.dev/mcp

--- a/remotes/sentry.yaml
+++ b/remotes/sentry.yaml
@@ -3,7 +3,7 @@ entryKey: obot-sentry
 serverUserType: singleUser
 shortDescription: Search, investigate, and manage Sentry errors, issues, and projects
 description: |
-  [Sentry's official remote Model Context Protocol (MCP) server](https://docs.sentry.io/product/sentry-mcp/) connects AI agents to Sentry errors, issues, projects, releases, and performance data.
+  Search, investigate, and manage Sentry errors, issues, projects, releases, and performance data through [Sentry's official MCP server](https://docs.sentry.io/product/sentry-mcp/).
 
   ## Features
   - Search errors, transactions, issues, releases, tags, and documentation

--- a/remotes/slack-official.yaml
+++ b/remotes/slack-official.yaml
@@ -4,7 +4,7 @@ serverUserType: singleUser
 shortDescription: Connect to Slack and work with messages, files, channels, and more
 description: |
 
-  A Model Context Protocol (MCP) that connects to your Slack workspace.
+  Search conversations and work with messages and channels through [Slack's official MCP server](https://docs.slack.dev/ai/slack-mcp-server).
   This is the official Slack MCP server.
 
   ## Features

--- a/remotes/snowflake.yaml
+++ b/remotes/snowflake.yaml
@@ -9,7 +9,7 @@ upgradeNote: |
   - **Compatibility:** Username/password authentication and Service Config YAML are no longer supported.
   - **Tool changes:** Tool names, parameters, and availability are defined by the configured Snowflake MCP server.
 description: |
-  Connect to an official Snowflake-managed Model Context Protocol (MCP) server. Snowflake hosts the endpoint and uses native role-based access control to govern access to the server and each configured tool.
+  Query and manage Snowflake data through [Snowflake's managed MCP server](https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-agents-mcp). Snowflake hosts the endpoint and uses native role-based access control for the server and each configured tool.
 
   > **Upgrade notice**
   >

--- a/remotes/square.yaml
+++ b/remotes/square.yaml
@@ -3,7 +3,7 @@ entryKey: obot-square
 serverUserType: singleUser
 shortDescription: Manage Square payments, customers, orders, catalog, and business operations
 description: |
-  A Model Context Protocol (MCP) server for Square that connects AI assistants directly to the full Square API platform, providing programmatic access to customers, orders, items, payments, and commerce operations.
+  Manage customers, orders, items, payments, and commerce operations across the Square API platform through [Square's MCP server](https://github.com/square/square-mcp-server).
 
   ## Features
   - **Payment Ecosystem**: Complete payment processing including Apple Pay, cards, checkouts, refunds, and payouts

--- a/remotes/stripe.yaml
+++ b/remotes/stripe.yaml
@@ -3,7 +3,7 @@ entryKey: obot-stripe
 serverUserType: singleUser
 shortDescription: Process payments, manage subscriptions, invoices, customers, and disputes with Stripe
 description: |
-  A Model Context Protocol (MCP) server for the Stripe API that enables AI agents to interact with Stripe payments, billing, and commerce functionality. This server provides comprehensive tools for managing customers, products, payments, subscriptions, invoices, and disputes with full API coverage for building agentic payment workflows.
+  Manage Stripe customers, products, payments, subscriptions, invoices, disputes, and other commerce workflows through [Stripe's MCP server](https://docs.stripe.com/mcp).
 
   ## Features
   - **Customer Management**: Create, list, and manage customers with comprehensive data handling

--- a/remotes/supabase.yaml
+++ b/remotes/supabase.yaml
@@ -9,7 +9,7 @@ upgradeNote: |
   - **Authentication change:** A personal access token is no longer required; OAuth is used when the token is omitted.
   - **Tool changes:** Tool names, parameters, and available project, database, function, branch, storage, and documentation operations change.
 description: |
-  The official hosted Supabase Model Context Protocol (MCP) server connects AI assistants to your Supabase projects.
+  Manage Supabase projects and development workflows through [Supabase's hosted MCP server](https://supabase.com/docs/guides/ai-tools/mcp).
 
   > **⚠️ Upgrade notice**
   >

--- a/remotes/supermetrics.yaml
+++ b/remotes/supermetrics.yaml
@@ -3,7 +3,7 @@ entryKey: obot-supermetrics-marketing-analytics
 serverUserType: singleUser
 shortDescription: Analyze marketing data and manage campaigns across many platforms
 description: |
-  [Supermetrics' official remote Model Context Protocol (MCP) server](https://mcp.supermetrics.com/docs) connects AI agents to advertising, analytics, CRM, e-commerce, email, and social-media data sources.
+  Analyze marketing data and manage campaigns across advertising, analytics, CRM, e-commerce, email, and social platforms with [Supermetrics' official MCP server](https://mcp.supermetrics.com/docs).
 
   ## Features
   - Discover data sources, accounts, and available fields

--- a/remotes/supermetrics.yaml
+++ b/remotes/supermetrics.yaml
@@ -1,0 +1,24 @@
+name: Supermetrics Marketing Analytics
+entryKey: obot-supermetrics-marketing-analytics
+serverUserType: singleUser
+shortDescription: Analyze marketing data and manage campaigns across many platforms
+description: |
+  [Supermetrics' official remote Model Context Protocol (MCP) server](https://mcp.supermetrics.com/docs) connects AI agents to advertising, analytics, CRM, e-commerce, email, and social-media data sources.
+
+  ## Features
+  - Discover data sources, accounts, and available fields
+  - Query and analyze marketing performance data
+  - Create, retrieve, and update supported advertising campaigns
+  - Create and share live marketing dashboards
+
+  ## What you'll need to connect
+
+  Supermetrics uses OAuth and can create an account during authorization if needed.
+
+metadata:
+  categories: Marketing, Data & Analytics, SaaS & API Integrations
+icon: https://supermetrics.com/favicon.ico
+repoURL: https://mcp.supermetrics.com/docs
+runtime: remote
+remoteConfig:
+  fixedURL: https://mcp.supermetrics.com/mcp

--- a/remotes/tableau_cloud.yaml
+++ b/remotes/tableau_cloud.yaml
@@ -3,7 +3,7 @@ entryKey: obot-tableau-cloud
 serverUserType: singleUser
 shortDescription: Query Tableau Cloud data, explore content, and manage Pulse metrics with OAuth
 description: |
-  The official Tableau-hosted Model Context Protocol (MCP) server for Tableau Cloud. It uses your Tableau Cloud identity, so each tool call respects your existing site role and content permissions.
+  Explore and manage Tableau Cloud content through [Tableau's hosted MCP server](https://tableau.github.io/tableau-mcp/docs/hosted-tableau-mcp). It uses your Tableau Cloud identity, so each tool call respects your existing site role and content permissions.
 
   [Read the official hosted Tableau MCP documentation](https://tableau.github.io/tableau-mcp/docs/hosted-tableau-mcp).
 

--- a/remotes/todoist.yaml
+++ b/remotes/todoist.yaml
@@ -4,7 +4,7 @@ serverUserType: singleUser
 shortDescription: Manage Todoist tasks, projects, and team collaboration through natural language
 description: |
 
-  A Model Context Protocol (MCP) server for Todoist integration, providing comprehensive task and project management capabilities through Todoist's API.
+  Manage Todoist tasks and projects through [Todoist's MCP integration](https://github.com/Doist/todoist-ai) and API.
 
   ## Features
   - **Access Todoist data from compatible AI applications**

--- a/remotes/webflow.yaml
+++ b/remotes/webflow.yaml
@@ -1,0 +1,25 @@
+name: Webflow
+entryKey: obot-webflow
+serverUserType: singleUser
+shortDescription: Manage Webflow sites, CMS content, pages, assets, and styles
+description: |
+  [Webflow's official remote Model Context Protocol (MCP) server](https://developers.webflow.com/mcp/v1.0.0/reference/overview) connects AI agents to Webflow sites and design content.
+
+  ## Features
+  - Browse and update CMS collections and content
+  - Create and edit pages, components, layouts, and styles
+  - Manage assets, forms, localization, scripts, and webhooks
+  - Inspect sites and work with the Webflow Designer
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **Webflow Account**: Each user authenticates through OAuth and can access sites allowed by their Webflow permissions
+
+metadata:
+  categories: Developer Tools, Design, SaaS & API Integrations
+icon: https://webflow.com/favicon.ico
+repoURL: https://developers.webflow.com/mcp/v1.0.0/reference/overview
+runtime: remote
+remoteConfig:
+  fixedURL: https://mcp.webflow.com/mcp

--- a/remotes/webflow.yaml
+++ b/remotes/webflow.yaml
@@ -3,7 +3,7 @@ entryKey: obot-webflow
 serverUserType: singleUser
 shortDescription: Manage Webflow sites, CMS content, pages, assets, and styles
 description: |
-  [Webflow's official remote Model Context Protocol (MCP) server](https://developers.webflow.com/mcp/v1.0.0/reference/overview) connects AI agents to Webflow sites and design content.
+  Manage Webflow sites, CMS content, pages, assets, and styles through [Webflow's official MCP server](https://developers.webflow.com/mcp/v1.0.0/reference/overview).
 
   ## Features
   - Browse and update CMS collections and content

--- a/remotes/windsor_ai.yaml
+++ b/remotes/windsor_ai.yaml
@@ -18,7 +18,7 @@ description: |
 
 metadata:
   categories: Marketing, Data & Analytics, SaaS & API Integrations
-icon: https://windsor.ai/favicon.ico
+icon: "https://t2.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=http://windsor.ai&size=256"
 repoURL: https://windsor.ai/documentation/windsor-mcp/
 runtime: remote
 remoteConfig:

--- a/remotes/windsor_ai.yaml
+++ b/remotes/windsor_ai.yaml
@@ -3,7 +3,7 @@ entryKey: obot-windsor-ai
 serverUserType: singleUser
 shortDescription: Analyze marketing, sales, analytics, and e-commerce data
 description: |
-  [Windsor.ai's official remote Model Context Protocol (MCP) server](https://windsor.ai/documentation/windsor-mcp/) connects AI agents to marketing, advertising, analytics, CRM, e-commerce, and warehouse data.
+  Analyze marketing, advertising, analytics, CRM, e-commerce, and warehouse data through [Windsor.ai's official MCP server](https://windsor.ai/documentation/windsor-mcp/).
 
   ## Features
   - Query metrics from hundreds of connected data sources

--- a/remotes/windsor_ai.yaml
+++ b/remotes/windsor_ai.yaml
@@ -1,0 +1,25 @@
+name: Windsor.ai
+entryKey: obot-windsor-ai
+serverUserType: singleUser
+shortDescription: Analyze marketing, sales, analytics, and e-commerce data
+description: |
+  [Windsor.ai's official remote Model Context Protocol (MCP) server](https://windsor.ai/documentation/windsor-mcp/) connects AI agents to marketing, advertising, analytics, CRM, e-commerce, and warehouse data.
+
+  ## Features
+  - Query metrics from hundreds of connected data sources
+  - Blend advertising, analytics, sales, and e-commerce data
+  - Inspect available connectors, accounts, fields, and query options
+  - Manage supported campaigns, budgets, exports, and other write actions
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **Windsor.ai Account**: Each user authenticates through OAuth and can access the data sources connected to their Windsor.ai account
+
+metadata:
+  categories: Marketing, Data & Analytics, SaaS & API Integrations
+icon: https://windsor.ai/favicon.ico
+repoURL: https://windsor.ai/documentation/windsor-mcp/
+runtime: remote
+remoteConfig:
+  fixedURL: https://mcp.windsor.ai/

--- a/remotes/wispr_flow.yaml
+++ b/remotes/wispr_flow.yaml
@@ -1,0 +1,25 @@
+name: Wispr Flow
+entryKey: obot-wispr-flow
+serverUserType: singleUser
+shortDescription: Search meetings, transcripts, notes, calendars, and tasks
+description: |
+  [Wispr Flow's official Model Context Protocol (MCP) integration](https://docs.wisprflow.ai/articles/4759919286-how-to-connect-wispr-flow-to-claude-chatgpt-and-other-ai-tools-mcp) connects AI agents to captured meetings, transcripts, notes, calendar events, and action items.
+
+  ## Features
+  - Search meetings and retrieve recordings and transcripts
+  - Find decisions, summaries, and action items across meeting history
+  - Search scratchpad notes and calendar events
+  - Create, retrieve, search, and update tasks
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **Wispr Flow Account**: Each user authenticates through OAuth and can access content associated with their Wispr Flow account
+
+metadata:
+  categories: Communication, Productivity, SaaS & API Integrations
+icon: https://wisprflow.ai/favicon.ico
+repoURL: https://docs.wisprflow.ai/articles/4759919286-how-to-connect-wispr-flow-to-claude-chatgpt-and-other-ai-tools-mcp
+runtime: remote
+remoteConfig:
+  fixedURL: https://api.wisprflow.ai/connect/mcp

--- a/remotes/wispr_flow.yaml
+++ b/remotes/wispr_flow.yaml
@@ -3,7 +3,7 @@ entryKey: obot-wispr-flow
 serverUserType: singleUser
 shortDescription: Search meetings, transcripts, notes, calendars, and tasks
 description: |
-  [Wispr Flow's official Model Context Protocol (MCP) integration](https://docs.wisprflow.ai/articles/4759919286-how-to-connect-wispr-flow-to-claude-chatgpt-and-other-ai-tools-mcp) connects AI agents to captured meetings, transcripts, notes, calendar events, and action items.
+  Search meetings, transcripts, notes, calendar events, and action items through [Wispr Flow's official MCP integration](https://docs.wisprflow.ai/articles/4759919286-how-to-connect-wispr-flow-to-claude-chatgpt-and-other-ai-tools-mcp).
 
   ## Features
   - Search meetings and retrieve recordings and transcripts

--- a/remotes/wispr_flow.yaml
+++ b/remotes/wispr_flow.yaml
@@ -18,7 +18,7 @@ description: |
 
 metadata:
   categories: Communication, Productivity, SaaS & API Integrations
-icon: https://wisprflow.ai/favicon.ico
+icon: "https://t2.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=http://wisprflow.ai&size=256"
 repoURL: https://docs.wisprflow.ai/articles/4759919286-how-to-connect-wispr-flow-to-claude-chatgpt-and-other-ai-tools-mcp
 runtime: remote
 remoteConfig:

--- a/remotes/wix.yaml
+++ b/remotes/wix.yaml
@@ -3,7 +3,7 @@ entryKey: obot-wix
 serverUserType: singleUser
 shortDescription: Access Wix APIs to manage sites, bookings, pricing plans, and CMS
 description: |
-  A Model Context Protocol (MCP) server for Wix, providing access to Wix's API and documentation.
+  Access Wix APIs and documentation through [Wix's MCP server](https://www.wix.com/studio/developers/mcp-server).
 
   ## Features
   - **API**: Access Wix's APIs to manage sites, bookings, pricing plans, CMS, and more.

--- a/remotes/zapier.yaml
+++ b/remotes/zapier.yaml
@@ -3,7 +3,7 @@ entryKey: obot-zapier
 serverUserType: singleUser
 shortDescription: Access 30,000+ actions across 8,000+ apps in Zapier automation platform
 description: |
-  A Model Context Protocol (MCP) server for Zapier, providing access to apps and actions.
+  Access connected apps and run actions through [Zapier's MCP server](https://zapier.com/mcp).
 
   ## Features
 

--- a/remotes/zoom.yaml
+++ b/remotes/zoom.yaml
@@ -1,0 +1,27 @@
+name: Zoom
+entryKey: obot-zoom
+serverUserType: singleUser
+shortDescription: Search meetings and retrieve Zoom recordings, transcripts, and notes
+description: |
+  [Zoom's official remote Model Context Protocol (MCP) server](https://developers.zoom.us/docs/mcp/zoom/) connects AI agents to Zoom meeting content and Zoom Hub resources.
+
+  ## Features
+  - Search meetings using natural language
+  - Retrieve recordings, transcripts, summaries, and next steps
+  - Access meeting assets and locate where topics were discussed
+  - Create notes and follow-up content in Zoom Hub
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **Zoom Account**: A Zoom account with the required meeting and recording access
+  - **Zoom OAuth App**: Create an OAuth app, register the redirect URI shown by Obot, and grant the meeting, recording, notes, and Hub scopes needed by the tools you plan to use
+
+metadata:
+  categories: Communication, Productivity, SaaS & API Integrations
+icon: https://zoom.us/favicon.ico
+repoURL: https://developers.zoom.us/docs/mcp/zoom/
+runtime: remote
+remoteConfig:
+  fixedURL: https://mcp.zoom.us/mcp/zoom/streamable
+  staticOAuthRequired: true

--- a/remotes/zoom.yaml
+++ b/remotes/zoom.yaml
@@ -3,7 +3,7 @@ entryKey: obot-zoom
 serverUserType: singleUser
 shortDescription: Search meetings and retrieve Zoom recordings, transcripts, and notes
 description: |
-  [Zoom's official remote Model Context Protocol (MCP) server](https://developers.zoom.us/docs/mcp/zoom/) connects AI agents to Zoom meeting content and Zoom Hub resources.
+  Search meetings and retrieve recordings, transcripts, notes, and Zoom Hub resources through [Zoom's official MCP server](https://developers.zoom.us/docs/mcp/zoom/).
 
   ## Features
   - Search meetings using natural language

--- a/scripts/claude-directory/reviewed.yaml
+++ b/scripts/claude-directory/reviewed.yaml
@@ -4,6 +4,18 @@ records:
     name: PayPal
     status: existing
     catalog_entry: remotes/paypal.yaml
+  - id: 038318ff-ed0d-45f8-a453-b01de0071561
+    name: Make
+    status: imported
+    catalog_entry: remotes/make.yaml
+  - id: 092d0ef3-9fc6-4101-8f7e-c2b80e58a065
+    name: Webflow
+    status: imported
+    catalog_entry: remotes/webflow.yaml
+  - id: 098cb32a-ba21-4770-97dd-78bb54655419
+    name: Ahrefs
+    status: imported
+    catalog_entry: remotes/ahrefs.yaml
   - id: 0cce5c8c-7590-41d0-abbe-aa5c64961ac0
     name: Lucid
     status: imported
@@ -16,6 +28,14 @@ records:
     name: Supabase
     status: existing
     catalog_entry: remotes/supabase.yaml
+  - id: 1d9dadfe-0a7d-4a47-af18-101ae0ae0efd
+    name: Lovable
+    status: imported
+    catalog_entry: remotes/lovable.yaml
+  - id: 1e4280cc-037c-47f0-9873-56bea1871bdb
+    name: Dropbox
+    status: imported
+    catalog_entry: remotes/dropbox.yaml
   - id: 1ed68a66-c371-4d26-82dc-28e6c260ece8
     name: Zoom for Claude
     status: imported
@@ -32,6 +52,10 @@ records:
     name: Gmail
     status: existing
     catalog_entry: obot-remotes/gmail.yaml
+  - id: 275b944b-60a0-4f0d-9e55-0c0e5927a5c7
+    name: HyperFrames by HeyGen
+    status: imported
+    catalog_entry: remotes/hyperframes.yaml
   - id: 2a838eaa-f7b4-4bc2-bd47-c326f3c813c5
     name: Google Calendar
     status: existing
@@ -44,10 +68,18 @@ records:
     name: Morningstar
     status: existing
     catalog_entry: remotes/morningstar.yaml
+  - id: 360c0c31-4bb6-42ca-8e50-5da0a100a68e
+    name: Windsor.ai
+    status: imported
+    catalog_entry: remotes/windsor_ai.yaml
   - id: 37153cd7-b17c-470e-8b46-007e2859e0f3
     name: Context7
     status: existing
     catalog_entry: remotes/context7.yaml
+  - id: 37ed56d5-9d61-4fd4-ad00-b9134c694296
+    name: Hugging Face
+    status: imported
+    catalog_entry: remotes/hugging_face.yaml
   - id: 41aefcf3-a829-45eb-8cee-d90b93912f57
     name: Asana
     status: existing
@@ -64,10 +96,22 @@ records:
     name: Granola
     status: imported
     catalog_entry: remotes/granola.yaml
+  - id: 50688846-553c-4a12-bc21-df94d2173734
+    name: PostHog
+    status: imported
+    catalog_entry: remotes/posthog.yaml
   - id: 597f662f-36de-437e-836e-5a81013cbfbe
     name: Slack
     status: existing
     catalog_entry: remotes/slack-official.yaml
+  - id: 61bac03c-3f98-4b3c-affb-1b99533fa82c
+    name: Ramp
+    status: imported
+    catalog_entry: remotes/ramp.yaml
+  - id: 65247229-f0c7-49df-9044-fcbb8b3894c6
+    name: Consensus
+    status: imported
+    catalog_entry: remotes/consensus.yaml
   - id: 68268024-1a91-4316-a9e1-14ecb814cb18
     name: Datadog
     status: existing
@@ -96,10 +140,18 @@ records:
     name: Shopify
     status: skipped
     reason: Shopify recommends official per-client apps instead of custom connectors, and its MCP OAuth metadata exposes no registration method or Obot-compatible client setup.
+  - id: 816d73d2-2c34-4ad5-a1a3-c119c719e3af
+    name: Netlify
+    status: imported
+    catalog_entry: remotes/netlify.yaml
   - id: 81cc5080-a204-4aa1-a694-fa868a3c8721
     name: PubMed
     status: skipped
     reason: This is an Anthropic-hosted Claude service with no authoritative documentation supporting use as a portable MCP endpoint outside Claude.
+  - id: 839a0ae2-0c0f-4c27-9f85-726ed6515536
+    name: Fireflies
+    status: imported
+    catalog_entry: remotes/fireflies.yaml
   - id: 875dee50-9b3f-452b-af8c-fbc839966273
     name: HubSpot
     status: existing
@@ -108,6 +160,10 @@ records:
     name: Microsoft Learn
     status: existing
     catalog_entry: remotes/microsoft-docs.yaml
+  - id: 8fd555a4-ea5f-49cf-9335-582dd6760597
+    name: Apollo.io
+    status: imported
+    catalog_entry: remotes/apollo.yaml
   - id: 91408932-1110-4350-97c7-2d6b3a6d9694
     name: Exa
     status: existing
@@ -116,10 +172,22 @@ records:
     name: Excalidraw
     status: imported
     catalog_entry: remotes/excalidraw.yaml
+  - id: 954b8c86-38d8-431b-bdaf-85b14336989c
+    name: Fathom – Your Meeting Intelligence Layer
+    status: imported
+    catalog_entry: remotes/fathom.yaml
+  - id: 958b6948-97e4-4315-9ee5-82254f617557
+    name: Wispr Flow
+    status: imported
+    catalog_entry: remotes/wispr_flow.yaml
   - id: a5380429-c773-4180-b642-301418240c8c
     name: Box
     status: imported
     catalog_entry: remotes/box.yaml
+  - id: a8159026-14b4-403a-933b-bd897a5b36ca
+    name: Clay
+    status: imported
+    catalog_entry: remotes/clay.yaml
   - id: a876b642-2b05-4808-a565-deeb271802fd
     name: Docusign
     status: imported
@@ -128,6 +196,10 @@ records:
     name: ClickUp
     status: imported
     catalog_entry: remotes/clickup.yaml
+  - id: aed7e2be-868e-4046-9e12-5c917b4e6b97
+    name: Jotform
+    status: imported
+    catalog_entry: remotes/jotform.yaml
   - id: b2def8dc-ae47-4d46-877a-19b6a6ebb771
     name: Intercom
     status: imported
@@ -152,6 +224,10 @@ records:
     name: Airtable
     status: imported
     catalog_entry: remotes/airtable.yaml
+  - id: cc599e7b-8c59-4e89-9bf0-36d47bb9ec80
+    name: Supermetrics Marketing Analytics
+    status: imported
+    catalog_entry: remotes/supermetrics.yaml
   - id: ce0c9cda-5ea5-44c5-9cf2-40810dfa6582
     name: Microsoft 365
     status: skipped
@@ -160,6 +236,10 @@ records:
     name: Todoist
     status: existing
     catalog_entry: remotes/todoist.yaml
+  - id: d778b2f9-25f4-42a2-87ab-dbaa896deb1b
+    name: Calendly
+    status: imported
+    catalog_entry: remotes/calendly.yaml
   - id: d8a25d2a-e5ea-4860-b990-277244df5417
     name: Tavily
     status: existing

--- a/scripts/claude-directory/reviewed.yaml
+++ b/scripts/claude-directory/reviewed.yaml
@@ -40,6 +40,10 @@ records:
     name: Asana
     status: existing
     catalog_entry: remotes/asana.yaml
+  - id: 49e0f9ba-7d45-4fb6-b098-55eec956fbc6
+    name: monday.com
+    status: existing
+    catalog_entry: remotes/mondaycom.yaml
   - id: 597f662f-36de-437e-836e-5a81013cbfbe
     name: Slack
     status: existing
@@ -68,6 +72,14 @@ records:
     name: Exa
     status: existing
     catalog_entry: remotes/exa_search.yaml
+  - id: a5380429-c773-4180-b642-301418240c8c
+    name: Box
+    status: imported
+    catalog_entry: remotes/box.yaml
+  - id: b2def8dc-ae47-4d46-877a-19b6a6ebb771
+    name: Intercom
+    status: imported
+    catalog_entry: remotes/intercom.yaml
   - id: b89f7865-a755-4f86-8062-c3bd651740ce
     name: Google Drive
     status: existing
@@ -76,6 +88,14 @@ records:
     name: Postman
     status: existing
     catalog_entry: remotes/postman.yaml
+  - id: c758d038-d8eb-4421-b426-9dd68dc7f84a
+    name: Figma
+    status: imported
+    catalog_entry: remotes/figma.yaml
+  - id: ce0c9cda-5ea5-44c5-9cf2-40810dfa6582
+    name: Microsoft 365
+    status: skipped
+    reason: Anthropic-hosted connector requires Claude-specific Microsoft Entra applications and Claude organization enablement, so it is not portable to Obot.
   - id: d1bac76b-5673-4d98-b275-41451f3dd847
     name: Todoist
     status: existing

--- a/scripts/claude-directory/reviewed.yaml
+++ b/scripts/claude-directory/reviewed.yaml
@@ -4,6 +4,10 @@ records:
     name: PayPal
     status: existing
     catalog_entry: remotes/paypal.yaml
+  - id: 0cce5c8c-7590-41d0-abbe-aa5c64961ac0
+    name: Lucid
+    status: imported
+    catalog_entry: remotes/lucid.yaml
   - id: 11ba10d9-477b-4988-bd1c-90a7fa680dc1
     name: Atlassian Rovo
     status: existing
@@ -12,10 +16,18 @@ records:
     name: Supabase
     status: existing
     catalog_entry: remotes/supabase.yaml
+  - id: 1ed68a66-c371-4d26-82dc-28e6c260ece8
+    name: Zoom for Claude
+    status: imported
+    catalog_entry: remotes/zoom.yaml
   - id: 1f6f271e-3d29-4241-b35e-8abe6def4891
     name: Zapier
     status: existing
     catalog_entry: remotes/zapier.yaml
+  - id: 22854937-9510-4b57-9230-62c820102d8f
+    name: Adobe for creativity
+    status: skipped
+    reason: Adobe documents this connector only for Claude, and the endpoint does not expose public OAuth discovery metadata needed to map authentication safely to Obot.
   - id: 2701e52f-b826-4aaf-8b25-11f2a97c98b0
     name: Gmail
     status: existing
@@ -40,10 +52,18 @@ records:
     name: Asana
     status: existing
     catalog_entry: remotes/asana.yaml
+  - id: 46d6322a-5f75-4822-b739-f49261805e9c
+    name: Sentry
+    status: imported
+    catalog_entry: remotes/sentry.yaml
   - id: 49e0f9ba-7d45-4fb6-b098-55eec956fbc6
     name: monday.com
     status: existing
     catalog_entry: remotes/mondaycom.yaml
+  - id: 4d608ca4-1664-4ddd-be1c-c88c0ea2ec7e
+    name: Granola
+    status: imported
+    catalog_entry: remotes/granola.yaml
   - id: 597f662f-36de-437e-836e-5a81013cbfbe
     name: Slack
     status: existing
@@ -56,10 +76,30 @@ records:
     name: Notion
     status: existing
     catalog_entry: remotes/notion.yaml
+  - id: 72480fb8-32ed-4075-b1c4-79e09c858b29
+    name: Miro
+    status: imported
+    catalog_entry: remotes/miro.yaml
   - id: 780a3621-8271-4822-bd0b-b9cab309375d
     name: Wix
     status: existing
     catalog_entry: remotes/wix.yaml
+  - id: 78cb9092-b837-4439-845d-fdccd5723e7f
+    name: Indeed
+    status: skipped
+    reason: Indeed's official MCP documentation states that this beta server is available only for the Claude Connector, so it is not currently portable to Obot.
+  - id: 7eb42afe-0087-4493-a105-da2b021d5c03
+    name: Vercel
+    status: skipped
+    reason: Vercel documents that its MCP OAuth server only accepts reviewed and approved clients, and Obot is not currently listed as a supported client.
+  - id: 80917cb7-3071-4fca-b053-a4262d356c60
+    name: Shopify
+    status: skipped
+    reason: Shopify recommends official per-client apps instead of custom connectors, and its MCP OAuth metadata exposes no registration method or Obot-compatible client setup.
+  - id: 81cc5080-a204-4aa1-a694-fa868a3c8721
+    name: PubMed
+    status: skipped
+    reason: This is an Anthropic-hosted Claude service with no authoritative documentation supporting use as a portable MCP endpoint outside Claude.
   - id: 875dee50-9b3f-452b-af8c-fbc839966273
     name: HubSpot
     status: existing
@@ -72,10 +112,22 @@ records:
     name: Exa
     status: existing
     catalog_entry: remotes/exa_search.yaml
+  - id: 934bf25a-e0d1-43ff-a488-b2c5567ec956
+    name: Excalidraw
+    status: imported
+    catalog_entry: remotes/excalidraw.yaml
   - id: a5380429-c773-4180-b642-301418240c8c
     name: Box
     status: imported
     catalog_entry: remotes/box.yaml
+  - id: a876b642-2b05-4808-a565-deeb271802fd
+    name: Docusign
+    status: imported
+    catalog_entry: remotes/docusign.yaml
+  - id: aa5a2bca-4004-49ea-bc2b-978162587a3a
+    name: ClickUp
+    status: imported
+    catalog_entry: remotes/clickup.yaml
   - id: b2def8dc-ae47-4d46-877a-19b6a6ebb771
     name: Intercom
     status: imported
@@ -88,10 +140,18 @@ records:
     name: Postman
     status: existing
     catalog_entry: remotes/postman.yaml
+  - id: ba1eef5a-c510-416e-b5fa-c34d523d81a1
+    name: Gamma
+    status: imported
+    catalog_entry: remotes/gamma.yaml
   - id: c758d038-d8eb-4421-b426-9dd68dc7f84a
     name: Figma
     status: imported
     catalog_entry: remotes/figma.yaml
+  - id: cb504fab-e494-490f-bff8-bb3ab23a2209
+    name: Airtable
+    status: imported
+    catalog_entry: remotes/airtable.yaml
   - id: ce0c9cda-5ea5-44c5-9cf2-40810dfa6582
     name: Microsoft 365
     status: skipped


### PR DESCRIPTION
https://github.com/obot-platform/obot/issues/7611

## Summary

- Add 33 remote MCP connectors from the Claude directory. I cherry-picked and tested a few of these.
- Rewrite description intros for all catalog entries so they lead with useful product functionality instead of MCP boilerplate (`A Model Context Protocol (MCP) server for...`). Sorry to put this all in one PR, but I noticed the new entries following this bad pattern and fixed it here.
- Generalize catalog authoring guidance to require capability-first descriptions and prefer `MCP` over the expanded protocol name.

## New connectors

- Ahrefs
- Airtable
- Apollo.io
- Box
- Calendly
- Clay
- ClickUp
- Consensus
- Docusign
- Dropbox
- Excalidraw
- Fathom
- Figma
- Fireflies
- Gamma
- Granola
- Hugging Face
- HyperFrames by HeyGen
- Intercom
- Jotform
- Lovable
- Lucid
- Make
- Miro
- Netlify
- PostHog
- Ramp
- Sentry
- Supermetrics Marketing Analytics
- Webflow
- Windsor.ai
- Wispr Flow
- Zoom

## Validation

- `obot mcp validate-catalog-yaml --require-entry-key .`
- `git diff --check`
