### PR TITLE
fix: update nested catalog image tags

### DIFF
--- a/.github/workflows/update-image-tag.yml
+++ b/.github/workflows/update-image-tag.yml
@@ -114,8 +114,15 @@ jobs:
 
           updated_files = []
 
-          # Find all YAML files in the repository
-          yaml_files = list(Path('.').glob('*.yaml')) + list(Path('.').glob('*.yml'))
+          # Catalog entries live at the repository root and under obot-images.
+          # Keep discovery scoped to those locations so workflow/configuration YAML
+          # elsewhere in the repository can never be modified by this dispatch.
+          yaml_files = sorted({
+              *Path('.').glob('*.yaml'),
+              *Path('.').glob('*.yml'),
+              *Path('obot-images').rglob('*.yaml'),
+              *Path('obot-images').rglob('*.yml'),
+          })
 
           for yaml_file in yaml_files:
               try:


### PR DESCRIPTION
Related: https://github.com/obot-platform/mcp-images/pull/754

This updates the image updating to work better with the new directory structure. This should be merged first so it will auto-create PRs when the other is merged