### PR TITLE
Add Magic Hour remote MCP server

### DIFF
--- a/remotes/magic_hour.yaml
+++ b/remotes/magic_hour.yaml
@@ -1,0 +1,27 @@
+name: Magic Hour
+entryKey: obot-magic-hour
+serverUserType: singleUser
+shortDescription: Generate and transform video, image, and audio assets with Magic Hour
+description: |
+  Generate and transform video, image, and audio assets through the [Magic Hour MCP setup guide](https://magichour.ai/mcp), including the required authentication and client instructions.
+
+  ## Features
+  - Generate video from text or still images and animate portraits
+  - Edit video with face swap, lip sync, and other media workflows
+  - Generate and edit images, remove backgrounds, and colorize photos
+  - Generate speech and use audio in tools that accept audio inputs
+  - Upload source media, poll asynchronous render jobs, and return exact download URLs
+
+  ## What you'll need to connect
+
+  **Required:**
+  - **Magic Hour API key**: The OAuth authorization page asks you to enter an active Magic Hour API key
+  - **Magic Hour credits**: Generation and editing tools consume credits according to current pricing
+
+metadata:
+  categories: Video & Audio, Content Creation, Design
+icon: https://magichour.ai/logo.svg
+repoURL: https://magichour.ai/mcp
+runtime: remote
+remoteConfig:
+  fixedURL: https://mcp.magichour.ai/


### PR DESCRIPTION
## Summary

- add the vendor-maintained Magic Hour hosted MCP server
- describe concrete video, image, audio, upload, and async-render workflows
- use the canonical Streamable HTTP endpoint, OAuth-oriented setup guide, and stable first-party logo

## Verification

- repository code, issue, and PR searches were duplicate-clear before this submission
- `https://mcp.magichour.ai/` returns the RFC 9728 protected-resource challenge
- protected-resource and RFC 8414 authorization-server metadata advertise bearer-header auth, dynamic client registration, authorization code, and PKCE S256
- `https://magichour.ai/mcp` and `https://magichour.ai/logo.svg` return HTTP 200; the logo is served as `image/svg+xml`
- YAML parses successfully and `git diff --check` passes
- Obot CLI was not installed locally; repository CI remains the authoritative `validate-catalog-yaml --require-entry-key` check

## Scope note

This entry does not claim a local npm/stdio package or embed credentials. A full interactive Obot OAuth connection was not performed, so the PR intentionally claims only the documented remote endpoint and authentication requirements.