### PR TITLE
Add ParlayAPI for individual account workflows

### DIFF
--- a/parlayapi.yaml
+++ b/parlayapi.yaml
@@ -44,5 +44,5 @@ env:
     sensitive: false
 runtime: uvx
 uvxConfig:
-  package: parlayapi-mcp==0.3.5
+  package: parlayapi-mcp==0.3.6
   command: parlayapi-mcp

--- a/parlayapi.yaml
+++ b/parlayapi.yaml
@@ -1,0 +1,48 @@
+name: ParlayAPI
+entryKey: obot-parlayapi
+serverUserType: singleUser
+shortDescription: Query sports odds, player props, public discovery and your account usage
+description: |
+  Query available sports odds and player props, inspect public sport discovery,
+  and check your own account's tier and usage from a private workflow.
+  See the [setup instructions](https://github.com/JacobiusMakes/parlay-api-mcp#readme)
+  and [API documentation](https://parlay-api.com/docs).
+
+  ## Features
+  - Public discovery and pricing tools can run without an API key.
+  - Account tools query available events, markets and sources using your own key.
+  - Calculation tools operate on returned prices and assumptions. Quotes and
+    availability can change, and calculated values do not guarantee outcomes.
+
+  ## Connect your account
+  Each user gets a separate server instance. Enter your own ParlayAPI key in the
+  sensitive account-key field to use account tools, or leave it blank for public
+  discovery. Account allowances apply; check [current pricing](https://parlay-api.com/pricing).
+  This entry runs the published Python package through uvx over stdio.
+
+  ## Actions and data use
+  The server also exposes account signup, login-email delivery, checkout-link
+  creation and saved-book preferences. Approve those actions explicitly before
+  invoking their tools. They are not needed to start or list the server's tools.
+  Keep your key and account data in your private workflow. Sharing the MIT
+  software does not grant data distribution rights; the applicable API
+  [Terms](https://parlay-api.com/terms) and any written agreement govern data use.
+metadata:
+  categories: Data & Analytics
+icon: https://raw.githubusercontent.com/JacobiusMakes/parlay-api-mcp/cdfd4e41453d5f3878bf9b1ece6bb8dce0413809/mcpb/icon.png
+repoURL: https://github.com/JacobiusMakes/parlay-api-mcp#readme
+env:
+  - key: PARLAYAPI_KEY
+    name: Your ParlayAPI account key
+    required: false
+    sensitive: true
+    description: Your own account key. Leave blank for public discovery; account tools require a key and consume your account allowance.
+  - key: PARLAYAPI_BASE_URL
+    name: ParlayAPI base URL
+    value: https://parlay-api.com
+    required: false
+    sensitive: false
+runtime: uvx
+uvxConfig:
+  package: parlayapi-mcp==0.3.5
+  command: parlayapi-mcp


### PR DESCRIPTION
## Change

Add ParlayAPI using the published `parlayapi-mcp==0.3.5` Python package. The entry declares `singleUser`, an optional sensitive key supplied by each user, and explicit uvx package/command fields. Public discovery can start without a key; account tools use that user's allowance. Setup documentation, action side effects, and API data-use terms are linked and described.

## Validation

- YAML parsing, catalog field review, duplicate checks, and whitespace checks passed.
- Reviewed Obot's `configureUVXRuntime`: this emits `uvx --from parlayapi-mcp==0.3.5 parlayapi-mcp`. The exact command previously completed MCP initialization and listed 22 tools with no account key, no Python network attempts, and no tool calls.
- Obot CLI is unavailable locally, so `obot mcp validate-catalog-yaml --require-entry-key .` has **not** been run by the submitter. The existing upstream Build workflow performs that validation; that validation remains pending. GitHub currently requires maintainer approval for the first-contributor workflow: https://github.com/obot-platform/mcp-catalog/actions/runs/33987605163 . This submission is ready for maintainer review; an unrun check is not reported as passed.
- No native Obot session or authenticated account-tool behavior is claimed. No credentials are supplied in this PR.
